### PR TITLE
Report prompt-cache hit metrics to the mothership (0.5.1a)

### DIFF
--- a/app/lib/token_usage.py
+++ b/app/lib/token_usage.py
@@ -1,0 +1,49 @@
+"""Extract token-usage metadata (including prompt-cache hits) from LLM responses.
+
+LangChain standardizes per-call usage into ``AIMessage.usage_metadata``, shaped like::
+
+    {
+        "input_tokens": int,         # total prompt tokens (includes cached + cache-write)
+        "output_tokens": int,
+        "total_tokens": int,
+        "input_token_details": {"cache_read": int, "cache_creation": int, ...},
+        "output_token_details": {"reasoning": int, ...},
+    }
+
+The ``input_token_details`` sub-dict is where prompt-cache info lives. It is populated for
+both DeepSeek (the default model — via the OpenAI-compatible ``prompt_tokens_details.cached_tokens``,
+which LangChain maps to ``cache_read``) and Anthropic/Claude (``cache_read`` + ``cache_creation``).
+
+Forwarding only the three top-level scalars drops the cache signal, so we surface the cache
+fields here too. The mothership computes cache-hit rate as
+``cache_read_input_tokens / input_tokens``.
+"""
+from typing import Any, Optional
+
+
+def _get(usage: Any, key: str, default: int = 0) -> Any:
+    """Read ``key`` off a usage_metadata value that may be a dict or an object."""
+    if isinstance(usage, dict):
+        return usage.get(key, default)
+    return getattr(usage, key, default)
+
+
+def extract_token_usage(message: Any) -> Optional[dict]:
+    """Return a token-usage dict for an LLM response message, or ``None`` if unavailable.
+
+    Includes prompt-cache fields (``cache_read_input_tokens`` / ``cache_creation_input_tokens``)
+    so downstream consumers can measure cache-hit rate.
+    """
+    usage = getattr(message, "usage_metadata", None)
+    if not usage:
+        return None
+
+    details = _get(usage, "input_token_details", {}) or {}
+
+    return {
+        "input_tokens": _get(usage, "input_tokens"),
+        "output_tokens": _get(usage, "output_tokens"),
+        "total_tokens": _get(usage, "total_tokens"),
+        "cache_read_input_tokens": _get(details, "cache_read"),
+        "cache_creation_input_tokens": _get(details, "cache_creation"),
+    }

--- a/app/tests/test_token_usage.py
+++ b/app/tests/test_token_usage.py
@@ -1,0 +1,59 @@
+"""Tests for token-usage extraction, including prompt-cache hit metadata.
+
+These guard the regression where only input/output/total token counts were forwarded
+to the mothership and the prompt-cache signal (input_token_details) was dropped, making
+cache-hit rate impossible to measure downstream.
+"""
+from app.lib.token_usage import extract_token_usage
+
+
+class _Msg:
+    """Minimal stand-in for a LangChain AIMessage carrying usage_metadata."""
+
+    def __init__(self, usage_metadata):
+        self.usage_metadata = usage_metadata
+
+
+def test_extract_includes_cache_read_for_deepseek_style():
+    # DeepSeek (default model) surfaces cache hits via the OpenAI-compatible
+    # prompt_tokens_details.cached_tokens, which LangChain maps to input_token_details.cache_read.
+    msg = _Msg({
+        "input_tokens": 4025,
+        "output_tokens": 16,
+        "total_tokens": 4041,
+        "input_token_details": {"cache_read": 3968},
+        "output_token_details": {"reasoning": 14},
+    })
+    usage = extract_token_usage(msg)
+    assert usage["input_tokens"] == 4025
+    assert usage["output_tokens"] == 16
+    assert usage["total_tokens"] == 4041
+    assert usage["cache_read_input_tokens"] == 3968
+    assert usage["cache_creation_input_tokens"] == 0
+
+
+def test_extract_includes_cache_creation_for_anthropic_style():
+    # Anthropic/Claude reports both cache reads and cache writes (creation).
+    msg = _Msg({
+        "input_tokens": 5000,
+        "output_tokens": 100,
+        "total_tokens": 5100,
+        "input_token_details": {"cache_read": 4000, "cache_creation": 800},
+    })
+    usage = extract_token_usage(msg)
+    assert usage["cache_read_input_tokens"] == 4000
+    assert usage["cache_creation_input_tokens"] == 800
+
+
+def test_extract_handles_missing_cache_details():
+    # A cold call (or a provider without caching) has no input_token_details.
+    msg = _Msg({"input_tokens": 10, "output_tokens": 5, "total_tokens": 15})
+    usage = extract_token_usage(msg)
+    assert usage["input_tokens"] == 10
+    assert usage["cache_read_input_tokens"] == 0
+    assert usage["cache_creation_input_tokens"] == 0
+
+
+def test_extract_returns_none_without_usage():
+    assert extract_token_usage(_Msg(None)) is None
+    assert extract_token_usage(_Msg({})) is None

--- a/app/websocket/request_handler.py
+++ b/app/websocket/request_handler.py
@@ -5,6 +5,7 @@ from fastapi import FastAPI, WebSocket
 from starlette.websockets import WebSocketState
 
 from app.websocket.web_socket_request_context import WebSocketRequestContext
+from app.lib.token_usage import extract_token_usage
 from typing import Dict, Optional
 
 from langchain_core.messages import HumanMessage
@@ -471,18 +472,12 @@ class RequestHandler:
                                         logger.warning(f"Failed to serialize message: {e}")
                                         base_message_as_dict = {"content": str(message), "type": "ai"}
 
-                                    # Extract token usage metadata if available (for context window tracking)
-                                    # Anthropic sends usage_metadata on the final AIMessage (not during streaming)
-                                    token_usage = None
-                                    usage_metadata = getattr(message, 'usage_metadata', None)
-
-                                    if usage_metadata:
-                                        token_usage = {
-                                            "input_tokens": usage_metadata.get("input_tokens", 0) if isinstance(usage_metadata, dict) else getattr(usage_metadata, 'input_tokens', 0),
-                                            "output_tokens": usage_metadata.get("output_tokens", 0) if isinstance(usage_metadata, dict) else getattr(usage_metadata, 'output_tokens', 0),
-                                            "total_tokens": usage_metadata.get("total_tokens", 0) if isinstance(usage_metadata, dict) else getattr(usage_metadata, 'total_tokens', 0)
-                                        }
-                                        # logger.info(f"📊 Token usage: {token_usage}")
+                                    # Extract token usage metadata if available (for context window tracking).
+                                    # Includes prompt-cache fields (cache_read/cache_creation) so the
+                                    # mothership can measure cache-hit rate. Anthropic sends usage_metadata
+                                    # on the final AIMessage (not during streaming).
+                                    token_usage = extract_token_usage(message)
+                                    # logger.info(f"📊 Token usage: {token_usage}")
 
                                     # Only send if WebSocket is still open
                                     if self._is_websocket_open(websocket):
@@ -666,14 +661,7 @@ class RequestHandler:
                                     except Exception:
                                         base_message_as_dict = {"content": str(message), "type": "ai"}
 
-                                    token_usage = None
-                                    usage_metadata = getattr(message, 'usage_metadata', None)
-                                    if usage_metadata:
-                                        token_usage = {
-                                            "input_tokens": usage_metadata.get("input_tokens", 0) if isinstance(usage_metadata, dict) else getattr(usage_metadata, 'input_tokens', 0),
-                                            "output_tokens": usage_metadata.get("output_tokens", 0) if isinstance(usage_metadata, dict) else getattr(usage_metadata, 'output_tokens', 0),
-                                            "total_tokens": usage_metadata.get("total_tokens", 0) if isinstance(usage_metadata, dict) else getattr(usage_metadata, 'total_tokens', 0)
-                                        }
+                                    token_usage = extract_token_usage(message)
 
                                     if self._is_websocket_open(websocket):
                                         ws_msg = {
@@ -867,14 +855,7 @@ class RequestHandler:
                                     except Exception:
                                         base_message_as_dict = {"content": str(message), "type": "ai"}
 
-                                    token_usage = None
-                                    usage_metadata = getattr(message, 'usage_metadata', None)
-                                    if usage_metadata:
-                                        token_usage = {
-                                            "input_tokens": usage_metadata.get("input_tokens", 0) if isinstance(usage_metadata, dict) else getattr(usage_metadata, 'input_tokens', 0),
-                                            "output_tokens": usage_metadata.get("output_tokens", 0) if isinstance(usage_metadata, dict) else getattr(usage_metadata, 'output_tokens', 0),
-                                            "total_tokens": usage_metadata.get("total_tokens", 0) if isinstance(usage_metadata, dict) else getattr(usage_metadata, 'total_tokens', 0)
-                                        }
+                                    token_usage = extract_token_usage(message)
 
                                     if self._is_websocket_open(websocket):
                                         ws_msg = {

--- a/docs/dev_logs/0.5.1
+++ b/docs/dev_logs/0.5.1
@@ -1,0 +1,5 @@
+0.5.1:
+- [x] Add better automated QA process to prevent bugs
+
+0.5.1a:
+- [x] Include token input caching hits/misses in our message telemetry


### PR DESCRIPTION
## What & why

LlamaBot extracted only `input_tokens`/`output_tokens`/`total_tokens` from each response's `usage_metadata` and threw away `input_token_details` — exactly where the prompt-cache signal lives. So the mothership had no way to measure cache-hit rate per message/thread.

This forwards `cache_read_input_tokens` and `cache_creation_input_tokens` alongside the existing counts. The mothership computes hit rate as `cache_read_input_tokens / input_tokens`.

## Provider coverage (cache signal is standardized by LangChain into `input_token_details`)

| Provider | Verified | Notes |
|---|---|---|
| DeepSeek (default) | ✅ live — 98.7% hit on repeat | via OpenAI-compatible `cached_tokens` |
| Gemini 3.x flash + flash-lite | ✅ live — 67.8% hit on repeat | via `cached_content_token_count` |
| Anthropic/Claude | structural | same field; also reports `cache_creation` (cache writes) |

## Implementation

- New shared helper `app/lib/token_usage.py` (`extract_token_usage`) — replaces three byte-identical, drifting copies in `request_handler.py` (the duplication is how the cache fields got dropped uniformly).
- Transport unchanged: `mothership_client.report_message()` already passes `token_usage` through verbatim.

## Tests

- New `app/tests/test_token_usage.py` — DeepSeek-style, Anthropic-style (cache_creation), cold-call, and no-usage cases. Written failing-first.
- `test_token_usage + test_websocket + test_websocket_auth`: 38 passed.

## Scope / follow-up

Scheduled-job runs (`ScheduledJobRun` in `headless_agent_executor.py`) still store only input/output totals and do **not** report to the mothership — adding cache columns there needs a DB migration, left as a follow-up.

Changelog: `docs/dev_logs/0.5.1` → `0.5.1a`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)