### PR TITLE
dev_log: promote docx work to 0.5.1 (QA-system milestone)

### DIFF
--- a/docs/dev_logs/0.5.0
+++ b/docs/dev_logs/0.5.0
@@ -23,7 +23,8 @@
 0.5.0e:
 - [x] Add proactive building after ticket mode to speed up dev
  
-0.5.0f:
+0.5.1:
+- [x] **Milestone: first image cut through the new candidate QA system** — a real-VM QA gate now sits in front of main (see Leonardo docs/QA_STAGING.md and RELEASE_FLOW.md). This release rolls up the previously-unshipped 0.5.0e–f changes.
 - [x] Allow .docx upload to assets; the file path is handed to the agent (via the existing uploaded-files message), which reads it from the Rails environment — no document parsing in the LLM transport layer.
 - [x] Add a Download button to every file in Browse Uploads (serves Content-Disposition: attachment; the OS opens it in the real app).
 - [x] Accept slideshows (PowerPoint .pptx/.ppt/.pptm, Keynote .key, OpenDocument .odp) and all Excel types incl. macros (.xlsm/.xlsb/.xltx/.xltm) for upload.


### PR DESCRIPTION
Reframes the docx/upload/download dev_log block from `0.5.0f` to **`0.5.1`** so the changelog label matches the DockerHub image tag we're about to cut (`kody06/llamabot:0.5.1`).

Per the convention: dev_log sub-version == DockerHub tag (same string), and a **minor bump marks a milestone** — `0.5.1` = the epoch where the candidate real-VM QA gate went live. This release rolls up the previously-unshipped `0.5.0e`–`f` changes.

Docs-only (one changelog line). Once merged, I'll tag `v0.5.1` to publish the image, then bump the pin in Leonardo's `docker-compose.yml` on `candidate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)