### PR TITLE
feat: ask_user_uiux_question — visual option selection with sandboxed iframe previews

### DIFF
--- a/app/agents/leonardo/rails_plan_mode_agent/nodes.py
+++ b/app/agents/leonardo/rails_plan_mode_agent/nodes.py
@@ -25,6 +25,7 @@ from langchain.agents.middleware import SummarizationMiddleware
 from langchain_core.messages import SystemMessage, ToolMessage
 from langchain.tools import tool, ToolRuntime
 from langgraph.types import Command, interrupt
+from typing_extensions import TypedDict
 from datetime import date
 
 from app.agents.leonardo.rails_agent.state import RailsAgentState
@@ -159,6 +160,72 @@ def ask_user_question(
     )
 
 
+class UIUXOption(TypedDict):
+    """One visual option the user can pick from in ask_user_uiux_question.
+
+    Attributes:
+        id: Stable identifier returned (with the label) when this option is chosen.
+        label: Short human-readable label shown next to the radio button.
+        html: A self-contained Tailwind/DaisyUI HTML snippet rendered as a live
+            preview inside a sandboxed iframe (e.g. '<button class="btn btn-primary">Save</button>').
+    """
+
+    id: str
+    label: str
+    html: str
+
+
+ASK_USER_UIUX_QUESTION_DESCRIPTION = """Ask the user to choose between VISUAL UI/UX options by showing them live previews.
+
+Use this instead of ask_user_question whenever the choice is about how something LOOKS —
+e.g. picking between layouts, components, button styles, card designs, color treatments, or
+section arrangements. Each option is rendered as a live, isolated preview the user picks by sight.
+
+IMPORTANT: Ask ONE question per tool call. Wait for the answer before asking the next.
+
+Parameters:
+- question: The question to ask, in plain non-technical language (e.g. "Which hero layout do you prefer?").
+- options: A list of 2-4 visual options. Each option is an object with:
+    - id: a short stable identifier (e.g. "centered", "split", "minimal")
+    - label: a short human label shown next to the radio (e.g. "Centered hero")
+    - html: a SELF-CONTAINED Tailwind + DaisyUI HTML snippet for the preview. It must rely
+      ONLY on Tailwind/DaisyUI utility classes — NO <script> tags, NO external images, fonts,
+      or stylesheets, and no app-specific CSS. Those will not render in the sandboxed preview.
+      Keep snippets small and focused on the visual decision being made.
+- context: (Optional) Brief context about why you're asking (shown as a subtitle).
+
+This tool freezes execution and waits. The user's chosen option (id and label) is returned as the tool result."""
+
+
+@tool(description=ASK_USER_UIUX_QUESTION_DESCRIPTION)
+def ask_user_uiux_question(
+    question: str,
+    options: list[UIUXOption],
+    runtime: ToolRuntime,
+    context: str = "",
+) -> Command:
+    """Ask the user to pick a visual option, freeze execution, and resume with their choice."""
+    tool_call_id = runtime.tool_call_id
+
+    # interrupt() freezes the agent here. The value is sent to the frontend as a
+    # uiux_question_request. When the user picks an option, interrupt() returns their choice.
+    user_answer = interrupt({
+        "type": "uiux_question",
+        "question": question,
+        "options": options or [],
+        "context": context,
+    })
+
+    return Command(
+        update={
+            "messages": [ToolMessage(
+                content=f"User selected: {user_answer}",
+                tool_call_id=tool_call_id
+            )]
+        }
+    )
+
+
 # =============================================================================
 # Tool list and workflow
 # =============================================================================
@@ -166,6 +233,7 @@ def ask_user_question(
 default_tools = [
     # Plan mode specific
     ask_user_question,
+    ask_user_uiux_question,
     # Standard tools (same as beginner + search_file)
     write_todos,
     ls, read_file, write_file, edit_file, search_file, bash_command,

--- a/app/frontend/chat/websocket/MessageHandler.js
+++ b/app/frontend/chat/websocket/MessageHandler.js
@@ -118,6 +118,8 @@ export class MessageHandler {
       this.handleApprovalRequest(data);
     } else if (data.type === 'question_request') {
       this.handleQuestionRequest(data);
+    } else if (data.type === 'uiux_question_request') {
+      this.handleUiuxQuestionRequest(data);
     } else if (data.type === 'suggest_mode_switch') {
       this.handleSuggestModeSwitch(data);
     } else if (data.type === 'implement_ticket') {
@@ -652,6 +654,105 @@ export class MessageHandler {
 
     // Show thinking indicator since agent will resume
     window.chatApp?.setAgentRunning(true);
+  }
+
+  /**
+   * Handle UI/UX question request (plan mode — agent asks the user to pick between
+   * visual options via interrupt). Each option carries an HTML snippet rendered as a
+   * live preview inside a sandboxed iframe. Single-select: the chosen option resumes
+   * the agent over the existing question_response channel.
+   */
+  handleUiuxQuestionRequest(data) {
+    this.finalizeCurrentThinking();
+
+    const { question, options, context, thread_id, agent_name } = data;
+    const questionId = `uiux-${Date.now()}-${Math.random().toString(36).substr(2, 6)}`;
+
+    const html = this._buildUiuxCardHtml(questionId, question, options || [], context || '', thread_id, agent_name);
+    this.messageRenderer.addMessage(html, 'uiux_question_request', null);
+
+    // Set iframe previews and wire up selection after the DOM renders.
+    setTimeout(() => this._attachUiuxListeners(questionId, options || [], thread_id, agent_name), 0);
+  }
+
+  /**
+   * Wrap a raw Tailwind/DaisyUI snippet in a self-contained document for the sandboxed
+   * preview iframe. Tailwind (JIT) + DaisyUI load from CDN so the snippet renders with
+   * realistic styling without depending on the chat or target-app CSS.
+   */
+  _buildUiuxPreviewDoc(snippet) {
+    return `<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <script src="https://cdn.tailwindcss.com/3.4.16"></script>
+    <link href="https://cdn.jsdelivr.net/npm/daisyui@4.12.23/dist/full.min.css" rel="stylesheet" type="text/css">
+  </head>
+  <body class="p-4 bg-base-100">${snippet || ''}</body>
+</html>`;
+  }
+
+  _buildUiuxCardHtml(questionId, question, options, context, threadId, agentName) {
+    const optionCards = options.map((opt, i) => {
+      const optId = (opt && opt.id != null) ? String(opt.id) : String(i);
+      const label = (opt && opt.label != null) ? String(opt.label) : optId;
+      return `
+        <label class="uiux-option-card" data-option-index="${i}">
+          <div class="uiux-option-header">
+            <input type="radio" name="uiux-${questionId}" value="${this._escapeHtml(optId)}"
+                   data-option-label="${this._escapeHtml(label)}">
+            <span class="uiux-option-label">${this._escapeHtml(label)}</span>
+          </div>
+          <iframe class="uiux-option-preview" data-option-index="${i}"
+                  sandbox="allow-scripts" title="Preview: ${this._escapeHtml(label)}"></iframe>
+        </label>`;
+    }).join('');
+
+    return `
+      <div class="uiux-question-card plan-question-card" data-question-id="${questionId}"
+           data-thread-id="${threadId}" data-agent-name="${agentName}">
+        <div class="plan-question-text">${this._escapeHtml(question)}</div>
+        ${context ? `<div class="plan-question-context">${this._escapeHtml(context)}</div>` : ''}
+        <div class="uiux-option-grid">${optionCards}</div>
+        <button class="plan-continue-btn uiux-send-btn" style="display: none;">Send choice</button>
+      </div>
+    `;
+  }
+
+  _attachUiuxListeners(questionId, options, threadId, agentName) {
+    const card = document.querySelector(`[data-question-id="${questionId}"]`);
+    if (!card) return;
+
+    // Populate each preview iframe via srcdoc (set as a property so no attribute escaping
+    // is needed; the snippet is rendered as HTML inside the sandboxed document).
+    card.querySelectorAll('.uiux-option-preview').forEach(iframe => {
+      const idx = parseInt(iframe.dataset.optionIndex, 10);
+      const opt = options[idx];
+      iframe.srcdoc = this._buildUiuxPreviewDoc(opt && opt.html ? opt.html : '');
+    });
+
+    const sendBtn = card.querySelector('.uiux-send-btn');
+
+    // Reveal Send button + highlight the selected card on radio change.
+    card.querySelectorAll(`input[name="uiux-${questionId}"]`).forEach(radio => {
+      radio.addEventListener('change', () => {
+        card.querySelectorAll('.uiux-option-card').forEach(c => c.classList.remove('selected'));
+        radio.closest('.uiux-option-card')?.classList.add('selected');
+        if (sendBtn) sendBtn.style.display = 'block';
+      });
+    });
+
+    sendBtn?.addEventListener('click', () => {
+      const checked = card.querySelector(`input[name="uiux-${questionId}"]:checked`);
+      if (!checked) return;
+      const answer = `${checked.value}: ${checked.dataset.optionLabel || ''}`.trim();
+      this._submitQuestionAnswer(card, answer, threadId, agentName);
+    });
+
+    // Scroll question into view
+    card.scrollIntoView({ behavior: 'smooth', block: 'end' });
+    setTimeout(() => card.scrollIntoView({ behavior: 'smooth', block: 'end' }), 150);
   }
 
   /**

--- a/app/frontend/style.css
+++ b/app/frontend/style.css
@@ -2285,6 +2285,72 @@ body {
     padding: 4px 0;
 }
 
+/* ===== UI/UX visual question (ask_user_uiux_question) ===== */
+.uiux-option-grid {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 10px;
+    margin-top: 12px;
+}
+
+@media (min-width: 900px) {
+    .uiux-option-grid {
+        grid-template-columns: repeat(2, 1fr);
+    }
+}
+
+.uiux-option-card {
+    display: block;
+    border: 1px solid rgba(139, 92, 246, 0.3);
+    border-radius: 10px;
+    padding: 10px;
+    cursor: pointer;
+    background: rgba(139, 92, 246, 0.06);
+    transition: all 0.15s ease;
+}
+
+.uiux-option-card:hover {
+    border-color: rgba(139, 92, 246, 0.55);
+    background: rgba(139, 92, 246, 0.12);
+}
+
+.uiux-option-card.selected {
+    border-color: #8b5cf6;
+    background: rgba(139, 92, 246, 0.18);
+    box-shadow: 0 0 8px rgba(139, 92, 246, 0.3);
+}
+
+.uiux-option-header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 8px;
+}
+
+.uiux-option-header input[type="radio"] {
+    accent-color: #8b5cf6;
+    cursor: pointer;
+}
+
+.uiux-option-label {
+    font-size: 13px;
+    font-weight: 500;
+    color: #c4b5fd;
+}
+
+.uiux-option-preview {
+    width: 100%;
+    height: 12rem;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 8px;
+    background: #ffffff;
+    display: block;
+}
+
+.uiux-send-btn {
+    margin-top: 12px;
+}
+
 /* System message */
 [data-llamabot="system-message"] {
     text-align: center;

--- a/app/tests/test_uiux_question.py
+++ b/app/tests/test_uiux_question.py
@@ -1,0 +1,140 @@
+"""
+Tests for the visual UI/UX question flow:
+- ask_user_uiux_question tool fires the correct interrupt and returns the user's choice
+- the tool is registered in the plan mode agent's default_tools
+- _check_and_send_interrupts forwards a uiux_question interrupt to the frontend as
+  a uiux_question_request, preserving the structured options (id/label/html)
+"""
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from langchain_core.messages import ToolMessage
+from langgraph.types import Command
+
+
+SAMPLE_OPTIONS = [
+    {"id": "centered", "label": "Centered hero", "html": '<button class="btn btn-primary">Save</button>'},
+    {"id": "split", "label": "Split hero", "html": '<div class="card bg-base-200 p-4">Split</div>'},
+]
+
+
+class TestAskUserUiuxQuestionTool:
+    """Test the ask_user_uiux_question tool in the plan mode agent."""
+
+    def test_uiux_question_fires_interrupt(self):
+        """ask_user_uiux_question should call interrupt() with the uiux_question payload."""
+        from app.agents.leonardo.rails_plan_mode_agent.nodes import ask_user_uiux_question
+
+        with patch(
+            "app.agents.leonardo.rails_plan_mode_agent.nodes.interrupt"
+        ) as mock_interrupt:
+            mock_interrupt.return_value = "centered: Centered hero"
+
+            mock_runtime = MagicMock()
+            mock_runtime.tool_call_id = "tool_call_abc"
+
+            result = ask_user_uiux_question.func(
+                question="Which hero layout do you prefer?",
+                options=SAMPLE_OPTIONS,
+                runtime=mock_runtime,
+                context="Phase 1: Clarify",
+            )
+
+            mock_interrupt.assert_called_once_with({
+                "type": "uiux_question",
+                "question": "Which hero layout do you prefer?",
+                "options": SAMPLE_OPTIONS,
+                "context": "Phase 1: Clarify",
+            })
+
+            assert isinstance(result, Command)
+            messages = result.update["messages"]
+            assert len(messages) == 1
+            assert isinstance(messages[0], ToolMessage)
+            assert "centered: Centered hero" in messages[0].content
+            assert messages[0].tool_call_id == "tool_call_abc"
+
+    def test_uiux_question_in_default_tools(self):
+        """ask_user_uiux_question should be registered in the plan mode default_tools list."""
+        from app.agents.leonardo.rails_plan_mode_agent.nodes import default_tools
+
+        tool_names = [t.name for t in default_tools]
+        assert "ask_user_uiux_question" in tool_names
+
+
+class TestCheckAndSendInterruptsUiuxQuestion:
+    """Test that _check_and_send_interrupts forwards uiux_question interrupts."""
+
+    @pytest.mark.asyncio
+    async def test_uiux_question_forwarded_with_options(self):
+        """A uiux_question interrupt becomes a uiux_question_request preserving options."""
+        from app.websocket.request_handler import RequestHandler
+
+        handler = RequestHandler.__new__(RequestHandler)
+        handler._connection_locks = {}
+        handler._is_websocket_open = MagicMock(return_value=True)
+
+        mock_interrupt = MagicMock()
+        mock_interrupt.value = {
+            "type": "uiux_question",
+            "question": "Which hero layout do you prefer?",
+            "options": SAMPLE_OPTIONS,
+            "context": "Phase 1: Clarify",
+        }
+
+        mock_task = MagicMock()
+        mock_task.interrupts = [mock_interrupt]
+
+        mock_state_snapshot = MagicMock()
+        mock_state_snapshot.tasks = [mock_task]
+
+        mock_app = AsyncMock()
+        mock_app.aget_state = AsyncMock(return_value=mock_state_snapshot)
+
+        mock_websocket = AsyncMock()
+        message_data = {"thread_id": "thread_123", "agent_name": "rails_plan_mode_agent"}
+
+        result = await handler._check_and_send_interrupts(
+            mock_app, {}, message_data, mock_websocket
+        )
+
+        assert result is True
+        mock_websocket.send_json.assert_called_once_with({
+            "type": "uiux_question_request",
+            "question": "Which hero layout do you prefer?",
+            "options": SAMPLE_OPTIONS,
+            "context": "Phase 1: Clarify",
+            "thread_id": "thread_123",
+            "agent_name": "rails_plan_mode_agent",
+        })
+
+    @pytest.mark.asyncio
+    async def test_uiux_question_defaults_when_fields_missing(self):
+        """Missing question/options/context default to empty values, not errors."""
+        from app.websocket.request_handler import RequestHandler
+
+        handler = RequestHandler.__new__(RequestHandler)
+        handler._connection_locks = {}
+        handler._is_websocket_open = MagicMock(return_value=True)
+
+        mock_interrupt = MagicMock()
+        mock_interrupt.value = {"type": "uiux_question"}
+
+        mock_task = MagicMock()
+        mock_task.interrupts = [mock_interrupt]
+
+        mock_state_snapshot = MagicMock()
+        mock_state_snapshot.tasks = [mock_task]
+
+        mock_app = AsyncMock()
+        mock_app.aget_state = AsyncMock(return_value=mock_state_snapshot)
+
+        mock_websocket = AsyncMock()
+        message_data = {"thread_id": "t1", "agent_name": "rails_plan_mode_agent"}
+
+        await handler._check_and_send_interrupts(mock_app, {}, message_data, mock_websocket)
+
+        sent = mock_websocket.send_json.call_args[0][0]
+        assert sent["type"] == "uiux_question_request"
+        assert sent["question"] == ""
+        assert sent["options"] == []
+        assert sent["context"] == ""

--- a/app/websocket/request_handler.py
+++ b/app/websocket/request_handler.py
@@ -887,6 +887,18 @@ class RequestHandler:
                         })
                         logger.info("Graph interrupted for plan mode question")
 
+                    # Plan mode visual (UI/UX) question interrupt — options carry HTML previews
+                    elif isinstance(interrupt_value, dict) and interrupt_value.get("type") == "uiux_question":
+                        await websocket.send_json({
+                            "type": "uiux_question_request",
+                            "question": interrupt_value.get("question", ""),
+                            "options": interrupt_value.get("options", []),
+                            "context": interrupt_value.get("context", ""),
+                            "thread_id": message_data.get('thread_id'),
+                            "agent_name": message_data.get('agent_name'),
+                        })
+                        logger.info("Graph interrupted for plan mode UI/UX question")
+
                     # Suggest plan mode interrupt
                     elif isinstance(interrupt_value, dict) and interrupt_value.get("type") == "suggest_mode_switch":
                         await websocket.send_json({


### PR DESCRIPTION
## What

Adds a new plan-mode tool, **`ask_user_uiux_question`**, so Leo can ask the user to choose between **UI/UX options by sight** instead of plain text labels. It reuses the existing `ask_user_question` interrupt/resume cycle, adding a new interrupt type and a native single-select card renderer where each option's HTML snippet renders inside a **sandboxed iframe**.

Per the design: only the *visual preview* is an iframe; the radio/selection chrome stays native and agent-controlled (no postMessage plumbing). The resume path is reused **unchanged** — selections come back over the existing `question_response` channel.

```
ask_user_uiux_question  → interrupt({type:"uiux_question", options:[{id,label,html}]})
  → request_handler._check_and_send_interrupts → ws "uiux_question_request"
  → MessageHandler renders native radio cards, each with a sandboxed <iframe srcdoc=...>
  → user picks one → existing "question_response" → Command(resume=answer)  (UNCHANGED)
```

## Changes

- **`rails_plan_mode_agent/nodes.py`** — new `ask_user_uiux_question` tool + `UIUXOption` TypedDict (`id`/`label`/`html`), registered in plan-mode `default_tools`. Returns the user's choice as the tool result.
- **`request_handler.py`** — one new branch in `_check_and_send_interrupts` forwarding `uiux_question` → `uiux_question_request` (options preserved). No change to the resume handler.
- **`MessageHandler.js`** — `handleUiuxQuestionRequest` renders native radio cards; each snippet is wrapped (Tailwind + DaisyUI via CDN) and set as iframe `srcdoc` with `sandbox="allow-scripts"` (no `allow-same-origin`, so untrusted LLM HTML is isolated from the parent page).
- **`style.css`** — card/grid/preview styles matching the plan-question theme.
- **`test_uiux_question.py`** — tool fires the right interrupt, is registered, and the interrupt is forwarded with options intact.

## Scope / decisions

- **Plan-mode agent only** (for now).
- **Single-select** radio.
- **CDN `srcdoc` previews** (self-contained, no gem changes). Follow-up: a true-fidelity Rails preview route rendering snippets in the target app's real layout — the payload shape already accommodates a future `preview_mode` switch.

## Verification

- 4 backend tests pass in-container.
- Drove headless Chromium against a reproduction of the cards: DaisyUI/Tailwind snippets render correctly **inside** the sandboxed iframe (verified `btn-primary` computed background), and an inline `<script>` in a snippet **cannot** escape the sandbox to mutate the parent page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)