### PR TITLE
Fix unbuildable 0.4.1-alpha: pin langchain stack to known-good

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -48,24 +48,28 @@ jiter==0.9.0
 jsonpatch==1.33
 jsonpointer==3.0.0
 jsonschema_rs==0.29.1
-langchain>=1.1.3
-langchain-anthropic>=1.1.3
+# Pinned to the last verified-working resolved set (the runtime built & tested
+# 2026-06-12). Floating `>=` pins let langchain-community 0.4.2 in, which now
+# requires langchain-classic>=1.0.7 and broke resolution. Pinning the whole
+# stack keeps builds reproducible and stops the rot. Bump deliberately, together.
+langchain==1.3.2
+langchain-anthropic==1.4.0
 langchain-classic==1.0.0
-langchain-community>=0.4
-langchain-core>=1.1.3
-langchain-google-genai>=4.0.0
-langchain-google-vertexai>=2.0.0
+langchain-community==0.4.1
+langchain-core==1.4.6
+langchain-google-genai==4.1.1
+langchain-google-vertexai==3.2.4
 langchain-ollama==1.0.0
 langchain-openai==1.0.0
-langchain-deepseek>=0.1.0
+langchain-deepseek==1.0.1
 langchain-text-splitters==1.0.0
-langgraph>=1.0.2
-langgraph-checkpoint>=2.1.1
-langgraph-checkpoint-postgres>=2.0.23
-langgraph-cli>=0.3.6
-langgraph-prebuilt>=1.0.0
-langgraph-sdk>=0.2.9
-langgraph-supervisor>=0.0.28
+langgraph==1.2.2
+langgraph-checkpoint==4.1.1
+langgraph-checkpoint-postgres==3.0.4
+langgraph-cli==0.4.29
+langgraph-prebuilt==1.1.0
+langgraph-sdk==0.3.6
+langgraph-supervisor==0.0.31
 langsmith==0.4.8
 -e git+https://github.com/KodyKendall/LlamaBot.git@38d6daa5795f32b6f63637bc02baee53e0ac8dfd#egg=LlamaBot
 Mako==1.3.10


### PR DESCRIPTION
## The bug
`0.4.1-alpha` is currently **un-buildable** — every CI job that builds the image fails at `pip install`:

```
langchain-community 0.4.2 depends on langchain-classic >=1.0.7
The user requested langchain-classic==1.0.0   → ResolutionImpossible
```

The langchain block floated on `>=`, so a fresh `langchain-community 0.4.2` on PyPI (requires `langchain-classic>=1.0.7`) broke resolution against the hard-pinned `langchain-classic==1.0.0`. Pre-existing dependency rot, unrelated to recent feature work — it built fine for `0.5.0d` (06-10) and rotted since.

## The fix
Pinned the whole `langchain*/langgraph*` block to the **last verified-working resolved set** — the exact versions in the runtime built & tested earlier today (`community 0.4.1` + `classic 1.0.0` + `text-splitters 1.0.0`, etc.). This:
- resolves the conflict (validated with a full `pip install --dry-run`),
- ships the exact runtime the in-flight work was tested against,
- makes the build **reproducible** and stops the rot.

Chasing pins forward instead (`classic>=1.0.7`) just cascades — `classic 1.0.7` then needs `text-splitters>=1.1.2`, also hard-pinned at `1.0.0` — and would de-facto upgrade langchain. Pinning to known-good is the safer, deterministic fix.

## Note
The build failure **is** the reproduction; this PR turns the red image-build green. Future langchain bumps should be deliberate and done together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)