### PR TITLE
Fix DeltaChannel summarization loop + repair robustness (0.5.2a)

### DIFF
--- a/SUMMARIZATION_BUG.md
+++ b/SUMMARIZATION_BUG.md
@@ -2,8 +2,44 @@
 
 **Date**: 2026-02-14  
 **Trace ID**: [019c5d80-663c-7f51-ac78-4489f830a94d](ls://runs/019c5d80-cc02-7290-9631-1a51a38134d8)  
-**Status**: Under Investigation  
+**Status**: RESOLVED (2026-06-25, 0.5.2a) — see "Resolution" below  
 **Severity**: Medium - Causes 6-8 second delays on every turn and loses conversation context prematurely
+
+---
+
+## Resolution (2026-06-25, SupportIncident #106)
+
+The recurring "summarize on every turn" loop (later reproduced on `mbc-preceptors`
+thread `c77fce95`, where checkpoint history raced from step ~193 to ~435) had a
+**single root cause distinct from the hypotheses below**: the DeltaChannel
+`messages` reducer (`_messages_delta_reducer`) does **not** implement
+`REMOVE_ALL_MESSAGES`. `SummarizationMiddleware` clears history by writing
+`[RemoveMessage(REMOVE_ALL_MESSAGES), summary, *preserved]`, but the marker was
+silently dropped, so the summary was appended on top of the full history. The
+post-summary token count never dropped, so summarization re-fired every turn.
+
+Fixes shipped:
+
+1. **`app/agents/utils/delta_state.py`** — `messages_delta_reducer` wraps the
+   upstream reducer and honors `RemoveMessage(REMOVE_ALL_MESSAGES)` while staying
+   batching-invariant (required by DeltaChannel). Core fix; also repairs
+   `ToolResultImageClearingMiddleware` and `/compact`, which emit the same marker.
+2. **`app/agents/leonardo/summarization.py`** — centralized
+   `make_summarization_middleware()` + `RailsSummarizationMiddleware`:
+   token-budgeted `keep=("tokens", 30000)` (auto-trimmed recent tail), preserves
+   the first user messages verbatim, and re-injects the last `write_todos` list
+   into the summary with a restore instruction. All Rails agents use it.
+3. **`make_summarization_model()`** — provider fallback
+   DeepSeek → Gemini 3 Flash → OpenAI → Anthropic (compile-safe with no keys).
+4. **`checkpoint_cleanup.py`** — periodic sweep no longer references the
+   nonexistent `checkpoint_blobs.checkpoint_id`.
+5. **`request_handler._normalize_messages`** — repair path unwraps `_DeltaSnapshot`.
+
+Regression tests: `test_delta_reducer_remove_all.py`,
+`test_rails_summarization_middleware.py`, `test_summarization_fallback.py`,
+`test_checkpoint_cleanup_sql.py`, `test_repair_delta_snapshot.py`.
+
+The original 2026-02-14 hypotheses below are retained for history.
 
 ---
 

--- a/app/agents/leonardo/llm_factory.py
+++ b/app/agents/leonardo/llm_factory.py
@@ -224,19 +224,42 @@ def get_llm(model_name: str):
 def make_summarization_model():
     """Build (model, token_counter, trim_tokens_to_summarize) for SummarizationMiddleware.
 
-    Prefers Gemini 3 Flash (cheap, large multimodal context). Falls back to
-    DeepSeek when no Google/Gemini key is set so that graph compilation never
-    raises at startup due to a missing/rotated Gemini key (SupportIncident #93).
+    Fallback chain, in priority order, picking the first provider whose API key is
+    present in the environment:
 
-    Returns a 3-tuple so callers can configure the surrounding SummarizationMiddleware
-    correctly — the middleware args differ between Gemini (multimodal, no trim limit)
-    and DeepSeek (text-only, tiktoken counter, explicit trim guard).
+        DeepSeek v4 Flash  ->  Gemini 3 Flash  ->  OpenAI gpt-5-mini  ->  Anthropic Haiku
+
+    DeepSeek is first because it is the project default LLM (model policy), so the
+    summarizer matches the conversation model and stays on the provider we
+    actually pay for. Gemini is the strongest fallback (cheap, 1M multimodal
+    context). OpenAI then Anthropic are last-resort so summarization keeps working
+    on instances configured with only those keys.
+
+    Graph compilation must NEVER raise here just because a key is missing
+    (fleet-wide compile guard, SupportIncident #93) — every branch is gated on its
+    own key, and the final fallback returns DeepSeek so a compiled graph always
+    has *a* summarizer (it only errors at call time if literally no key exists).
+
+    Returns a 3-tuple so the caller can configure the surrounding middleware:
+    the token_counter and trim limit differ between the multimodal Gemini path
+    (no trim — let it see everything) and the text-only providers (tiktoken
+    counter + explicit trim guard to stay inside their context windows).
     """
     from app.agents.utils.token_counter import (
         gemini_multimodal_token_counter,
         tiktoken_token_counter,
     )
 
+    # 1) DeepSeek — project default; text-only, tiktoken counter, explicit cap so
+    #    the summarizer input stays inside DeepSeek's smaller context window.
+    if os.getenv("DEEPSEEK_API_KEY"):
+        return (
+            ChatDeepSeekWithReasoning(model="deepseek-v4-flash", timeout=180),
+            tiktoken_token_counter,
+            60000,
+        )
+
+    # 2) Gemini 3 Flash — large multimodal context, can see the full conversation.
     if os.getenv("GOOGLE_API_KEY") or os.getenv("GEMINI_API_KEY"):
         return (
             ChatGoogleGenerativeAI(
@@ -245,12 +268,36 @@ def make_summarization_model():
                 temperature=1.0,
             ),
             gemini_multimodal_token_counter,
-            None,  # let Gemini see the full conversation
+            None,
         )
 
-    # DeepSeek fallback: text-only model, tiktoken counter, explicit context cap
+    # 3) OpenAI — large context; tiktoken counts cleanly without an external call.
+    if os.getenv("OPENAI_API_KEY"):
+        return (
+            ChatOpenAI(model="gpt-5-mini"),
+            tiktoken_token_counter,
+            None,
+        )
+
+    # 4) Anthropic — last resort.
+    if os.getenv("ANTHROPIC_API_KEY"):
+        return (
+            ChatAnthropic(model="claude-haiku-4-5", max_tokens=8192),
+            tiktoken_token_counter,
+            None,
+        )
+
+    # Nothing configured: still return a (DeepSeek) model so graph compilation
+    # succeeds (fleet-wide compile guard). ChatDeepSeek validates that an api_key
+    # exists at *construction* time, so we pass a placeholder — the graph compiles
+    # and only a summarization that actually fires would error, the same failure
+    # surface as the chat model with no key.
     return (
-        ChatDeepSeekWithReasoning(model="deepseek-v4-flash", timeout=180),
+        ChatDeepSeekWithReasoning(
+            model="deepseek-v4-flash",
+            timeout=180,
+            api_key="missing-deepseek-api-key-placeholder",
+        ),
         tiktoken_token_counter,
-        60000,  # keep summarizer input well inside DeepSeek's context window
+        60000,
     )

--- a/app/agents/leonardo/pyxl_agent/nodes.py
+++ b/app/agents/leonardo/pyxl_agent/nodes.py
@@ -14,6 +14,7 @@ circuit breaker.
 from langchain_google_genai import ChatGoogleGenerativeAI
 from langchain.agents import create_agent
 from langchain.agents.middleware import SummarizationMiddleware
+from app.agents.leonardo.summarization import make_summarization_middleware
 from langchain_core.messages import SystemMessage
 
 from app.agents.leonardo.rails_agent.state import RailsAgentState
@@ -107,20 +108,11 @@ def build_workflow(checkpointer=None):
         temperature=0.2,
     )
 
-    summarization_model = ChatGoogleGenerativeAI(
-        model="gemini-3-flash-preview",
-        vertexai=False,
-        temperature=1.0,
-    )
     middleware = [
-        SummarizationMiddleware(
-            model=summarization_model,
-            trigger=("tokens", SUMMARIZATION_TOKEN_THRESHOLD),
-            keep=("messages", 15),
-            token_counter=gemini_multimodal_token_counter,
-            trim_tokens_to_summarize=None,
-            summary_prompt=SUMMARIZATION_PROMPT,
-        ),
+        # Summarization for long conversations (shared factory: provider fallback
+        # model, token-budgeted keep, first-user-messages + todo preservation;
+        # REMOVE_ALL honored by the DeltaChannel reducer).
+        make_summarization_middleware(summary_prompt=SUMMARIZATION_PROMPT),
         DynamicModelMiddleware(),
         deepseek_reasoning_fix,
         check_failure_limit,

--- a/app/agents/leonardo/rails_agent/nodes.py
+++ b/app/agents/leonardo/rails_agent/nodes.py
@@ -18,6 +18,7 @@ from langchain_google_genai import ChatGoogleGenerativeAI
 from langchain.agents import create_agent
 from langchain.agents.middleware import SummarizationMiddleware
 from langchain.agents.middleware.human_in_the_loop import HumanInTheLoopMiddleware
+from app.agents.leonardo.summarization import make_summarization_middleware
 from langchain_core.messages import SystemMessage
 
 from app.agents.leonardo.rails_agent.state import RailsAgentState
@@ -218,12 +219,6 @@ def build_workflow(checkpointer=None, ask_before_edits=False):
     default_model = ChatAnthropic(model="claude-haiku-4-5", max_tokens=16384)
 
     # Configure middleware stack (order matters - executed top to bottom)
-    # Use Gemini 3 Flash for summarization (Google AI Studio, not Vertex)
-    summarization_model = ChatGoogleGenerativeAI(
-        model="gemini-3-flash-preview",
-        vertexai=False,  # Explicitly use Google AI Studio, not Vertex AI
-        temperature=1.0,
-    )
     middleware = [
         # 1. Repair orphaned tool calls — inject placeholder ToolMessages for any
         #    AIMessage tool_calls that have no response (e.g. from a Tavily crash).
@@ -234,17 +229,13 @@ def build_workflow(checkpointer=None, ask_before_edits=False):
         #    context above the summarization threshold on every turn → infinite loop.
         #    Must be before SummarizationMiddleware's before_model token counting.
         clear_old_tool_images,
-        # 3. Summarization for long conversations - prevents token limit issues.
-        #    token_counter strips old images before counting to prevent false triggers
-        #    in the same turn that clear_old_tool_images fires.
-        SummarizationMiddleware(
-            model=summarization_model,
-            trigger=("tokens", SUMMARIZATION_TOKEN_THRESHOLD),
-            keep=("messages", 15),  # Reduced from 20 for faster context recovery
-            token_counter=gemini_multimodal_token_counter_strip_images,
-            trim_tokens_to_summarize=None,  # KEY FIX: Disable trimming, let Gemini see everything
-            summary_prompt=SUMMARIZATION_PROMPT,
-        ),
+        # 3. Summarization for long conversations. The shared factory wires the
+        #    provider fallback model (DeepSeek->Gemini->OpenAI->Anthropic), a
+        #    token-budgeted keep policy, screenshot-stripping token counting, and
+        #    preservation of the first user messages + the live todo list. The
+        #    REMOVE_ALL it emits only clears history because of the DeltaChannel
+        #    reducer in app/agents/utils/delta_state.py (SupportIncident #106).
+        make_summarization_middleware(summary_prompt=SUMMARIZATION_PROMPT),
         # 4. Dynamic model selection based on state.llm_model from frontend
         DynamicModelMiddleware(),
         # 5. Strip image/video/PDF blocks from history when the active model can't

--- a/app/agents/leonardo/rails_engineer_plan_mode_agent/nodes.py
+++ b/app/agents/leonardo/rails_engineer_plan_mode_agent/nodes.py
@@ -23,6 +23,7 @@ from langchain_anthropic import ChatAnthropic
 from app.agents.leonardo.llm_factory import make_summarization_model
 from langchain.agents import create_agent
 from langchain.agents.middleware import SummarizationMiddleware
+from app.agents.leonardo.summarization import make_summarization_middleware
 from langchain_core.messages import SystemMessage
 from datetime import date
 
@@ -110,17 +111,11 @@ def build_workflow(checkpointer=None):
     default_model = ChatAnthropic(model="claude-haiku-4-5", max_tokens=16384)
 
     # Configure middleware stack (order matters - executed top to bottom)
-    summarization_model, summarization_token_counter, trim_tokens_to_summarize = make_summarization_model()
     middleware = [
-        # 1. Summarization for long conversations
-        SummarizationMiddleware(
-            model=summarization_model,
-            trigger=("tokens", SUMMARIZATION_TOKEN_THRESHOLD),
-            keep=("messages", 20),
-            token_counter=summarization_token_counter,
-            trim_tokens_to_summarize=trim_tokens_to_summarize,
-            summary_prompt=SUMMARIZATION_PROMPT,
-        ),
+        # 1. Summarization for long conversations (shared factory: provider
+        #    fallback model, token-budgeted keep, first-user-messages + todo
+        #    preservation; REMOVE_ALL honored by the DeltaChannel reducer).
+        make_summarization_middleware(summary_prompt=SUMMARIZATION_PROMPT),
         # 2. Dynamic model selection based on state.llm_model from frontend
         DynamicModelMiddleware(),
         # 3. View path context injection

--- a/app/agents/leonardo/rails_plan_mode_agent/nodes.py
+++ b/app/agents/leonardo/rails_plan_mode_agent/nodes.py
@@ -22,6 +22,7 @@ from langchain_anthropic import ChatAnthropic
 from app.agents.leonardo.llm_factory import make_summarization_model
 from langchain.agents import create_agent
 from langchain.agents.middleware import SummarizationMiddleware
+from app.agents.leonardo.summarization import make_summarization_middleware
 from langchain_core.messages import SystemMessage, ToolMessage
 from langchain.tools import tool, ToolRuntime
 from langgraph.types import Command, interrupt
@@ -263,17 +264,11 @@ def build_workflow(checkpointer=None):
     default_model = ChatAnthropic(model="claude-haiku-4-5", max_tokens=16384)
 
     # Configure middleware stack (order matters - executed top to bottom)
-    summarization_model, summarization_token_counter, trim_tokens_to_summarize = make_summarization_model()
     middleware = [
-        # 1. Summarization for long conversations
-        SummarizationMiddleware(
-            model=summarization_model,
-            trigger=("tokens", SUMMARIZATION_TOKEN_THRESHOLD),
-            keep=("messages", 20),
-            token_counter=summarization_token_counter,
-            trim_tokens_to_summarize=trim_tokens_to_summarize,
-            summary_prompt=SUMMARIZATION_PROMPT,
-        ),
+        # 1. Summarization for long conversations (shared factory: provider
+        #    fallback model, token-budgeted keep, first-user-messages + todo
+        #    preservation; REMOVE_ALL honored by the DeltaChannel reducer).
+        make_summarization_middleware(summary_prompt=SUMMARIZATION_PROMPT),
         # 2. Dynamic model selection based on state.llm_model from frontend
         DynamicModelMiddleware(),
         # 3. View path context injection

--- a/app/agents/leonardo/rails_testing_agent/nodes.py
+++ b/app/agents/leonardo/rails_testing_agent/nodes.py
@@ -25,6 +25,7 @@ from langchain_anthropic import ChatAnthropic
 from langchain_google_genai import ChatGoogleGenerativeAI
 from langchain.agents import create_agent
 from langchain.agents.middleware import SummarizationMiddleware
+from app.agents.leonardo.summarization import make_summarization_middleware
 from langchain_core.messages import SystemMessage
 from datetime import date
 
@@ -201,22 +202,11 @@ def build_workflow(checkpointer=None):
     default_model = ChatAnthropic(model="claude-haiku-4-5", max_tokens=16384)
 
     # Configure middleware stack (order matters - executed top to bottom)
-    # Use Gemini 3 Flash for summarization (Google AI Studio, not Vertex)
-    summarization_model = ChatGoogleGenerativeAI(
-        model="gemini-3-flash-preview",
-        vertexai=False,  # Explicitly use Google AI Studio, not Vertex AI
-        temperature=1.0,
-    )
     middleware = [
-        # 1. Summarization for long conversations - prevents token limit issues
-        SummarizationMiddleware(
-            model=summarization_model,
-            trigger=("tokens", SUMMARIZATION_TOKEN_THRESHOLD),
-            keep=("messages", 20),  # Match Claude Code's default
-            token_counter=gemini_multimodal_token_counter,
-            trim_tokens_to_summarize=None,  # KEY FIX: Disable trimming, let Gemini see everything
-            summary_prompt=SUMMARIZATION_PROMPT,
-        ),
+        # 1. Summarization for long conversations (shared factory: provider
+        #    fallback model, token-budgeted keep, first-user-messages + todo
+        #    preservation; REMOVE_ALL honored by the DeltaChannel reducer).
+        make_summarization_middleware(summary_prompt=SUMMARIZATION_PROMPT),
         # 2. Dynamic model selection based on state.llm_model from frontend
         DynamicModelMiddleware(),
         # 3. View path context injection - prepends page context to user messages

--- a/app/agents/leonardo/rails_ticket_mode_agent/nodes.py
+++ b/app/agents/leonardo/rails_ticket_mode_agent/nodes.py
@@ -22,6 +22,7 @@ from langchain_anthropic import ChatAnthropic
 from app.agents.leonardo.llm_factory import make_summarization_model
 from langchain.agents import create_agent
 from langchain.agents.middleware import SummarizationMiddleware
+from app.agents.leonardo.summarization import make_summarization_middleware
 from langchain_core.messages import SystemMessage, ToolMessage
 from langchain.tools import tool, ToolRuntime
 from langgraph.types import Command, interrupt
@@ -313,17 +314,11 @@ def build_workflow(checkpointer=None):
     default_model = ChatAnthropic(model="claude-haiku-4-5", max_tokens=16384)
 
     # Configure middleware stack (order matters - executed top to bottom)
-    summarization_model, summarization_token_counter, trim_tokens_to_summarize = make_summarization_model()
     middleware = [
-        # 1. Summarization for long conversations - prevents token limit issues
-        SummarizationMiddleware(
-            model=summarization_model,
-            trigger=("tokens", SUMMARIZATION_TOKEN_THRESHOLD),
-            keep=("messages", 20),  # Match Claude Code's default
-            token_counter=summarization_token_counter,
-            trim_tokens_to_summarize=trim_tokens_to_summarize,
-            summary_prompt=SUMMARIZATION_PROMPT,
-        ),
+        # 1. Summarization for long conversations (shared factory: provider
+        #    fallback model, token-budgeted keep, first-user-messages + todo
+        #    preservation; REMOVE_ALL honored by the DeltaChannel reducer).
+        make_summarization_middleware(summary_prompt=SUMMARIZATION_PROMPT),
         # 2. Dynamic model selection based on state.llm_model from frontend
         DynamicModelMiddleware(),
         # 3. View path context injection - prepends page context to user messages

--- a/app/agents/leonardo/rails_user_feedback_agent/nodes.py
+++ b/app/agents/leonardo/rails_user_feedback_agent/nodes.py
@@ -21,6 +21,7 @@ from langchain_anthropic import ChatAnthropic
 from app.agents.leonardo.llm_factory import make_summarization_model
 from langchain.agents import create_agent
 from langchain.agents.middleware import SummarizationMiddleware
+from app.agents.leonardo.summarization import make_summarization_middleware
 from langchain_core.messages import SystemMessage, ToolMessage
 from langchain.tools import tool, ToolRuntime
 from langgraph.types import Command
@@ -247,17 +248,11 @@ def build_workflow(checkpointer=None):
     default_model = ChatAnthropic(model="claude-haiku-4-5", max_tokens=16384)
 
     # Configure middleware stack (order matters - executed top to bottom)
-    summarization_model, summarization_token_counter, trim_tokens_to_summarize = make_summarization_model()
     middleware = [
-        # 1. Summarization for long conversations - prevents token limit issues
-        SummarizationMiddleware(
-            model=summarization_model,
-            trigger=("tokens", SUMMARIZATION_TOKEN_THRESHOLD),
-            keep=("messages", 20),  # Match Claude Code's default
-            token_counter=summarization_token_counter,
-            trim_tokens_to_summarize=trim_tokens_to_summarize,
-            summary_prompt=SUMMARIZATION_PROMPT,
-        ),
+        # 1. Summarization for long conversations (shared factory: provider
+        #    fallback model, token-budgeted keep, first-user-messages + todo
+        #    preservation; REMOVE_ALL honored by the DeltaChannel reducer).
+        make_summarization_middleware(summary_prompt=SUMMARIZATION_PROMPT),
         # 2. Dynamic model selection based on state.llm_model from frontend
         DynamicModelMiddleware(),
         # 3. View path context injection - prepends page context to user messages

--- a/app/agents/leonardo/rails_user_mode_agent/nodes.py
+++ b/app/agents/leonardo/rails_user_mode_agent/nodes.py
@@ -19,6 +19,7 @@ from langchain_anthropic import ChatAnthropic
 from app.agents.leonardo.llm_factory import make_summarization_model
 from langchain.agents import create_agent
 from langchain.agents.middleware import SummarizationMiddleware
+from app.agents.leonardo.summarization import make_summarization_middleware
 from langchain_core.messages import SystemMessage
 from datetime import date
 
@@ -148,17 +149,11 @@ def build_workflow(checkpointer=None):
     default_model = ChatAnthropic(model="claude-haiku-4-5", max_tokens=16384)
 
     # Configure middleware stack (order matters - executed top to bottom)
-    summarization_model, summarization_token_counter, trim_tokens_to_summarize = make_summarization_model()
     middleware = [
-        # 1. Summarization for long conversations - prevents token limit issues
-        SummarizationMiddleware(
-            model=summarization_model,
-            trigger=("tokens", SUMMARIZATION_TOKEN_THRESHOLD),
-            keep=("messages", 20),  # Match Claude Code's default
-            token_counter=summarization_token_counter,
-            trim_tokens_to_summarize=trim_tokens_to_summarize,
-            summary_prompt=SUMMARIZATION_PROMPT,
-        ),
+        # 1. Summarization for long conversations (shared factory: provider
+        #    fallback model, token-budgeted keep, first-user-messages + todo
+        #    preservation; REMOVE_ALL honored by the DeltaChannel reducer).
+        make_summarization_middleware(summary_prompt=SUMMARIZATION_PROMPT),
         # 2. Dynamic model selection based on state.llm_model from frontend
         DynamicModelMiddleware(),
         # 3. View path context injection - prepends page context to user messages

--- a/app/agents/leonardo/summarization.py
+++ b/app/agents/leonardo/summarization.py
@@ -1,0 +1,236 @@
+"""Shared summarization middleware for the Leonardo agent fleet.
+
+`make_summarization_middleware()` is the single source of truth for how every
+agent compacts long conversations. It wires together:
+
+- the provider fallback model (`make_summarization_model`: DeepSeek -> Gemini ->
+  OpenAI -> Anthropic),
+- a token-budgeted retention policy (`keep=("tokens", SUMMARIZATION_KEEP_TOKENS)`)
+  so the preserved recent tail is bounded by tokens and auto-trimmed by the
+  middleware's binary-search cutoff rather than a fixed message count,
+- a screenshot-stripping token counter so accumulated browser_inspect images
+  never inflate the count,
+- and `RailsSummarizationMiddleware`, which additionally preserves the first few
+  user messages verbatim and re-injects the most recent todo list.
+
+Why a subclass
+--------------
+Stock `SummarizationMiddleware` keeps only the recent suffix; the original user
+intent and the live todo list disappear into the summary text. After a long run
+that loses the thread's north star. `RailsSummarizationMiddleware` post-processes
+the stock output to:
+
+1. Re-add the first K human messages verbatim (the original ask), and
+2. Append the last `write_todos` payload to the summary with an instruction to
+   immediately restore it — keeping the todo list active across compaction.
+
+The stock middleware emits `[RemoveMessage(REMOVE_ALL_MESSAGES), summary, *tail]`.
+That `REMOVE_ALL_MESSAGES` only actually clears history because of the custom
+DeltaChannel reducer in `app/agents/utils/delta_state.py`; without it the whole
+thing loops (SupportIncident #106).
+"""
+from __future__ import annotations
+
+import json
+import logging
+
+from langchain.agents.middleware import SummarizationMiddleware
+from langchain_core.messages import HumanMessage
+
+logger = logging.getLogger(__name__)
+
+
+def _strip_images_then_count(counter):
+    """Wrap a token counter so old browser_inspect screenshots are stripped first.
+
+    Each screenshot is ~25-50k tokens; counting them keeps the conversation above
+    the summarization threshold on every turn. `ToolResultImageClearingMiddleware`
+    strips them from state, and counting the stripped view here keeps the trigger
+    check honest in the same turn that stripping happens.
+    """
+    from app.agents.utils.token_counter import _strip_old_images
+
+    def _counter(messages):
+        return counter(_strip_old_images(list(messages)))
+
+    return _counter
+
+
+class RailsSummarizationMiddleware(SummarizationMiddleware):
+    """`SummarizationMiddleware` that preserves original intent and the todo list.
+
+    On top of the stock summarize-and-keep-recent behavior it:
+      - re-adds the first ``keep_initial_human`` user messages verbatim, so the
+        agent never loses the original request, and
+      - appends the most recent ``write_todos`` payload to the summary with an
+        instruction to restore it immediately, so todos survive compaction.
+    """
+
+    def __init__(self, *args, keep_initial_human: int = 3, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.keep_initial_human = keep_initial_human
+
+    # -- hooks ----------------------------------------------------------------
+
+    def before_model(self, state, runtime):
+        original = list(state["messages"])
+        result = super().before_model(state, runtime)
+        if result is None:
+            return None
+        return self._augment(original, result)
+
+    async def abefore_model(self, state, runtime):
+        original = list(state["messages"])
+        result = await super().abefore_model(state, runtime)
+        if result is None:
+            return None
+        return self._augment(original, result)
+
+    # -- augmentation ---------------------------------------------------------
+
+    def _augment(self, original_messages, result):
+        """Rebuild the summarize write to also keep first-K humans + the todo list."""
+        msgs = list(result.get("messages", []))
+        if not msgs:
+            return result
+
+        # Stock shape: [RemoveMessage(REMOVE_ALL_MESSAGES), summary, *preserved]
+        remove_op = msgs[0]
+        body = msgs[1:]
+
+        summary_idx = next(
+            (
+                i
+                for i, m in enumerate(body)
+                if isinstance(m, HumanMessage)
+                and (getattr(m, "additional_kwargs", None) or {}).get("lc_source")
+                == "summarization"
+            ),
+            None,
+        )
+        if summary_idx is None:
+            # Unexpected shape (upstream changed); leave the stock result alone.
+            return result
+
+        summary_msg = body[summary_idx]
+        preserved = body[summary_idx + 1:]
+        preserved_ids = {getattr(m, "id", None) for m in preserved}
+
+        # (1) First-K human messages verbatim (skip any already in the tail).
+        initial = self._first_human_messages(original_messages, preserved_ids)
+
+        # (2) Restore the live todo list via the summary.
+        todos = self._extract_last_todos(original_messages)
+        if todos:
+            summary_msg = self._with_todo_restore(summary_msg, todos)
+            logger.info(
+                "RailsSummarizationMiddleware: re-injected %d todo(s) into summary",
+                len(todos),
+            )
+
+        if initial:
+            logger.info(
+                "RailsSummarizationMiddleware: preserved %d initial user message(s)",
+                len(initial),
+            )
+
+        return {"messages": [remove_op, *initial, summary_msg, *preserved]}
+
+    def _first_human_messages(self, messages, exclude_ids):
+        """First `keep_initial_human` real user messages, excluding the tail set."""
+        out = []
+        for m in messages:
+            if len(out) >= self.keep_initial_human:
+                break
+            if not isinstance(m, HumanMessage):
+                continue
+            if (getattr(m, "additional_kwargs", None) or {}).get("lc_source") == "summarization":
+                continue
+            if getattr(m, "id", None) in exclude_ids:
+                continue
+            out.append(m)
+        return out
+
+    @staticmethod
+    def _extract_last_todos(messages):
+        """Return the `todos` list from the most recent write_todos tool call, or None."""
+        for m in reversed(messages):
+            tool_calls = getattr(m, "tool_calls", None) or []
+            for tc in tool_calls:
+                name = tc.get("name") if isinstance(tc, dict) else None
+                if name != "write_todos":
+                    continue
+                args = tc.get("args") if isinstance(tc, dict) else None
+                if isinstance(args, str):
+                    try:
+                        args = json.loads(args)
+                    except (ValueError, TypeError):
+                        args = None
+                if isinstance(args, dict) and args.get("todos"):
+                    return args["todos"]
+        return None
+
+    @staticmethod
+    def _with_todo_restore(summary_msg, todos):
+        """Append an ACTIVE TODO LIST restore instruction to the summary message."""
+        try:
+            todos_json = json.dumps(todos, indent=2, default=str)
+        except (TypeError, ValueError):
+            todos_json = str(todos)
+
+        note = (
+            "\n\n## ACTIVE TODO LIST — RESTORE IMMEDIATELY\n"
+            "This was your most recent todo list before the conversation was compacted. "
+            "Compaction dropped the live todo state from view. As your VERY FIRST action, "
+            "call the `write_todos` tool with EXACTLY this list to restore it, then continue. "
+            "Do not skip this step.\n\n"
+            f"```json\n{todos_json}\n```"
+        )
+
+        content = summary_msg.content
+        if isinstance(content, str):
+            new_content = content + note
+        elif isinstance(content, list):
+            new_content = [*content, {"type": "text", "text": note}]
+        else:
+            new_content = note
+
+        return HumanMessage(
+            content=new_content,
+            id=getattr(summary_msg, "id", None),
+            additional_kwargs=dict(getattr(summary_msg, "additional_kwargs", None) or {}),
+        )
+
+
+def make_summarization_middleware(
+    *,
+    summary_prompt: str,
+    keep_initial_human: int = 3,
+    keep_tokens: int | None = None,
+):
+    """Build the shared `RailsSummarizationMiddleware` for an agent.
+
+    Args:
+        summary_prompt: the agent's summarization prompt (kept per-agent so each
+            mode can tune what it extracts).
+        keep_initial_human: number of leading user messages to preserve verbatim.
+        keep_tokens: token budget for the preserved recent tail. Defaults to
+            SUMMARIZATION_KEEP_TOKENS.
+    """
+    from app.agents.leonardo.llm_factory import make_summarization_model
+    from app.agents.utils.token_counter import (
+        SUMMARIZATION_KEEP_TOKENS,
+        SUMMARIZATION_TOKEN_THRESHOLD,
+    )
+
+    model, token_counter, trim_tokens_to_summarize = make_summarization_model()
+
+    return RailsSummarizationMiddleware(
+        model=model,
+        trigger=("tokens", SUMMARIZATION_TOKEN_THRESHOLD),
+        keep=("tokens", keep_tokens or SUMMARIZATION_KEEP_TOKENS),
+        token_counter=_strip_images_then_count(token_counter),
+        trim_tokens_to_summarize=trim_tokens_to_summarize,
+        summary_prompt=summary_prompt,
+        keep_initial_human=keep_initial_human,
+    )

--- a/app/agents/utils/delta_state.py
+++ b/app/agents/utils/delta_state.py
@@ -29,11 +29,71 @@ releases. Keep the version pins in `requirements.txt` in lockstep.
 """
 from typing import Annotated
 
-from langchain_core.messages import AnyMessage
+from langchain_core.messages import AnyMessage, RemoveMessage
 from typing_extensions import Required
 
 from langgraph.channels.delta import DeltaChannel
-from langgraph.graph.message import _messages_delta_reducer
+from langgraph.graph.message import _messages_delta_reducer, REMOVE_ALL_MESSAGES
+
+
+def messages_delta_reducer(state, writes):
+    """`_messages_delta_reducer` that also honors `RemoveMessage(REMOVE_ALL_MESSAGES)`.
+
+    Why this exists
+    ---------------
+    The upstream `_messages_delta_reducer` (LangGraph 1.2) explicitly does NOT
+    implement `REMOVE_ALL_MESSAGES` semantics — its docstring says so. When it
+    sees `RemoveMessage(id="__remove_all__")` it looks the id up in its index,
+    finds nothing (no real message has that id), and silently drops the marker.
+
+    `SummarizationMiddleware` (and our `ToolResultImageClearingMiddleware`) clear
+    history by writing::
+
+        [RemoveMessage(id=REMOVE_ALL_MESSAGES), summary, *preserved]
+
+    With the stock reducer the marker is dropped and `summary`/`preserved` are
+    appended on top of the *full* prior history (preserved ones updated in place
+    by id). The post-summary message list therefore never shrinks, its token
+    count stays above `SUMMARIZATION_TOKEN_THRESHOLD`, and summarization
+    re-triggers on every single turn — the production loop seen on
+    `mbc-preceptors` thread c77fce95 (SupportIncident #106), where the checkpoint
+    history raced from step ~193 to ~435 with repeated `loop` checkpoints.
+
+    Semantics
+    ---------
+    A `RemoveMessage(REMOVE_ALL_MESSAGES)` discards EVERYTHING accumulated before
+    it — both the prior `state` and any earlier messages in the same write batch —
+    keeping only the messages that follow the LAST such marker. The remainder is
+    then handed to the upstream reducer so its dedup-by-id / tombstoning / message
+    coercion behavior is preserved unchanged.
+
+    Batching invariance
+    -------------------
+    `DeltaChannel` requires the reducer to satisfy
+    ``reducer(reducer(s, xs), ys) == reducer(s, xs + ys)`` so it can replay deltas
+    from a snapshot. Treating REMOVE_ALL as "reset everything accumulated so far,
+    continue with what follows" preserves that property (verified for the marker
+    appearing in either batch, both, or neither). Without this invariant,
+    DeltaChannel reconstruction from snapshots would diverge.
+    """
+    # Flatten writes exactly like the upstream reducer does.
+    flat = []
+    for w in writes:
+        if isinstance(w, list):
+            flat.extend(w)
+        else:
+            flat.append(w)
+
+    # Find the LAST REMOVE_ALL marker. Everything up to and including it — the
+    # prior state plus earlier messages in this batch — is discarded.
+    last_remove_all = -1
+    for i, m in enumerate(flat):
+        if isinstance(m, RemoveMessage) and getattr(m, "id", None) == REMOVE_ALL_MESSAGES:
+            last_remove_all = i
+
+    if last_remove_all >= 0:
+        return _messages_delta_reducer([], [flat[last_remove_all + 1:]])
+    return _messages_delta_reducer(state, [flat])
 
 # Write a full snapshot every N updates to the channel. Higher = less storage but
 # more deltas to replay on resume; lower = bounded replay latency at the cost of
@@ -49,6 +109,6 @@ DELTA_SNAPSHOT_FREQUENCY = 50
 DeltaMessages = Required[
     Annotated[
         list[AnyMessage],
-        DeltaChannel(_messages_delta_reducer, snapshot_frequency=DELTA_SNAPSHOT_FREQUENCY),
+        DeltaChannel(messages_delta_reducer, snapshot_frequency=DELTA_SNAPSHOT_FREQUENCY),
     ]
 ]

--- a/app/agents/utils/token_counter.py
+++ b/app/agents/utils/token_counter.py
@@ -13,6 +13,15 @@ causing compaction to never trigger for DeepSeek conversations.
 # This value is used by both backend (SummarizationMiddleware) and frontend (TokenIndicator)
 SUMMARIZATION_TOKEN_THRESHOLD = 100000
 
+# Token budget for the recent-message tail kept verbatim AFTER a summarization.
+# SummarizationMiddleware is configured with keep=("tokens", SUMMARIZATION_KEEP_TOKENS)
+# so the preserved suffix is bounded by token count (and auto-trimmed via the
+# middleware's binary-search cutoff), not a fixed message count. Sized well under
+# SUMMARIZATION_TOKEN_THRESHOLD (~30%) so that summary + first user messages +
+# this tail leaves wide headroom and cannot immediately re-trigger summarization
+# on the next turn — the failure mode behind the production loop (SupportIncident #106).
+SUMMARIZATION_KEEP_TOKENS = 30000
+
 # How many recent browser_inspect screenshots to keep in the context window.
 # Older ones are stripped before token counting (and permanently from state via middleware)
 # to prevent the summarization-every-turn loop caused by screenshot accumulation.

--- a/app/services/checkpoint_cleanup.py
+++ b/app/services/checkpoint_cleanup.py
@@ -133,6 +133,19 @@ async def cleanup_stale_thread_checkpoints(pool, stale_minutes: int = 30):
         stale_minutes: accepted for signature/backwards compatibility. Orphan
             collection is always safe, so it no longer gates deletion.
     """
+    # SCHEMA NOTE (LangGraph PostgresSaver):
+    #   checkpoint_blobs  PK (thread_id, checkpoint_ns, channel, version)  — NO checkpoint_id column
+    #   checkpoint_writes PK (thread_id, checkpoint_ns, checkpoint_id, task_id, idx)
+    #   checkpoints       PK (thread_id, checkpoint_ns, checkpoint_id)
+    #
+    # The previous query joined blobs on a per-checkpoint id column, which does
+    # not exist on checkpoint_blobs, so the whole sweep crashed with a
+    # missing-column error (SupportIncident #106). Blobs are versioned per channel, not per checkpoint,
+    # so the only orphan check that is both valid AND DeltaChannel-safe is at
+    # thread/ns granularity: a blob is debris only when its entire thread has no
+    # surviving checkpoint at all (a thread that was fully deleted or never
+    # committed). That can never delete a blob belonging to a live delta chain.
+    # Writes keep the precise per-checkpoint orphan check (they DO have checkpoint_id).
     async with pool.connection() as conn:
         # Count orphaned rows before cleanup (for logging)
         result = await conn.execute("""
@@ -140,7 +153,7 @@ async def cleanup_stale_thread_checkpoints(pool, stale_minutes: int = 30):
                 (SELECT COUNT(*) FROM checkpoint_blobs b
                  WHERE NOT EXISTS (
                      SELECT 1 FROM checkpoints c
-                     WHERE c.thread_id = b.thread_id AND c.checkpoint_id = b.checkpoint_id
+                     WHERE c.thread_id = b.thread_id AND c.checkpoint_ns = b.checkpoint_ns
                  )) AS orphan_blobs,
                 (SELECT COUNT(*) FROM checkpoint_writes w
                  WHERE NOT EXISTS (
@@ -150,16 +163,16 @@ async def cleanup_stale_thread_checkpoints(pool, stale_minutes: int = 30):
         """)
         orphan_blobs, orphan_writes = await result.fetchone()
 
-        # Delete orphaned blobs (the BIG storage consumers)
+        # Delete orphaned blobs: only blobs whose entire thread/ns has no checkpoint.
         await conn.execute("""
             DELETE FROM checkpoint_blobs b
             WHERE NOT EXISTS (
                 SELECT 1 FROM checkpoints c
-                WHERE c.thread_id = b.thread_id AND c.checkpoint_id = b.checkpoint_id
+                WHERE c.thread_id = b.thread_id AND c.checkpoint_ns = b.checkpoint_ns
             )
         """)
 
-        # Delete orphaned writes
+        # Delete orphaned writes: writes whose specific checkpoint no longer exists.
         await conn.execute("""
             DELETE FROM checkpoint_writes w
             WHERE NOT EXISTS (

--- a/app/tests/test_checkpoint_cleanup_sql.py
+++ b/app/tests/test_checkpoint_cleanup_sql.py
@@ -1,0 +1,64 @@
+"""Schema-level regression for the periodic checkpoint cleanup SQL.
+
+Guards SupportIncident #106's secondary bug: the orphan sweep referenced
+`b.checkpoint_id`, a column that does not exist on `checkpoint_blobs`
+(PK: thread_id, checkpoint_ns, channel, version), so every periodic run crashed
+with `column b.checkpoint_id does not exist`.
+
+A FakeConn unit test can't catch a column-existence error, so this executes the
+real sweep against the live PostgresSaver schema. Skips cleanly if no checkpoint
+DB is reachable (e.g. CI without Postgres).
+"""
+import os
+import inspect
+
+import pytest
+
+from app.services import checkpoint_cleanup
+from app.services.checkpoint_cleanup import cleanup_stale_thread_checkpoints
+
+
+def test_blob_orphan_query_does_not_reference_nonexistent_column():
+    """Static guard: the sweep must never join blobs on the missing checkpoint_id."""
+    src = inspect.getsource(cleanup_stale_thread_checkpoints)
+    assert "b.checkpoint_id" not in src, (
+        "checkpoint_blobs has no checkpoint_id column; the orphan-blob query must "
+        "key on (thread_id, checkpoint_ns)"
+    )
+
+
+def _checkpoint_db_uri():
+    return (
+        os.getenv("CHECKPOINTER_DB_URI")
+        or os.getenv("LEONARDO_DB_URI")
+        or os.getenv("AUTH_DB_URI")
+        or os.getenv("DB_URI")
+    )
+
+
+@pytest.mark.asyncio
+async def test_cleanup_runs_against_real_schema_without_error():
+    uri = _checkpoint_db_uri()
+    if not uri:
+        pytest.skip("no checkpoint DB URI in env")
+
+    from psycopg_pool import AsyncConnectionPool
+
+    pool = AsyncConnectionPool(uri, open=False)
+    await pool.open()
+    try:
+        # Confirm this DB actually has the PostgresSaver tables; otherwise skip
+        # (this URI might point at a non-checkpoint database).
+        async with pool.connection() as conn:
+            res = await conn.execute(
+                "SELECT to_regclass('public.checkpoint_blobs'), "
+                "to_regclass('public.checkpoints')"
+            )
+            blobs_tbl, ckpt_tbl = await res.fetchone()
+        if blobs_tbl is None or ckpt_tbl is None:
+            pytest.skip("checkpoint tables not present in this DB")
+
+        # The actual assertion: this used to raise ProgrammingError on b.checkpoint_id.
+        await cleanup_stale_thread_checkpoints(pool, stale_minutes=30)
+    finally:
+        await pool.close()

--- a/app/tests/test_delta_reducer_remove_all.py
+++ b/app/tests/test_delta_reducer_remove_all.py
@@ -1,0 +1,129 @@
+"""Regression tests for the DeltaChannel messages reducer honoring REMOVE_ALL.
+
+Reproduces and guards the SummarizationMiddleware loop seen in production on
+`mbc-preceptors` thread c77fce95 (SupportIncident #106): the stock
+`_messages_delta_reducer` silently drops `RemoveMessage(REMOVE_ALL_MESSAGES)`,
+so a summarize write `[RemoveMessage(ALL), summary, *preserved]` leaves the full
+prior history in place. The post-summary token count never drops below
+SUMMARIZATION_TOKEN_THRESHOLD, so summarization re-fires every turn.
+
+These assert *structure* (reducer in/out), no LLM and no DB needed.
+"""
+from langchain_core.messages import HumanMessage, AIMessage, RemoveMessage
+from langgraph.graph.message import _messages_delta_reducer, REMOVE_ALL_MESSAGES
+
+from app.agents.utils.delta_state import messages_delta_reducer
+
+
+def _base():
+    return [
+        HumanMessage(content="original user intent", id="h1"),
+        AIMessage(content="assistant turn 1", id="a1"),
+        HumanMessage(content="second user turn", id="h2"),
+        AIMessage(content="assistant turn 2", id="a2"),
+    ]
+
+
+def _summary_write(preserved):
+    summary = HumanMessage(content="Here is a summary of the conversation", id="sum1")
+    return [RemoveMessage(id=REMOVE_ALL_MESSAGES), summary, *preserved]
+
+
+# --- the bug: stock reducer leaves history in place ---------------------------
+
+def test_stock_reducer_drops_remove_all_marker():
+    """Documents the upstream defect this module works around."""
+    state = _base()
+    result = _messages_delta_reducer(state, [_summary_write([state[3]])])
+    # The summary is appended on top of all 4 originals instead of replacing them.
+    assert len(result) == 5
+    assert [m.id for m in result] == ["h1", "a1", "h2", "a2", "sum1"]
+
+
+# --- the fix: our reducer clears history on REMOVE_ALL ------------------------
+
+def test_remove_all_clears_prior_history():
+    state = _base()
+    result = messages_delta_reducer(state, [_summary_write([state[3]])])
+    assert [m.id for m in result] == ["sum1", "a2"], (
+        "after a summary write the reconstructed state must contain only the "
+        "summary + preserved tail, not the pre-summary history"
+    )
+
+
+def test_post_summary_state_is_smaller_so_loop_cannot_recur():
+    """The whole point: the post-summary list must shrink."""
+    state = _base()
+    result = messages_delta_reducer(state, [_summary_write([state[3]])])
+    assert len(result) < len(state)
+
+
+# --- normal (non REMOVE_ALL) behavior is unchanged ---------------------------
+
+def test_passthrough_matches_upstream_without_remove_all():
+    state = _base()
+    write = [[AIMessage(content="new", id="n1")]]
+    assert (
+        [m.id for m in messages_delta_reducer(state, write)]
+        == [m.id for m in _messages_delta_reducer(state, write)]
+    )
+
+
+def test_single_id_remove_still_tombstones():
+    state = _base()
+    result = messages_delta_reducer(state, [[RemoveMessage(id="h2")]])
+    ids = [m.id for m in result]
+    assert "h2" not in ids and ids == ["h1", "a1", "a2"]
+
+
+def test_dedup_by_id_preserved_after_remove_all():
+    # preserved tail keeps its original id; no duplicate should appear.
+    state = _base()
+    result = messages_delta_reducer(state, [_summary_write([state[2], state[3]])])
+    ids = [m.id for m in result]
+    assert ids == ["sum1", "h2", "a2"]
+    assert len(ids) == len(set(ids))
+
+
+# --- batching invariance: DeltaChannel replays deltas from snapshots ---------
+# reducer(reducer(s, xs), ys) MUST equal reducer(s, xs + ys) or snapshot replay
+# diverges from live state.
+
+def _ids(msgs):
+    return [m.id for m in msgs]
+
+
+def test_batching_invariance_remove_all_in_second_batch():
+    xs = [HumanMessage(content="x", id="x1")]
+    ys = [RemoveMessage(id=REMOVE_ALL_MESSAGES), HumanMessage(content="y", id="y1")]
+    combined = messages_delta_reducer(_base(), [xs + ys])
+    stepwise = messages_delta_reducer(messages_delta_reducer(_base(), [xs]), [ys])
+    assert _ids(combined) == _ids(stepwise) == ["y1"]
+
+
+def test_batching_invariance_remove_all_in_first_batch():
+    xs = [RemoveMessage(id=REMOVE_ALL_MESSAGES), HumanMessage(content="x", id="x1")]
+    ys = [AIMessage(content="y", id="y1")]
+    combined = messages_delta_reducer(_base(), [xs + ys])
+    stepwise = messages_delta_reducer(messages_delta_reducer(_base(), [xs]), [ys])
+    assert _ids(combined) == _ids(stepwise) == ["x1", "y1"]
+
+
+def test_batching_invariance_no_remove_all():
+    xs = [AIMessage(content="x", id="x1")]
+    ys = [AIMessage(content="y", id="y1")]
+    combined = messages_delta_reducer(_base(), [xs + ys])
+    stepwise = messages_delta_reducer(messages_delta_reducer(_base(), [xs]), [ys])
+    assert _ids(combined) == _ids(stepwise)
+
+
+def test_last_remove_all_wins_when_multiple():
+    state = _base()
+    write = [
+        RemoveMessage(id=REMOVE_ALL_MESSAGES),
+        HumanMessage(content="discarded", id="d1"),
+        RemoveMessage(id=REMOVE_ALL_MESSAGES),
+        HumanMessage(content="kept", id="k1"),
+    ]
+    result = messages_delta_reducer(state, [write])
+    assert _ids(result) == ["k1"]

--- a/app/tests/test_rails_summarization_middleware.py
+++ b/app/tests/test_rails_summarization_middleware.py
@@ -1,0 +1,186 @@
+"""Tests for RailsSummarizationMiddleware + make_summarization_middleware.
+
+Covers the user-facing retention contract: after a summarization the rebuilt
+message list must contain (a) the first K user messages verbatim, (b) the
+summary with the live todo list re-injected, and (c) the recent tail — and
+nothing else. Also proves it composes with the DeltaChannel REMOVE_ALL reducer so
+the reconstructed state actually shrinks (no loop).
+
+No real LLM: a fake chat model returns a fixed summary string.
+"""
+import pytest
+from langchain_core.language_models.chat_models import BaseChatModel
+from langchain_core.messages import (
+    AIMessage,
+    HumanMessage,
+    ToolMessage,
+    RemoveMessage,
+)
+from langchain_core.outputs import ChatGeneration, ChatResult
+from langgraph.graph.message import REMOVE_ALL_MESSAGES
+
+from app.agents.leonardo.summarization import (
+    RailsSummarizationMiddleware,
+    make_summarization_middleware,
+)
+from app.agents.utils.delta_state import messages_delta_reducer
+from app.agents.utils.token_counter import (
+    SUMMARIZATION_KEEP_TOKENS,
+    SUMMARIZATION_TOKEN_THRESHOLD,
+)
+
+
+class _FakeSummaryModel(BaseChatModel):
+    """Returns a fixed summary; counts every message as 1000 'tokens' via len."""
+
+    @property
+    def _llm_type(self):
+        return "fake-summary"
+
+    def _generate(self, messages, stop=None, run_manager=None, **kwargs):
+        return ChatResult(
+            generations=[ChatGeneration(message=AIMessage(content="FIXED SUMMARY TEXT"))]
+        )
+
+
+def _word_counter(messages):
+    """Cheap deterministic counter: 1000 'tokens' per message."""
+    return 1000 * len(list(messages))
+
+
+def _mw(keep_initial_human=3):
+    return RailsSummarizationMiddleware(
+        model=_FakeSummaryModel(),
+        trigger=("tokens", 5000),       # 5 messages
+        keep=("tokens", 2000),          # ~2 messages tail
+        token_counter=_word_counter,
+        trim_tokens_to_summarize=None,
+        summary_prompt="Summarize:\n{messages}",
+        keep_initial_human=keep_initial_human,
+    )
+
+
+def _long_convo():
+    """A realistic-ish thread with an early write_todos call."""
+    return [
+        HumanMessage(content="Build me a blog with posts and comments", id="h1"),
+        AIMessage(
+            content="",
+            id="a1",
+            tool_calls=[{
+                "name": "write_todos",
+                "id": "tc1",
+                "args": {"todos": [
+                    {"content": "scaffold Post model", "status": "completed"},
+                    {"content": "add Comment model", "status": "in_progress"},
+                    {"content": "wire routes", "status": "pending"},
+                ]},
+            }],
+        ),
+        ToolMessage(content="Updated todo list", tool_call_id="tc1", id="t1"),
+        HumanMessage(content="also add tags", id="h2"),
+        AIMessage(content="working on tags", id="a2"),
+        HumanMessage(content="how's it going?", id="h3"),
+        AIMessage(content="almost done", id="a3"),
+    ]
+
+
+class TestAugmentStructure:
+    def test_preserves_first_user_message_verbatim(self):
+        mw = _mw(keep_initial_human=1)
+        result = mw.before_model({"messages": _long_convo()}, runtime=None)
+        msgs = result["messages"]
+        assert isinstance(msgs[0], RemoveMessage) and msgs[0].id == REMOVE_ALL_MESSAGES
+        # first real human message, verbatim, right after the remove marker
+        assert isinstance(msgs[1], HumanMessage)
+        assert msgs[1].content == "Build me a blog with posts and comments"
+        assert msgs[1].id == "h1"
+
+    def test_summary_present_with_todo_restore_block(self):
+        mw = _mw()
+        result = mw.before_model({"messages": _long_convo()}, runtime=None)
+        summary = next(
+            m for m in result["messages"]
+            if isinstance(m, HumanMessage)
+            and (m.additional_kwargs or {}).get("lc_source") == "summarization"
+        )
+        assert "FIXED SUMMARY TEXT" in summary.content
+        assert "ACTIVE TODO LIST" in summary.content
+        assert "write_todos" in summary.content
+        # the actual todo content must be embedded so the model can restore it
+        assert "scaffold Post model" in summary.content
+        assert "add Comment model" in summary.content
+
+    def test_no_pre_summary_history_leaks(self):
+        mw = _mw(keep_initial_human=1)
+        result = mw.before_model({"messages": _long_convo()}, runtime=None)
+        # The mid-conversation messages that were summarized (h2/a2/t1) must not
+        # reappear verbatim outside the preserved tail.
+        ids = [getattr(m, "id", None) for m in result["messages"]]
+        assert "t1" not in ids  # the tool message in the middle was summarized away
+
+    def test_reconstruction_through_delta_reducer_shrinks(self):
+        """End-to-end: feed the summarize write through the real reducer."""
+        convo = _long_convo()
+        mw = _mw(keep_initial_human=1)
+        result = mw.before_model({"messages": convo}, runtime=None)
+        reconstructed = messages_delta_reducer(convo, [result["messages"]])
+        assert len(reconstructed) < len(convo), "post-summary state must shrink"
+        # first user message + summary survive
+        assert any(m.id == "h1" for m in reconstructed)
+        assert any(
+            isinstance(m, HumanMessage)
+            and (m.additional_kwargs or {}).get("lc_source") == "summarization"
+            for m in reconstructed
+        )
+
+    def test_no_summarization_below_trigger_returns_none(self):
+        mw = _mw()
+        short = [HumanMessage(content="hi", id="h1"), AIMessage(content="hello", id="a1")]
+        assert mw.before_model({"messages": short}, runtime=None) is None
+
+    def test_handles_thread_with_no_todos(self):
+        mw = _mw(keep_initial_human=1)
+        convo = [
+            HumanMessage(content="first", id="h1"),
+            AIMessage(content="a", id="a1"),
+            HumanMessage(content="second", id="h2"),
+            AIMessage(content="b", id="a2"),
+            HumanMessage(content="third", id="h3"),
+            AIMessage(content="c", id="a3"),
+        ]
+        result = mw.before_model({"messages": convo}, runtime=None)
+        summary = next(
+            m for m in result["messages"]
+            if isinstance(m, HumanMessage)
+            and (m.additional_kwargs or {}).get("lc_source") == "summarization"
+        )
+        assert "ACTIVE TODO LIST" not in summary.content
+
+
+class TestExtractTodos:
+    def test_extracts_most_recent(self):
+        msgs = [
+            AIMessage(content="", id="a1", tool_calls=[{
+                "name": "write_todos", "id": "x1",
+                "args": {"todos": [{"content": "old", "status": "pending"}]}}]),
+            AIMessage(content="", id="a2", tool_calls=[{
+                "name": "write_todos", "id": "x2",
+                "args": {"todos": [{"content": "new", "status": "pending"}]}}]),
+        ]
+        todos = RailsSummarizationMiddleware._extract_last_todos(msgs)
+        assert todos == [{"content": "new", "status": "pending"}]
+
+    def test_none_when_absent(self):
+        msgs = [HumanMessage(content="hi", id="h1"), AIMessage(content="yo", id="a1")]
+        assert RailsSummarizationMiddleware._extract_last_todos(msgs) is None
+
+
+class TestFactory:
+    def test_factory_builds_token_keyed_keep(self, monkeypatch):
+        monkeypatch.setenv("DEEPSEEK_API_KEY", "k")
+        mw = make_summarization_middleware(summary_prompt="Summarize {messages}")
+        assert isinstance(mw, RailsSummarizationMiddleware)
+        assert mw.trigger == ("tokens", SUMMARIZATION_TOKEN_THRESHOLD)
+        assert mw.keep == ("tokens", SUMMARIZATION_KEEP_TOKENS)
+        assert mw.keep_initial_human == 3

--- a/app/tests/test_repair_delta_snapshot.py
+++ b/app/tests/test_repair_delta_snapshot.py
@@ -1,0 +1,101 @@
+"""Repair path must normalize DeltaChannel `_DeltaSnapshot` message values.
+
+SupportIncident #106: on a DeltaChannel thread, `aget_state().values["messages"]`
+can surface as a `_DeltaSnapshot` whose list lives at `.value`. The repair scan
+iterated that object directly, silently seeing no messages and skipping a needed
+dangling-tool_call repair. These assert the normalization + that repair still
+fires for a dangling tool call hidden inside a snapshot.
+"""
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+
+from app.websocket.request_handler import RequestHandler
+
+
+class _Snapshot:
+    """Stand-in for langgraph's _DeltaSnapshot: real list lives at `.value`."""
+    def __init__(self, value):
+        self.value = value
+
+
+class TestNormalizeMessages:
+    def test_unwraps_delta_snapshot(self):
+        msgs = [HumanMessage(content="hi", id="h1")]
+        assert RequestHandler._normalize_messages(_Snapshot(msgs)) == msgs
+
+    def test_passthrough_plain_list(self):
+        msgs = [HumanMessage(content="hi", id="h1")]
+        assert RequestHandler._normalize_messages(msgs) == msgs
+
+    def test_none_and_empty(self):
+        assert RequestHandler._normalize_messages(None) == []
+        assert RequestHandler._normalize_messages([]) == []
+
+    def test_real_delta_snapshot_type_if_available(self):
+        try:
+            from langgraph.checkpoint.serde.types import _DeltaSnapshot
+        except Exception:
+            pytest.skip("_DeltaSnapshot not importable in this langgraph build")
+        msgs = [HumanMessage(content="hi", id="h1")]
+        snap = _DeltaSnapshot(value=msgs) if _has_kw(_DeltaSnapshot) else _DeltaSnapshot(msgs)
+        assert RequestHandler._normalize_messages(snap) == msgs
+
+
+def _has_kw(cls):
+    import inspect
+    try:
+        return "value" in inspect.signature(cls).parameters
+    except (ValueError, TypeError):
+        return False
+
+
+# --- repair fires through a snapshot-wrapped messages value ------------------
+
+class _FakeStateSnapshot:
+    def __init__(self, messages):
+        self.values = {"messages": messages}
+
+
+class _FakeApp:
+    def __init__(self, snapshot):
+        self._snapshot = snapshot
+        self.updated_with = None
+
+    async def aget_state(self, config):
+        return self._snapshot
+
+    async def aupdate_state(self, config, update):
+        self.updated_with = update
+
+
+@pytest.mark.asyncio
+async def test_repair_fires_for_dangling_toolcall_inside_snapshot():
+    # AIMessage with a tool_call that has no following ToolMessage.
+    dangling = AIMessage(
+        content="",
+        id="a1",
+        tool_calls=[{"name": "bash_command", "id": "call_1", "args": {}}],
+    )
+    messages = [HumanMessage(content="do it", id="h1"), dangling]
+    app = _FakeApp(_FakeStateSnapshot(_Snapshot(messages)))
+
+    handler = RequestHandler.__new__(RequestHandler)  # skip __init__ (needs FastAPI)
+    await handler._repair_thread_state_if_needed(app, {"configurable": {"thread_id": "t"}})
+
+    assert app.updated_with is not None, "repair should have run through the snapshot"
+    injected = app.updated_with["messages"]
+    assert any(
+        isinstance(m, ToolMessage) and m.tool_call_id == "call_1" for m in injected
+    ), "a synthetic ToolMessage must be injected for the dangling tool_call"
+
+
+@pytest.mark.asyncio
+async def test_no_repair_for_clean_snapshot():
+    messages = [
+        HumanMessage(content="hi", id="h1"),
+        AIMessage(content="hello", id="a1"),
+    ]
+    app = _FakeApp(_FakeStateSnapshot(_Snapshot(messages)))
+    handler = RequestHandler.__new__(RequestHandler)
+    await handler._repair_thread_state_if_needed(app, {"configurable": {"thread_id": "t"}})
+    assert app.updated_with is None

--- a/app/tests/test_summarization_fallback.py
+++ b/app/tests/test_summarization_fallback.py
@@ -1,71 +1,88 @@
-"""Tests for make_summarization_model() — DeepSeek fallback when no Gemini key.
+"""Tests for make_summarization_model() — provider fallback chain.
 
-Regression guard for the fleet-wide graph-compile failure that occurred when
-GOOGLE_API_KEY / GEMINI_API_KEY were absent (SupportIncident #93).
+Priority: DeepSeek -> Gemini 3 Flash -> OpenAI -> Anthropic (first key present
+wins). Also a fleet-wide graph-compile guard: compilation must never raise just
+because a key is missing (SupportIncident #93).
 """
 import pytest
 
 from app.agents.leonardo.llm_factory import ChatDeepSeekWithReasoning, make_summarization_model
 from langchain_google_genai import ChatGoogleGenerativeAI
+from langchain_openai import ChatOpenAI
+from langchain_anthropic import ChatAnthropic
 
 
 @pytest.fixture(autouse=True)
-def _clear_google_keys(monkeypatch):
-    """Strip Google key env vars by default; individual tests opt back in.
-    Always set a dummy DEEPSEEK_API_KEY so ChatDeepSeekWithReasoning can
-    instantiate in CI (where no real key is present). In production the real
-    key is always configured — this mirrors that assumption in tests."""
-    monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
-    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
-    monkeypatch.setenv("DEEPSEEK_API_KEY", "sk-ci-placeholder")
+def _clear_all_provider_keys(monkeypatch):
+    """Strip every provider key by default; each test opts the ones it needs
+    back in. This lets us assert the exact priority order of the fallback chain."""
+    for var in ("DEEPSEEK_API_KEY", "GOOGLE_API_KEY", "GEMINI_API_KEY",
+                "OPENAI_API_KEY", "ANTHROPIC_API_KEY"):
+        monkeypatch.delenv(var, raising=False)
 
 
-class TestMakeSummarizationModelNoKey:
-    def test_returns_deepseek_model_when_no_google_key(self):
-        model, token_counter, trim = make_summarization_model()
+class TestFallbackPriority:
+    def test_deepseek_wins_when_all_keys_present(self, monkeypatch):
+        for var in ("DEEPSEEK_API_KEY", "GOOGLE_API_KEY", "OPENAI_API_KEY", "ANTHROPIC_API_KEY"):
+            monkeypatch.setenv(var, "k")
+        model, _, _ = make_summarization_model()
         assert isinstance(model, ChatDeepSeekWithReasoning)
 
-    def test_no_raise_when_no_google_key(self):
-        # Must not raise — this is the fleet-wide compile-time guard
-        make_summarization_model()
+    def test_gemini_when_no_deepseek(self, monkeypatch):
+        monkeypatch.setenv("GOOGLE_API_KEY", "k")
+        monkeypatch.setenv("OPENAI_API_KEY", "k")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "k")
+        model, _, _ = make_summarization_model()
+        assert isinstance(model, ChatGoogleGenerativeAI)
 
-    def test_token_counter_is_callable(self):
-        _, token_counter, _ = make_summarization_model()
+    def test_gemini_api_key_alias(self, monkeypatch):
+        monkeypatch.setenv("GEMINI_API_KEY", "k")
+        model, _, _ = make_summarization_model()
+        assert isinstance(model, ChatGoogleGenerativeAI)
+
+    def test_openai_when_no_deepseek_or_gemini(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "k")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "k")
+        model, _, _ = make_summarization_model()
+        assert isinstance(model, ChatOpenAI)
+
+    def test_anthropic_when_only_anthropic(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "k")
+        model, _, _ = make_summarization_model()
+        assert isinstance(model, ChatAnthropic)
+
+
+class TestCompileGuard:
+    def test_no_raise_when_no_key_at_all(self):
+        # Fleet-wide compile-time guard: must return a model, never raise.
+        model, token_counter, trim = make_summarization_model()
+        assert isinstance(model, ChatDeepSeekWithReasoning)
         assert callable(token_counter)
 
-    def test_token_counter_does_not_call_gemini_api(self, monkeypatch):
-        """tiktoken-only path must work without any Google API call."""
-        from app.agents.utils import token_counter as tc_module
-        called = []
-        monkeypatch.setattr(tc_module, "_get_genai_client", lambda: called.append(1) or (_ for _ in ()).throw(AssertionError("Gemini API called on DeepSeek path")))
-        from langchain_core.messages import HumanMessage
-        _, token_counter, _ = make_summarization_model()
-        count = token_counter([HumanMessage(content="hello world")])
-        assert count > 0
-        assert called == [], "tiktoken_token_counter must not call Gemini API"
-
-    def test_trim_tokens_is_set_for_deepseek(self):
+    def test_deepseek_path_trim_is_set(self, monkeypatch):
+        monkeypatch.setenv("DEEPSEEK_API_KEY", "k")
         _, _, trim = make_summarization_model()
-        assert trim is not None
-        assert isinstance(trim, int)
-        assert trim > 0
+        assert isinstance(trim, int) and trim > 0
 
-
-class TestMakeSummarizationModelWithGeminiKey:
-    def test_returns_gemini_model_when_google_api_key_set(self, monkeypatch):
-        monkeypatch.setenv("GOOGLE_API_KEY", "fake-key-for-test")
-        model, token_counter, trim = make_summarization_model()
-        assert isinstance(model, ChatGoogleGenerativeAI)
-
-    def test_returns_gemini_model_when_gemini_api_key_set(self, monkeypatch):
-        monkeypatch.setenv("GEMINI_API_KEY", "fake-key-for-test")
-        model, token_counter, trim = make_summarization_model()
-        assert isinstance(model, ChatGoogleGenerativeAI)
-
-    def test_trim_is_none_for_gemini_path(self, monkeypatch):
-        monkeypatch.setenv("GOOGLE_API_KEY", "fake-key-for-test")
+    def test_gemini_path_trim_is_none(self, monkeypatch):
+        monkeypatch.setenv("GOOGLE_API_KEY", "k")
         _, _, trim = make_summarization_model()
         assert trim is None
+
+    def test_token_counter_does_not_call_gemini_api_on_deepseek_path(self, monkeypatch):
+        """tiktoken-only path must work without any Google API call."""
+        monkeypatch.setenv("DEEPSEEK_API_KEY", "k")
+        from app.agents.utils import token_counter as tc_module
+        called = []
+        monkeypatch.setattr(
+            tc_module, "_get_genai_client",
+            lambda: called.append(1) or (_ for _ in ()).throw(
+                AssertionError("Gemini API called on DeepSeek path")),
+        )
+        from langchain_core.messages import HumanMessage
+        _, token_counter, _ = make_summarization_model()
+        assert token_counter([HumanMessage(content="hello world")]) > 0
+        assert called == []
 
 
 class TestAgentGraphCompileNoGeminiKey:

--- a/app/websocket/request_handler.py
+++ b/app/websocket/request_handler.py
@@ -113,6 +113,26 @@ class RequestHandler:
                     return value
         return None
 
+    @staticmethod
+    def _normalize_messages(raw):
+        """Return a plain message list from a possibly DeltaChannel-wrapped value.
+
+        DeltaChannel-backed `messages` can surface as a `_DeltaSnapshot` whose
+        actual list lives at `.value` (seen on production thread c77fce95,
+        SupportIncident #106) instead of a resolved list. Scanning that object
+        directly would silently see zero messages and skip a needed repair, or
+        crash. Unwrap `.value` when present; otherwise pass the list through.
+        """
+        if raw is None:
+            return []
+        # `_DeltaSnapshot` is a NamedTuple (a `tuple` subclass) whose real message
+        # list lives at `.value`, so this check MUST come before the list/tuple
+        # coercion below — `isinstance(snapshot, tuple)` is True and would
+        # otherwise wrap the whole snapshot into a one-element list.
+        if not isinstance(raw, list) and hasattr(raw, "value"):
+            return list(raw.value) if raw.value is not None else []
+        return list(raw) if isinstance(raw, (list, tuple)) else raw
+
     async def _repair_thread_state_if_needed(self, app, config):
         """
         Detect and repair two shapes of corrupted thread state that violate
@@ -139,7 +159,7 @@ class RequestHandler:
             if not state_snapshot or not state_snapshot.values:
                 return
 
-            messages = state_snapshot.values.get("messages", [])
+            messages = self._normalize_messages(state_snapshot.values.get("messages", []))
             if not messages:
                 return
 

--- a/docs/dev_logs/0.5.2
+++ b/docs/dev_logs/0.5.2
@@ -1,3 +1,23 @@
 0.5.2:
 - [x] Improve UI/UX for engineer mode with animation and condensed tool messages similar to beginner mode
 - [x] improve thinking verb experience when asking and answering questions
+
+0.5.2a:
+- [.] Add the active todo list on the "Your App is Building" animation screen.
+- [x] Fix summarization/compaction bug, swap order of summarization LLM to go DeepSeek -> Gemini -> OpenAI -> Anthropic
+      Root cause: DeltaChannel's _messages_delta_reducer silently dropped
+      RemoveMessage(REMOVE_ALL_MESSAGES), so SummarizationMiddleware never cleared
+      history and re-fired every turn past ~100k tokens (SupportIncident #106).
+      Fixed the reducer (app/agents/utils/delta_state.py), centralized summarization
+      into app/agents/leonardo/summarization.py with a token-budgeted keep policy
+      that preserves the first user messages + recent tail, and rewrote
+      make_summarization_model() to the DeepSeek->Gemini->OpenAI->Anthropic chain.
+- [x] Have summarization/compaction prompt include the last TODO item
+      RailsSummarizationMiddleware extracts the most recent write_todos payload and
+      appends an "ACTIVE TODO LIST — RESTORE IMMEDIATELY" block to the summary,
+      instructing the agent to re-call write_todos first so todos survive compaction.
+- [x] Fix our delta blobs issue to try and make tool repair thread better.
+      checkpoint_cleanup periodic sweep no longer references the nonexistent
+      checkpoint_blobs.checkpoint_id column (orphan-blob check is now thread/ns
+      scoped, DeltaChannel-safe). Repair path normalizes _DeltaSnapshot message
+      values (.value) so dangling-tool_call repair fires on delta threads.


### PR DESCRIPTION
## Problem

Past ~100k tokens, agents got stuck **re-summarizing every turn** with the full context never shrinking (SupportIncident #106; reproduced on `mbc-preceptors` thread `c77fce95`, where checkpoint history raced step ~193 → ~435).

**Root cause:** `RailsAgentState.messages` uses `DeltaChannel(_messages_delta_reducer)`, and the upstream `_messages_delta_reducer` **does not implement `REMOVE_ALL_MESSAGES`** (its own docstring says so). `SummarizationMiddleware` clears history by writing `[RemoveMessage(REMOVE_ALL_MESSAGES), summary, *preserved]`; the marker was silently dropped, so the summary appended on top of the full history. The post-summary token count never dropped below the threshold → summarization re-fired on every turn. Reproduced empirically (history grew 4→5 instead of shrinking 4→2).

## Fixes

**Core** — `app/agents/utils/delta_state.py`: `messages_delta_reducer` wraps the upstream reducer and honors `RemoveMessage(REMOVE_ALL_MESSAGES)` while remaining **batching-invariant** (the property `DeltaChannel` requires for snapshot replay). One chokepoint fixes the loop for every agent, and also repairs `ToolResultImageClearingMiddleware` and the `/compact` command (both emit the same marker).

**Summarization quality** — new `app/agents/leonardo/summarization.py`:
- `RailsSummarizationMiddleware`: token-budgeted `keep=("tokens", 30000)` (recent tail auto-trimmed by the middleware's binary-search cutoff), **preserves the first user messages verbatim**, and **re-injects the last `write_todos` list** into the summary with an "ACTIVE TODO LIST — RESTORE IMMEDIATELY" instruction so todos stay active across compaction.
- `make_summarization_middleware()` factory — all 8 Rails agents now build summarization through it (removes per-agent drift; 3 were hardcoding Gemini).
- `make_summarization_model()` rewritten to the **DeepSeek → Gemini 3 Flash → OpenAI → Anthropic** fallback chain (compile-safe with no keys; keeps the incident-#93 guard).

**Checkpoint/repair robustness** (the related dev-inbox task):
- `checkpoint_cleanup.py`: periodic sweep no longer references the nonexistent `checkpoint_blobs.checkpoint_id` column — fixes `column b.checkpoint_id does not exist`. Orphan-blob check is now thread/ns scoped and DeltaChannel-safe (never deletes a live delta chain).
- `request_handler._normalize_messages`: repair path unwraps `_DeltaSnapshot` (`.value`), so dangling-tool_call repair fires on delta threads instead of silently seeing zero messages. (The server-side `ask_user_question` resume routing from #106 was already in place.)

## Tests

New, run in `leonardo-llamabot-1`: `test_delta_reducer_remove_all.py` (REMOVE_ALL + batching invariance + documents the upstream bug), `test_rails_summarization_middleware.py` (first-K + TODO + end-to-end reconstruction through the real reducer), `test_summarization_fallback.py` (provider priority + compile guard), `test_checkpoint_cleanup_sql.py` (executes the sweep against the **real** PostgresSaver schema), `test_repair_delta_snapshot.py` (real `_DeltaSnapshot` — caught a genuine NamedTuple bug in the first attempt).

**Full suite: 318 passed, 1 skipped.** All 8 agent graphs compile. Live dev box restarted and verified clean.

## Rollout

Source-only; no schema/dep changes. Roll the fixed LlamaBot image through the normal gated tag → boot-smoke → push workflow, then bump the image tag in Leonardo via PR. No manual `docker buildx --push`.

## Scope notes / follow-ups
- `/compact` benefits from the reducer fix (it now actually clears history) but does not yet apply first-K/TODO augmentation — minor follow-up.
- Stale pending `__error__` write supersession (from the #106 writeup) is **not** included — it needs risky LangGraph-internal manipulation and a safe repro harness; tracked separately.
- The frontend "disable main chat box during a pending `ask_user_question`" UI change is separate frontend work (not in this branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)