### PR TITLE
Strip unsupported multimodal blocks from history for text-only models

### DIFF
--- a/app/agents/leonardo/model_capabilities.py
+++ b/app/agents/leonardo/model_capabilities.py
@@ -1,0 +1,48 @@
+"""
+Single source of truth for per-model multimodal capabilities.
+
+Both the websocket request handler (which decides what to attach to a *new*
+outgoing message) and the rails-agent middleware (which scrubs unsupported
+content out of *replayed history* before each LLM call) read from here, so the
+capability table never drifts between the two.
+"""
+
+# Each model has different support for images, video, PDFs, etc.
+MODEL_CAPABILITIES = {
+    # Gemini models support video, images, PDFs
+    'gemini-3-flash': {'images': True, 'video': True, 'pdf': True},
+    'gemini-3-pro': {'images': True, 'video': True, 'pdf': True},
+    'gemini-3.1-flash-lite': {'images': True, 'video': True, 'pdf': True},
+    'gemini-2.5-flash': {'images': True, 'video': True, 'pdf': True},
+    'gemini-2.5-pro': {'images': True, 'video': True, 'pdf': True},
+
+    # Claude models support images and PDFs only (no video)
+    'claude-4.5-haiku': {'images': True, 'video': False, 'pdf': True},
+    'claude-4.5-sonnet': {'images': True, 'video': False, 'pdf': True},
+    'claude-sonnet-4': {'images': True, 'video': False, 'pdf': True},
+    'claude-opus-4': {'images': True, 'video': False, 'pdf': True},
+
+    # OpenAI/GPT models support images only
+    'gpt-4o': {'images': True, 'video': False, 'pdf': False},
+    'gpt-4o-mini': {'images': True, 'video': False, 'pdf': False},
+    'gpt-5-codex': {'images': True, 'video': False, 'pdf': False},
+
+    # DeepSeek - primarily text focused
+    'deepseek-v4-flash': {'images': False, 'video': False, 'pdf': False},
+}
+
+
+def get_model_capabilities(model_name: str) -> dict:
+    """Get capabilities for a model, defaulting to Gemini if unknown (most permissive)."""
+    return MODEL_CAPABILITIES.get(model_name, {'images': True, 'video': True, 'pdf': True})
+
+
+def get_file_category(mime_type: str) -> str:
+    """Categorize a mime type into content category."""
+    if mime_type.startswith('image/'):
+        return 'images'
+    elif mime_type.startswith('video/'):
+        return 'video'
+    elif mime_type == 'application/pdf':
+        return 'pdf'
+    return 'unknown'

--- a/app/agents/leonardo/rails_agent/middleware.py
+++ b/app/agents/leonardo/rails_agent/middleware.py
@@ -15,6 +15,10 @@ import logging
 
 from app.agents.leonardo.rails_agent.state import RailsAgentState
 from app.agents.leonardo.llm_factory import get_llm
+from app.agents.leonardo.model_capabilities import (
+    get_model_capabilities,
+    get_file_category,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -194,6 +198,117 @@ class FailureCircuitBreakerMiddleware(AgentMiddleware):
 
 
 # =============================================================================
+# Strip Unsupported Multimodal Content
+# =============================================================================
+
+class StripUnsupportedMultimodalMiddleware(AgentMiddleware):
+    """Remove multimodal blocks the active model can't consume from replayed history.
+
+    A thread can be started on a vision model (e.g. Gemini), which persists
+    ``image_url`` / ``file`` content blocks into the conversation history. If the
+    user then switches to a text-only model (e.g. DeepSeek), that history is
+    replayed and the provider rejects the request with a 400:
+
+        Failed to deserialize the JSON body into the target type:
+        messages[N]: unknown variant `image_url`, expected `text`
+
+    Per-message attachment gating at *send* time (request_handler._build_message_content)
+    can't fix this because the offending blocks are already in state. This
+    middleware scrubs the whole message list right before the LLM call, keyed off
+    the same MODEL_CAPABILITIES table, and replaces each dropped block with a short
+    text note so the model knows something was attached rather than seeing a gap.
+    """
+
+    # content-block type -> capability key it requires
+    _BLOCK_CAPABILITY = {
+        "image_url": "images",
+        "image": "images",
+    }
+
+    def _placeholder(self, capability: str, model_name: str) -> str:
+        kind = {"images": "image", "video": "video", "pdf": "PDF"}.get(capability, "file")
+        return (
+            f"[A {kind} was attached here earlier, but it was removed because the "
+            f"current model ({model_name}) can't see {kind}s.]"
+        )
+
+    def _block_capability(self, block: dict) -> str | None:
+        """Return the capability a content block requires, or None if it's plain text/unknown."""
+        btype = block.get("type")
+        if btype in self._BLOCK_CAPABILITY:
+            return self._BLOCK_CAPABILITY[btype]
+        if btype == "file":
+            # File blocks carry a mime_type; map it to images/video/pdf.
+            mime = block.get("mime_type") or ""
+            category = get_file_category(mime)
+            return category if category != "unknown" else None
+        return None
+
+    def _strip_content(self, content, capabilities: dict, model_name: str):
+        """Strip unsupported blocks from one message's content; collapse to str if only text remains."""
+        if not isinstance(content, list):
+            return content, False
+
+        new_blocks = []
+        changed = False
+        for block in content:
+            if not isinstance(block, dict):
+                new_blocks.append(block)
+                continue
+            capability = self._block_capability(block)
+            if capability is not None and not capabilities.get(capability, False):
+                new_blocks.append({
+                    "type": "text",
+                    "text": self._placeholder(capability, model_name),
+                })
+                changed = True
+            else:
+                new_blocks.append(block)
+
+        if not changed:
+            return content, False
+
+        # Collapse to a plain string when nothing but text blocks survive — the
+        # simplest valid shape for text-only providers.
+        if all(isinstance(b, dict) and b.get("type") == "text" for b in new_blocks):
+            return "\n\n".join(b.get("text", "") for b in new_blocks), True
+        return new_blocks, True
+
+    def _strip_unsupported(self, messages, model_name: str):
+        """Return a message list with content the model can't consume removed."""
+        capabilities = get_model_capabilities(model_name)
+        # Fast path: model supports everything we ever attach.
+        if capabilities.get("images") and capabilities.get("video") and capabilities.get("pdf"):
+            return messages
+
+        modified = []
+        any_changed = False
+        for msg in messages:
+            new_content, changed = self._strip_content(msg.content, capabilities, model_name)
+            if changed:
+                any_changed = True
+                modified.append(msg.model_copy(update={"content": new_content}))
+            else:
+                modified.append(msg)
+
+        return modified if any_changed else messages
+
+    def wrap_model_call(self, request, handler):
+        model_name = request.state.get('llm_model') or 'deepseek-v4-flash'
+        messages = self._strip_unsupported(request.messages, model_name)
+        if messages is not request.messages:
+            return handler(request.override(messages=messages))
+        return handler(request)
+
+    async def awrap_model_call(self, request, handler):
+        model_name = request.state.get('llm_model') or 'deepseek-v4-flash'
+        messages = self._strip_unsupported(request.messages, model_name)
+        if messages is not request.messages:
+            return await handler(request.override(messages=messages))
+        return await handler(request)
+
+
+# =============================================================================
 # DeepSeek Reasoning Content Middleware
 # =============================================================================
 
@@ -300,3 +415,4 @@ class DynamicModelMiddleware(AgentMiddleware):
 inject_view_context = ViewPathContextMiddleware()
 check_failure_limit = FailureCircuitBreakerMiddleware()
 deepseek_reasoning_fix = DeepSeekReasoningMiddleware()
+strip_unsupported_multimodal = StripUnsupportedMultimodalMiddleware()

--- a/app/agents/leonardo/rails_agent/nodes.py
+++ b/app/agents/leonardo/rails_agent/nodes.py
@@ -37,6 +37,7 @@ from app.agents.leonardo.rails_agent.middleware import (
     check_failure_limit,
     DynamicModelMiddleware,
     deepseek_reasoning_fix,
+    strip_unsupported_multimodal,
 )
 from app.agents.utils.token_counter import gemini_multimodal_token_counter, SUMMARIZATION_TOKEN_THRESHOLD
 from app.agents.leonardo.rails_agent.sub_agents import delegate_task, delegate_research
@@ -213,15 +214,18 @@ def build_workflow(checkpointer=None, ask_before_edits=False):
         ),
         # 2. Dynamic model selection based on state.llm_model from frontend
         DynamicModelMiddleware(),
-        # 3. DeepSeek reasoning fix - injects reasoning_content for multi-turn tool calls
+        # 3. Strip image/video/PDF blocks from history when the active model can't
+        #    consume them (e.g. switching a vision thread onto text-only DeepSeek).
+        strip_unsupported_multimodal,
+        # 4. DeepSeek reasoning fix - injects reasoning_content for multi-turn tool calls
         deepseek_reasoning_fix,
-        # 4. View path context injection - prepends page context to user messages
+        # 5. View path context injection - prepends page context to user messages
         inject_view_context,
-        # 5. Circuit breaker - stop tool calls after 3 failures
+        # 6. Circuit breaker - stop tool calls after 3 failures
         check_failure_limit,
     ]
 
-    # 6. Optional: Human-in-the-loop approval for destructive tools
+    # 7. Optional: Human-in-the-loop approval for destructive tools
     if ask_before_edits:
         DESTRUCTIVE_TOOLS = ['edit_file', 'write_file', 'bash_command']
         middleware.append(HumanInTheLoopMiddleware(

--- a/app/tests/test_multimodal_stripping.py
+++ b/app/tests/test_multimodal_stripping.py
@@ -1,0 +1,106 @@
+"""
+Tests for StripUnsupportedMultimodalMiddleware.
+
+Regression coverage for the bug where switching from a vision model (e.g.
+Gemini) to a text-only model (DeepSeek) mid-thread caused a 400 from DeepSeek:
+
+    Failed to deserialize the JSON body into the target type:
+    messages[36]: unknown variant `image_url`, expected `text`
+
+The image lived in *replayed history*, so per-message attachment gating at
+send time wasn't enough — the whole message list has to be scrubbed before the
+LLM call when the active model can't see images / video / PDFs.
+"""
+import pytest
+from langchain_core.messages import HumanMessage, AIMessage, SystemMessage
+
+from app.agents.leonardo.rails_agent.middleware import (
+    StripUnsupportedMultimodalMiddleware,
+)
+
+mw = StripUnsupportedMultimodalMiddleware()
+
+
+def _img_block():
+    return {
+        "type": "image_url",
+        "image_url": {"url": "data:image/png;base64,iVBORw0KGgoAAAANS"},
+    }
+
+
+def _history_with_image():
+    return [
+        SystemMessage(content="You are a helpful assistant."),
+        HumanMessage(content=[
+            {"type": "text", "text": "What's in this picture?"},
+            _img_block(),
+        ]),
+        AIMessage(content="It's a cat."),
+        HumanMessage(content="Now switch models and continue."),
+    ]
+
+
+def _contains_image_url(messages) -> bool:
+    for m in messages:
+        if isinstance(m.content, list):
+            for block in m.content:
+                if isinstance(block, dict) and block.get("type") == "image_url":
+                    return True
+    return False
+
+
+def test_strips_image_url_for_text_only_model():
+    """DeepSeek (no vision) must not receive any image_url blocks."""
+    out = mw._strip_unsupported(_history_with_image(), "deepseek-v4-flash")
+    assert not _contains_image_url(out), "image_url block leaked to a text-only model"
+
+
+def test_replaces_stripped_image_with_explanatory_text():
+    """The dropped image becomes a note the LLM can reason about, not a silent gap."""
+    out = mw._strip_unsupported(_history_with_image(), "deepseek-v4-flash")
+    human = out[1]
+    text = human.content if isinstance(human.content, str) else " ".join(
+        b.get("text", "") for b in human.content if isinstance(b, dict)
+    )
+    assert "image" in text.lower() and "removed" in text.lower()
+    # Original text is preserved alongside the note.
+    assert "What's in this picture?" in text
+
+
+def test_preserves_original_text_block():
+    out = mw._strip_unsupported(_history_with_image(), "deepseek-v4-flash")
+    assert any(
+        "What's in this picture?" in (m.content if isinstance(m.content, str) else "")
+        or (
+            isinstance(m.content, list)
+            and any(
+                isinstance(b, dict) and "What's in this picture?" in b.get("text", "")
+                for b in m.content
+            )
+        )
+        for m in out
+    )
+
+
+def test_vision_model_passes_through_unchanged():
+    """Gemini can see images — history must be left exactly as-is."""
+    history = _history_with_image()
+    out = mw._strip_unsupported(history, "gemini-3-flash")
+    assert _contains_image_url(out)
+    assert out is history or out == history
+
+
+def test_string_content_messages_untouched():
+    """Plain-text messages should never be rewritten."""
+    history = [HumanMessage(content="just text, no media")]
+    out = mw._strip_unsupported(history, "deepseek-v4-flash")
+    assert out[0].content == "just text, no media"
+
+
+def test_collapses_to_string_when_only_text_remains():
+    """A list that's just one text block after stripping should collapse to a str."""
+    history = [HumanMessage(content=[_img_block()])]
+    out = mw._strip_unsupported(history, "deepseek-v4-flash")
+    # Only the placeholder text remains; simplest valid shape is a plain string.
+    assert isinstance(out[0].content, str)
+    assert "image" in out[0].content.lower()

--- a/app/websocket/request_handler.py
+++ b/app/websocket/request_handler.py
@@ -30,44 +30,13 @@ load_dotenv()
 
 from typing import Any, Dict, TypedDict
 
-# Model capabilities for multimodal content
-# Each model has different support for images, video, PDFs, etc.
-MODEL_CAPABILITIES = {
-    # Gemini models support video, images, PDFs
-    'gemini-3-flash': {'images': True, 'video': True, 'pdf': True},
-    'gemini-3-pro': {'images': True, 'video': True, 'pdf': True},
-    'gemini-3.1-flash-lite': {'images': True, 'video': True, 'pdf': True},
-    'gemini-2.5-flash': {'images': True, 'video': True, 'pdf': True},
-    'gemini-2.5-pro': {'images': True, 'video': True, 'pdf': True},
-
-    # Claude models support images and PDFs only (no video)
-    'claude-4.5-haiku': {'images': True, 'video': False, 'pdf': True},
-    'claude-4.5-sonnet': {'images': True, 'video': False, 'pdf': True},
-    'claude-sonnet-4': {'images': True, 'video': False, 'pdf': True},
-    'claude-opus-4': {'images': True, 'video': False, 'pdf': True},
-
-    # OpenAI/GPT models support images only
-    'gpt-4o': {'images': True, 'video': False, 'pdf': False},
-    'gpt-4o-mini': {'images': True, 'video': False, 'pdf': False},
-    'gpt-5-codex': {'images': True, 'video': False, 'pdf': False},
-
-    # DeepSeek - primarily text focused
-    'deepseek-v4-flash': {'images': False, 'video': False, 'pdf': False},
-}
-
-def get_model_capabilities(model_name: str) -> dict:
-    """Get capabilities for a model, defaulting to Gemini if unknown (most permissive)."""
-    return MODEL_CAPABILITIES.get(model_name, {'images': True, 'video': True, 'pdf': True})
-
-def get_file_category(mime_type: str) -> str:
-    """Categorize a mime type into content category."""
-    if mime_type.startswith('image/'):
-        return 'images'
-    elif mime_type.startswith('video/'):
-        return 'video'
-    elif mime_type == 'application/pdf':
-        return 'pdf'
-    return 'unknown'
+# Model capabilities for multimodal content live in a shared module so the
+# history-scrubbing middleware and this handler never drift apart.
+from app.agents.leonardo.model_capabilities import (
+    MODEL_CAPABILITIES,
+    get_model_capabilities,
+    get_file_category,
+)
 
 class RequestHandler:
     def __init__(self, app: FastAPI):


### PR DESCRIPTION
## Problem

Switching a chat thread from a vision model (e.g. Gemini 3.1 Flash Lite, which had an image uploaded) onto a text-only model (DeepSeek v4 Flash) mid-conversation crashes:

```
Error code: 400 - {'error': {'message': 'Failed to deserialize the JSON body into the target type: messages[36]: unknown variant `image_url`, expected `text` ...
```

The image lives in **replayed history** (`messages[36]`). Per-message attachment gating at send time (`request_handler._build_message_content`) can't help, because the offending `image_url` block was already persisted into LangGraph state when Gemini was active, and gets re-sent on the next turn.

## Fix

Add `StripUnsupportedMultimodalMiddleware`, which scrubs the whole message list right before each LLM call, keyed off the existing `MODEL_CAPABILITIES` table:

- Drops `image_url` / `image` / `file` blocks the active model can't consume.
- Replaces each with a short text note — *"A image was attached here earlier, but it was removed because the current model (deepseek-v4-flash) can't see images."* — so the model reasons about the gap instead of hitting a provider 400.
- Collapses a content list back to a plain string when only text survives (simplest valid shape for text-only providers).
- Vision models (Gemini/Claude/GPT) pass through untouched via a fast path.

It mirrors the existing `DeepSeekReasoningMiddleware` pattern (rewrite messages in `wrap_model_call`/`awrap_model_call` based on `state.llm_model`) and is wired into the rails agent right after `DynamicModelMiddleware` resolves the model.

`MODEL_CAPABILITIES` / `get_model_capabilities` / `get_file_category` move into a new `app/agents/leonardo/model_capabilities.py` so the middleware and the request handler share **one source of truth** (no duplicated capability table).

## Testing

Test-first per repo rule. `app/tests/test_multimodal_stripping.py` (6 tests, all green) covers:
- image_url stripped for text-only model
- explanatory placeholder text present
- original user text preserved
- vision model passthrough unchanged
- plain-string messages untouched
- list collapses to string when only text remains

Full related suites green in-container: `47 passed, 1 skipped`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)