### PR TITLE
release: build amd64 only (cut ~11 min off every release)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,9 +73,6 @@ jobs:
           echo "sha=sha-$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
           echo "Releasing version '$v' (sha-$(git rev-parse --short HEAD))"
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -133,15 +130,19 @@ jobs:
           username: kody06
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      # 2) Smoke test passed — build multi-arch and push. The amd64 layers are
-      #    reused from the gha cache, so only arm64 is built fresh here.
-      - name: Build and push multi-arch image
+      # 2) Smoke test passed — push the amd64 image. Layers are reused from the
+      #    gha cache built in step 1, so this is nearly instant.
+      #    amd64-only: the fleet and QA boxes are x86_64. arm64 was ~11 min of
+      #    QEMU emulation for an image nothing in prod runs; Apple Silicon dev
+      #    runs the amd64 image via runtime emulation. Re-add linux/arm64 (and the
+      #    "Set up QEMU" step) if a native arm64 consumer ever appears.
+      - name: Build and push image
         if: ${{ github.event.inputs.dry_run != 'true' }}
         uses: docker/build-push-action@v6
         with:
           context: .
           file: Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
           tags: |
             ${{ env.IMAGE }}:${{ steps.meta.outputs.version }}


### PR DESCRIPTION
## Why
The `v0.5.1` release took ~17 min. Step breakdown showed where it went:

| Step | Time |
|---|---|
| Build amd64 (smoke) | 2m55s |
| **Build + push multi-arch (amd64+arm64)** | **11m06s** |

Caching is already configured and working — the cost was **arm64 built fresh under QEMU emulation** every release, for an image **nothing in prod runs** (the fleet and the `lxd4` QA box are `x86_64`).

## Change
Build/push `linux/amd64` only; remove the now-unneeded `Set up QEMU` step. `ci.yml`'s build was already amd64-only.

## Impact
- Release drops from **~17 min → ~3 min** (and ~1–2 min when `requirements.txt` is unchanged, now that the langchain stack is pinned).
- **Low risk:** every machine that actually runs the image is x86_64; the published amd64 image is unchanged for them. The boot-smoke + e2e + candidate-QA gates still apply.
- Apple Silicon dev still works — Docker runs the amd64 image via runtime emulation. Re-add `linux/arm64` + the QEMU step if a native arm64 consumer ever appears (documented inline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)