### PR TITLE
Chat: honor ?llm_model= URL param to pin an image-capable model (0.5.1b)

### DIFF
--- a/app/frontend/chat/index.js
+++ b/app/frontend/chat/index.js
@@ -357,6 +357,10 @@ class ChatApp {
     // Load settings from cookies
     this.loadSettingsFromCookies();
 
+    // Check for ?llm_model= URL param (e.g. funnels that need an image-capable
+    // model); overrides the cookie and must run before any auto-send below.
+    this.checkModelParam();
+
     // Fetch available models and disable unavailable ones
     this.fetchAvailableModels();
 
@@ -840,6 +844,32 @@ class ChatApp {
     } else {
       window.addEventListener('websocketConnected', sendOnConnect, { once: true });
     }
+  }
+
+  /**
+   * Check for ?llm_model= URL parameter and pin the model for this session.
+   * Used by funnels (e.g. mothership picture-to-html) that need an image-capable
+   * model since the default DeepSeek cannot view images. Persists to the llmModel
+   * cookie so the whole session stays on the chosen model, not just the first turn.
+   * Ignores unknown keys, matching the cookie-restore guard in loadSettingsFromCookies().
+   */
+  checkModelParam() {
+    const params = new URLSearchParams(window.location.search);
+    const model = params.get('llm_model');
+    if (!model) return;
+
+    // Remove the param so a refresh doesn't re-apply it after a manual switch
+    const url = new URL(window.location);
+    url.searchParams.delete('llm_model');
+    window.history.replaceState({}, '', url);
+
+    if (!this.elements.modelSelect) return;
+    const isValid = Array.from(this.elements.modelSelect.options).some(option => option.value === model);
+    if (!isValid) return;
+
+    this.elements.modelSelect.value = model;
+    setCookie('llmModel', model, this.config.cookieExpiryDays);
+    this.updateDropdownLabel(this.elements.modelSelect);
   }
 
   /**

--- a/docs/dev_logs/0.5.1
+++ b/docs/dev_logs/0.5.1
@@ -3,3 +3,6 @@
 
 0.5.1a:
 - [x] Include token input caching hits/misses in our message telemetry
+
+0.5.1b:
+- [x] Chat: honor a `?llm_model=` URL param on the chat page — pin the model picker to the requested model (validated against the real dropdown options) and persist it to the session `llmModel` cookie, so funnels that need an image-capable model (e.g. the mothership picture-to-html flow, where the default DeepSeek v4 Flash can't see images) can hand users off to Gemini 3 Flash instead of the image-blind default. Unknown keys are ignored and the param is stripped from the URL after load. Browser-smoke coverage added in Leonardo e2e.


### PR DESCRIPTION
## What & why

Users arriving from the mothership **picture-to-html** funnel land on the chat page mid-flow, but the default model is **DeepSeek v4 Flash, which can't view images** — so their image iteration breaks. This lets a funnel hand users off to an image-capable model.

`checkModelParam()` (in `chat/index.js`) runs on page init right after the cookie load and before any auto-send:
- reads `?llm_model=` from the URL
- validates it against the dropdown's real options (reuses the same guard as the cookie restore — unknown keys are ignored, no crash)
- pins the model picker and persists to the `llmModel` cookie (**sticky for the session**, so a mid-session screenshot re-upload also stays on an image-capable model — not just the first turn)
- strips the param from the URL so a refresh can't re-apply it after a manual switch

No backend change: `llm_model` already threads through `request_handler → DynamicModelMiddleware → get_llm()`.

The mothership half (appending `&llm_model=gemini-3-flash` to the funnel link it builds) is a separate, production-side change — this is a no-op until that lands.

## Tests

Browser-smoke coverage (Playwright) is added in a **follow-up Leonardo PR** against the published `0.5.1b` image — it can only run green once this change is in the image Leonardo CI uses. Verified locally against the dev stack: 5/5 e2e green (pins valid model + strips param; ignores unknown key).

## Changelog

`docs/dev_logs/0.5.1` → new `0.5.1b:` block.

## Release

Ships as `v0.5.1b` → `kody06/llamabot:0.5.1b`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)