### PR TITLE
0.5.2a:

### DIFF
--- a/SUMMARIZATION_BUG.md
+++ b/SUMMARIZATION_BUG.md
@@ -2,8 +2,44 @@
 
 **Date**: 2026-02-14  
 **Trace ID**: [019c5d80-663c-7f51-ac78-4489f830a94d](ls://runs/019c5d80-cc02-7290-9631-1a51a38134d8)  
-**Status**: Under Investigation  
+**Status**: RESOLVED (2026-06-25, 0.5.2a) — see "Resolution" below  
 **Severity**: Medium - Causes 6-8 second delays on every turn and loses conversation context prematurely
+
+---
+
+## Resolution (2026-06-25, SupportIncident #106)
+
+The recurring "summarize on every turn" loop (later reproduced on `mbc-preceptors`
+thread `c77fce95`, where checkpoint history raced from step ~193 to ~435) had a
+**single root cause distinct from the hypotheses below**: the DeltaChannel
+`messages` reducer (`_messages_delta_reducer`) does **not** implement
+`REMOVE_ALL_MESSAGES`. `SummarizationMiddleware` clears history by writing
+`[RemoveMessage(REMOVE_ALL_MESSAGES), summary, *preserved]`, but the marker was
+silently dropped, so the summary was appended on top of the full history. The
+post-summary token count never dropped, so summarization re-fired every turn.
+
+Fixes shipped:
+
+1. **`app/agents/utils/delta_state.py`** — `messages_delta_reducer` wraps the
+   upstream reducer and honors `RemoveMessage(REMOVE_ALL_MESSAGES)` while staying
+   batching-invariant (required by DeltaChannel). Core fix; also repairs
+   `ToolResultImageClearingMiddleware` and `/compact`, which emit the same marker.
+2. **`app/agents/leonardo/summarization.py`** — centralized
+   `make_summarization_middleware()` + `RailsSummarizationMiddleware`:
+   token-budgeted `keep=("tokens", 30000)` (auto-trimmed recent tail), preserves
+   the first user messages verbatim, and re-injects the last `write_todos` list
+   into the summary with a restore instruction. All Rails agents use it.
+3. **`make_summarization_model()`** — provider fallback
+   DeepSeek → Gemini 3 Flash → OpenAI → Anthropic (compile-safe with no keys).
+4. **`checkpoint_cleanup.py`** — periodic sweep no longer references the
+   nonexistent `checkpoint_blobs.checkpoint_id`.
+5. **`request_handler._normalize_messages`** — repair path unwraps `_DeltaSnapshot`.
+
+Regression tests: `test_delta_reducer_remove_all.py`,
+`test_rails_summarization_middleware.py`, `test_summarization_fallback.py`,
+`test_checkpoint_cleanup_sql.py`, `test_repair_delta_snapshot.py`.
+
+The original 2026-02-14 hypotheses below are retained for history.
 
 ---
 

--- a/app/agents/leonardo/llm_factory.py
+++ b/app/agents/leonardo/llm_factory.py
@@ -224,19 +224,42 @@ def get_llm(model_name: str):
 def make_summarization_model():
     """Build (model, token_counter, trim_tokens_to_summarize) for SummarizationMiddleware.
 
-    Prefers Gemini 3 Flash (cheap, large multimodal context). Falls back to
-    DeepSeek when no Google/Gemini key is set so that graph compilation never
-    raises at startup due to a missing/rotated Gemini key (SupportIncident #93).
+    Fallback chain, in priority order, picking the first provider whose API key is
+    present in the environment:
 
-    Returns a 3-tuple so callers can configure the surrounding SummarizationMiddleware
-    correctly — the middleware args differ between Gemini (multimodal, no trim limit)
-    and DeepSeek (text-only, tiktoken counter, explicit trim guard).
+        DeepSeek v4 Flash  ->  Gemini 3 Flash  ->  OpenAI gpt-5-mini  ->  Anthropic Haiku
+
+    DeepSeek is first because it is the project default LLM (model policy), so the
+    summarizer matches the conversation model and stays on the provider we
+    actually pay for. Gemini is the strongest fallback (cheap, 1M multimodal
+    context). OpenAI then Anthropic are last-resort so summarization keeps working
+    on instances configured with only those keys.
+
+    Graph compilation must NEVER raise here just because a key is missing
+    (fleet-wide compile guard, SupportIncident #93) — every branch is gated on its
+    own key, and the final fallback returns DeepSeek so a compiled graph always
+    has *a* summarizer (it only errors at call time if literally no key exists).
+
+    Returns a 3-tuple so the caller can configure the surrounding middleware:
+    the token_counter and trim limit differ between the multimodal Gemini path
+    (no trim — let it see everything) and the text-only providers (tiktoken
+    counter + explicit trim guard to stay inside their context windows).
     """
     from app.agents.utils.token_counter import (
         gemini_multimodal_token_counter,
         tiktoken_token_counter,
     )
 
+    # 1) DeepSeek — project default; text-only, tiktoken counter, explicit cap so
+    #    the summarizer input stays inside DeepSeek's smaller context window.
+    if os.getenv("DEEPSEEK_API_KEY"):
+        return (
+            ChatDeepSeekWithReasoning(model="deepseek-v4-flash", timeout=180),
+            tiktoken_token_counter,
+            60000,
+        )
+
+    # 2) Gemini 3 Flash — large multimodal context, can see the full conversation.
     if os.getenv("GOOGLE_API_KEY") or os.getenv("GEMINI_API_KEY"):
         return (
             ChatGoogleGenerativeAI(
@@ -245,12 +268,36 @@ def make_summarization_model():
                 temperature=1.0,
             ),
             gemini_multimodal_token_counter,
-            None,  # let Gemini see the full conversation
+            None,
         )
 
-    # DeepSeek fallback: text-only model, tiktoken counter, explicit context cap
+    # 3) OpenAI — large context; tiktoken counts cleanly without an external call.
+    if os.getenv("OPENAI_API_KEY"):
+        return (
+            ChatOpenAI(model="gpt-5-mini"),
+            tiktoken_token_counter,
+            None,
+        )
+
+    # 4) Anthropic — last resort.
+    if os.getenv("ANTHROPIC_API_KEY"):
+        return (
+            ChatAnthropic(model="claude-haiku-4-5", max_tokens=8192),
+            tiktoken_token_counter,
+            None,
+        )
+
+    # Nothing configured: still return a (DeepSeek) model so graph compilation
+    # succeeds (fleet-wide compile guard). ChatDeepSeek validates that an api_key
+    # exists at *construction* time, so we pass a placeholder — the graph compiles
+    # and only a summarization that actually fires would error, the same failure
+    # surface as the chat model with no key.
     return (
-        ChatDeepSeekWithReasoning(model="deepseek-v4-flash", timeout=180),
+        ChatDeepSeekWithReasoning(
+            model="deepseek-v4-flash",
+            timeout=180,
+            api_key="missing-deepseek-api-key-placeholder",
+        ),
         tiktoken_token_counter,
-        60000,  # keep summarizer input well inside DeepSeek's context window
+        60000,
     )

--- a/app/agents/leonardo/pyxl_agent/nodes.py
+++ b/app/agents/leonardo/pyxl_agent/nodes.py
@@ -14,6 +14,7 @@ circuit breaker.
 from langchain_google_genai import ChatGoogleGenerativeAI
 from langchain.agents import create_agent
 from langchain.agents.middleware import SummarizationMiddleware
+from app.agents.leonardo.summarization import make_summarization_middleware
 from langchain_core.messages import SystemMessage
 
 from app.agents.leonardo.rails_agent.state import RailsAgentState
@@ -107,20 +108,11 @@ def build_workflow(checkpointer=None):
         temperature=0.2,
     )
 
-    summarization_model = ChatGoogleGenerativeAI(
-        model="gemini-3-flash-preview",
-        vertexai=False,
-        temperature=1.0,
-    )
     middleware = [
-        SummarizationMiddleware(
-            model=summarization_model,
-            trigger=("tokens", SUMMARIZATION_TOKEN_THRESHOLD),
-            keep=("messages", 15),
-            token_counter=gemini_multimodal_token_counter,
-            trim_tokens_to_summarize=None,
-            summary_prompt=SUMMARIZATION_PROMPT,
-        ),
+        # Summarization for long conversations (shared factory: provider fallback
+        # model, token-budgeted keep, first-user-messages + todo preservation;
+        # REMOVE_ALL honored by the DeltaChannel reducer).
+        make_summarization_middleware(summary_prompt=SUMMARIZATION_PROMPT),
         DynamicModelMiddleware(),
         deepseek_reasoning_fix,
         check_failure_limit,

--- a/app/agents/leonardo/rails_agent/nodes.py
+++ b/app/agents/leonardo/rails_agent/nodes.py
@@ -18,6 +18,7 @@ from langchain_google_genai import ChatGoogleGenerativeAI
 from langchain.agents import create_agent
 from langchain.agents.middleware import SummarizationMiddleware
 from langchain.agents.middleware.human_in_the_loop import HumanInTheLoopMiddleware
+from app.agents.leonardo.summarization import make_summarization_middleware
 from langchain_core.messages import SystemMessage
 
 from app.agents.leonardo.rails_agent.state import RailsAgentState
@@ -218,12 +219,6 @@ def build_workflow(checkpointer=None, ask_before_edits=False):
     default_model = ChatAnthropic(model="claude-haiku-4-5", max_tokens=16384)
 
     # Configure middleware stack (order matters - executed top to bottom)
-    # Use Gemini 3 Flash for summarization (Google AI Studio, not Vertex)
-    summarization_model = ChatGoogleGenerativeAI(
-        model="gemini-3-flash-preview",
-        vertexai=False,  # Explicitly use Google AI Studio, not Vertex AI
-        temperature=1.0,
-    )
     middleware = [
         # 1. Repair orphaned tool calls — inject placeholder ToolMessages for any
         #    AIMessage tool_calls that have no response (e.g. from a Tavily crash).
@@ -234,17 +229,13 @@ def build_workflow(checkpointer=None, ask_before_edits=False):
         #    context above the summarization threshold on every turn → infinite loop.
         #    Must be before SummarizationMiddleware's before_model token counting.
         clear_old_tool_images,
-        # 3. Summarization for long conversations - prevents token limit issues.
-        #    token_counter strips old images before counting to prevent false triggers
-        #    in the same turn that clear_old_tool_images fires.
-        SummarizationMiddleware(
-            model=summarization_model,
-            trigger=("tokens", SUMMARIZATION_TOKEN_THRESHOLD),
-            keep=("messages", 15),  # Reduced from 20 for faster context recovery
-            token_counter=gemini_multimodal_token_counter_strip_images,
-            trim_tokens_to_summarize=None,  # KEY FIX: Disable trimming, let Gemini see everything
-            summary_prompt=SUMMARIZATION_PROMPT,
-        ),
+        # 3. Summarization for long conversations. The shared factory wires the
+        #    provider fallback model (DeepSeek->Gemini->OpenAI->Anthropic), a
+        #    token-budgeted keep policy, screenshot-stripping token counting, and
+        #    preservation of the first user messages + the live todo list. The
+        #    REMOVE_ALL it emits only clears history because of the DeltaChannel
+        #    reducer in app/agents/utils/delta_state.py (SupportIncident #106).
+        make_summarization_middleware(summary_prompt=SUMMARIZATION_PROMPT),
         # 4. Dynamic model selection based on state.llm_model from frontend
         DynamicModelMiddleware(),
         # 5. Strip image/video/PDF blocks from history when the active model can't

--- a/app/agents/leonardo/rails_engineer_plan_mode_agent/nodes.py
+++ b/app/agents/leonardo/rails_engineer_plan_mode_agent/nodes.py
@@ -23,6 +23,7 @@ from langchain_anthropic import ChatAnthropic
 from app.agents.leonardo.llm_factory import make_summarization_model
 from langchain.agents import create_agent
 from langchain.agents.middleware import SummarizationMiddleware
+from app.agents.leonardo.summarization import make_summarization_middleware
 from langchain_core.messages import SystemMessage
 from datetime import date
 
@@ -110,17 +111,11 @@ def build_workflow(checkpointer=None):
     default_model = ChatAnthropic(model="claude-haiku-4-5", max_tokens=16384)
 
     # Configure middleware stack (order matters - executed top to bottom)
-    summarization_model, summarization_token_counter, trim_tokens_to_summarize = make_summarization_model()
     middleware = [
-        # 1. Summarization for long conversations
-        SummarizationMiddleware(
-            model=summarization_model,
-            trigger=("tokens", SUMMARIZATION_TOKEN_THRESHOLD),
-            keep=("messages", 20),
-            token_counter=summarization_token_counter,
-            trim_tokens_to_summarize=trim_tokens_to_summarize,
-            summary_prompt=SUMMARIZATION_PROMPT,
-        ),
+        # 1. Summarization for long conversations (shared factory: provider
+        #    fallback model, token-budgeted keep, first-user-messages + todo
+        #    preservation; REMOVE_ALL honored by the DeltaChannel reducer).
+        make_summarization_middleware(summary_prompt=SUMMARIZATION_PROMPT),
         # 2. Dynamic model selection based on state.llm_model from frontend
         DynamicModelMiddleware(),
         # 3. View path context injection

--- a/app/agents/leonardo/rails_plan_mode_agent/nodes.py
+++ b/app/agents/leonardo/rails_plan_mode_agent/nodes.py
@@ -22,6 +22,7 @@ from langchain_anthropic import ChatAnthropic
 from app.agents.leonardo.llm_factory import make_summarization_model
 from langchain.agents import create_agent
 from langchain.agents.middleware import SummarizationMiddleware
+from app.agents.leonardo.summarization import make_summarization_middleware
 from langchain_core.messages import SystemMessage, ToolMessage
 from langchain.tools import tool, ToolRuntime
 from langgraph.types import Command, interrupt
@@ -166,8 +167,14 @@ class UIUXOption(TypedDict):
     Attributes:
         id: Stable identifier returned (with the label) when this option is chosen.
         label: Short human-readable label shown next to the radio button.
-        html: A self-contained Tailwind/DaisyUI HTML snippet rendered as a live
-            preview inside a sandboxed iframe (e.g. '<button class="btn btn-primary">Save</button>').
+        html: A self-contained HTML snippet rendered as a live preview inside a
+            sandboxed iframe. Style it with INLINE styles for anything visual — colors,
+            fonts, sizes, spacing (e.g. '<button style="background:#BE0000;color:#fff;
+            padding:8px 16px;border-radius:6px;">Save</button>'). See
+            ASK_USER_UIUX_QUESTION_DESCRIPTION for the full styling rules of thumb. 
+            Do NOT include emojis unless explicitly asked, instead use icons.
+            Try to use the existing branding, and look/feel of the current page they're on, unless they explicitly
+            are asking for something different.
     """
 
     id: str
@@ -188,16 +195,38 @@ Parameters:
 - options: A list of 2-4 visual options. Each option is an object with:
     - id: a short stable identifier (e.g. "centered", "split", "minimal")
     - label: a short human label for the option (e.g. "Centered hero")
-    - html: a SELF-CONTAINED HTML snippet for the preview, styled with PLAIN Tailwind
-      utility classes only. The preview is rendered with the SAME Tailwind (v2) the app
-      itself loads, so it looks like the real page. Keep it plain and simple — match the
-      app's understated style, do NOT use DaisyUI or other component-library classes
-      (no `btn`, `card`, `hero`, `badge`, `bg-base-*`, etc.; those won't render and look
-      out of place). NO <script> tags, NO external images/fonts/stylesheets, no app-specific
-      CSS. Keep snippets small and focused on the one visual decision being made.
+    - html: a SELF-CONTAINED HTML snippet for the preview (see styling rules below).
+  Do NOT add your own "none"/"other"/"something else" option — the UI automatically appends
+  a "None of these" choice the user can pick (and explain). Only provide the real designs.
 - context: (Optional) Brief context about why you're asking (shown as a subtitle).
 
-This tool freezes execution and waits. The user's chosen option (id and label) is returned as the tool result."""
+STYLING RULES OF THUMB (the preview iframe is locked-down and does NOT behave like the
+real app — these are hard-won, follow them or the preview renders blank/unstyled):
+- PREFER PLAIN INLINE STYLES for everything visual. Colors, fonts, sizes, spacing, borders
+  must go in a `style="..."` attribute (e.g. style="background:#BE0000;color:#fff;
+  font-family:sans-serif;padding:8px 16px"). Inline styles are the only thing guaranteed
+  to render. When in doubt, inline it.
+- DO NOT rely on Tailwind utility classes — especially arbitrary-value classes like
+  `bg-[#BE0000]`, `text-[20px]`, `w-[300px]`, `p-[12px]`. The preview only has a
+  precompiled Tailwind v2 stylesheet; v3-style bracket/arbitrary-value classes do NOT
+  exist in it and render as nothing. Use inline styles instead.
+- NO DaisyUI or other component-library classes (`btn`, `card`, `hero`, `badge`,
+  `bg-base-*`, etc.) — they won't render.
+- NO <script> tags, NO external images/fonts/stylesheets, no app-specific CSS. A small
+  inline <style> block (plain CSS) is fine if inline attributes get unwieldy.
+- FOR ICONS, write INLINE <svg> directly into the snippet — do NOT load an icon font
+  (Font Awesome, Material Icons, etc.) from a CDN; external fonts/stylesheets don't load
+  in this iframe and the icons render blank. Inline SVG is plain text the browser draws
+  with no loading. (In the REAL app you can still use the `fas fa-*` classes already on
+  the page — inline SVG is only needed for the preview.)
+- Keep snippets small, self-contained, and focused on the one visual decision being made.
+- Do NOT include emojis unless explicitly asked, instead use icons.
+- Try to use the existing branding, and look/feel of the current page they're on, unless they explicitly are asking for something different.
+
+(If you discover another preview-rendering quirk, add it to this list — these accumulate.)
+
+This tool freezes execution and waits. The user's chosen option (id and label) is returned as the tool result.
+"""
 
 
 @tool(description=ASK_USER_UIUX_QUESTION_DESCRIPTION)
@@ -263,17 +292,11 @@ def build_workflow(checkpointer=None):
     default_model = ChatAnthropic(model="claude-haiku-4-5", max_tokens=16384)
 
     # Configure middleware stack (order matters - executed top to bottom)
-    summarization_model, summarization_token_counter, trim_tokens_to_summarize = make_summarization_model()
     middleware = [
-        # 1. Summarization for long conversations
-        SummarizationMiddleware(
-            model=summarization_model,
-            trigger=("tokens", SUMMARIZATION_TOKEN_THRESHOLD),
-            keep=("messages", 20),
-            token_counter=summarization_token_counter,
-            trim_tokens_to_summarize=trim_tokens_to_summarize,
-            summary_prompt=SUMMARIZATION_PROMPT,
-        ),
+        # 1. Summarization for long conversations (shared factory: provider
+        #    fallback model, token-budgeted keep, first-user-messages + todo
+        #    preservation; REMOVE_ALL honored by the DeltaChannel reducer).
+        make_summarization_middleware(summary_prompt=SUMMARIZATION_PROMPT),
         # 2. Dynamic model selection based on state.llm_model from frontend
         DynamicModelMiddleware(),
         # 3. View path context injection

--- a/app/agents/leonardo/rails_testing_agent/nodes.py
+++ b/app/agents/leonardo/rails_testing_agent/nodes.py
@@ -25,6 +25,7 @@ from langchain_anthropic import ChatAnthropic
 from langchain_google_genai import ChatGoogleGenerativeAI
 from langchain.agents import create_agent
 from langchain.agents.middleware import SummarizationMiddleware
+from app.agents.leonardo.summarization import make_summarization_middleware
 from langchain_core.messages import SystemMessage
 from datetime import date
 
@@ -201,22 +202,11 @@ def build_workflow(checkpointer=None):
     default_model = ChatAnthropic(model="claude-haiku-4-5", max_tokens=16384)
 
     # Configure middleware stack (order matters - executed top to bottom)
-    # Use Gemini 3 Flash for summarization (Google AI Studio, not Vertex)
-    summarization_model = ChatGoogleGenerativeAI(
-        model="gemini-3-flash-preview",
-        vertexai=False,  # Explicitly use Google AI Studio, not Vertex AI
-        temperature=1.0,
-    )
     middleware = [
-        # 1. Summarization for long conversations - prevents token limit issues
-        SummarizationMiddleware(
-            model=summarization_model,
-            trigger=("tokens", SUMMARIZATION_TOKEN_THRESHOLD),
-            keep=("messages", 20),  # Match Claude Code's default
-            token_counter=gemini_multimodal_token_counter,
-            trim_tokens_to_summarize=None,  # KEY FIX: Disable trimming, let Gemini see everything
-            summary_prompt=SUMMARIZATION_PROMPT,
-        ),
+        # 1. Summarization for long conversations (shared factory: provider
+        #    fallback model, token-budgeted keep, first-user-messages + todo
+        #    preservation; REMOVE_ALL honored by the DeltaChannel reducer).
+        make_summarization_middleware(summary_prompt=SUMMARIZATION_PROMPT),
         # 2. Dynamic model selection based on state.llm_model from frontend
         DynamicModelMiddleware(),
         # 3. View path context injection - prepends page context to user messages

--- a/app/agents/leonardo/rails_ticket_mode_agent/nodes.py
+++ b/app/agents/leonardo/rails_ticket_mode_agent/nodes.py
@@ -22,6 +22,7 @@ from langchain_anthropic import ChatAnthropic
 from app.agents.leonardo.llm_factory import make_summarization_model
 from langchain.agents import create_agent
 from langchain.agents.middleware import SummarizationMiddleware
+from app.agents.leonardo.summarization import make_summarization_middleware
 from langchain_core.messages import SystemMessage, ToolMessage
 from langchain.tools import tool, ToolRuntime
 from langgraph.types import Command, interrupt
@@ -313,17 +314,11 @@ def build_workflow(checkpointer=None):
     default_model = ChatAnthropic(model="claude-haiku-4-5", max_tokens=16384)
 
     # Configure middleware stack (order matters - executed top to bottom)
-    summarization_model, summarization_token_counter, trim_tokens_to_summarize = make_summarization_model()
     middleware = [
-        # 1. Summarization for long conversations - prevents token limit issues
-        SummarizationMiddleware(
-            model=summarization_model,
-            trigger=("tokens", SUMMARIZATION_TOKEN_THRESHOLD),
-            keep=("messages", 20),  # Match Claude Code's default
-            token_counter=summarization_token_counter,
-            trim_tokens_to_summarize=trim_tokens_to_summarize,
-            summary_prompt=SUMMARIZATION_PROMPT,
-        ),
+        # 1. Summarization for long conversations (shared factory: provider
+        #    fallback model, token-budgeted keep, first-user-messages + todo
+        #    preservation; REMOVE_ALL honored by the DeltaChannel reducer).
+        make_summarization_middleware(summary_prompt=SUMMARIZATION_PROMPT),
         # 2. Dynamic model selection based on state.llm_model from frontend
         DynamicModelMiddleware(),
         # 3. View path context injection - prepends page context to user messages

--- a/app/agents/leonardo/rails_user_feedback_agent/nodes.py
+++ b/app/agents/leonardo/rails_user_feedback_agent/nodes.py
@@ -21,6 +21,7 @@ from langchain_anthropic import ChatAnthropic
 from app.agents.leonardo.llm_factory import make_summarization_model
 from langchain.agents import create_agent
 from langchain.agents.middleware import SummarizationMiddleware
+from app.agents.leonardo.summarization import make_summarization_middleware
 from langchain_core.messages import SystemMessage, ToolMessage
 from langchain.tools import tool, ToolRuntime
 from langgraph.types import Command
@@ -247,17 +248,11 @@ def build_workflow(checkpointer=None):
     default_model = ChatAnthropic(model="claude-haiku-4-5", max_tokens=16384)
 
     # Configure middleware stack (order matters - executed top to bottom)
-    summarization_model, summarization_token_counter, trim_tokens_to_summarize = make_summarization_model()
     middleware = [
-        # 1. Summarization for long conversations - prevents token limit issues
-        SummarizationMiddleware(
-            model=summarization_model,
-            trigger=("tokens", SUMMARIZATION_TOKEN_THRESHOLD),
-            keep=("messages", 20),  # Match Claude Code's default
-            token_counter=summarization_token_counter,
-            trim_tokens_to_summarize=trim_tokens_to_summarize,
-            summary_prompt=SUMMARIZATION_PROMPT,
-        ),
+        # 1. Summarization for long conversations (shared factory: provider
+        #    fallback model, token-budgeted keep, first-user-messages + todo
+        #    preservation; REMOVE_ALL honored by the DeltaChannel reducer).
+        make_summarization_middleware(summary_prompt=SUMMARIZATION_PROMPT),
         # 2. Dynamic model selection based on state.llm_model from frontend
         DynamicModelMiddleware(),
         # 3. View path context injection - prepends page context to user messages

--- a/app/agents/leonardo/rails_user_mode_agent/nodes.py
+++ b/app/agents/leonardo/rails_user_mode_agent/nodes.py
@@ -19,6 +19,7 @@ from langchain_anthropic import ChatAnthropic
 from app.agents.leonardo.llm_factory import make_summarization_model
 from langchain.agents import create_agent
 from langchain.agents.middleware import SummarizationMiddleware
+from app.agents.leonardo.summarization import make_summarization_middleware
 from langchain_core.messages import SystemMessage
 from datetime import date
 
@@ -148,17 +149,11 @@ def build_workflow(checkpointer=None):
     default_model = ChatAnthropic(model="claude-haiku-4-5", max_tokens=16384)
 
     # Configure middleware stack (order matters - executed top to bottom)
-    summarization_model, summarization_token_counter, trim_tokens_to_summarize = make_summarization_model()
     middleware = [
-        # 1. Summarization for long conversations - prevents token limit issues
-        SummarizationMiddleware(
-            model=summarization_model,
-            trigger=("tokens", SUMMARIZATION_TOKEN_THRESHOLD),
-            keep=("messages", 20),  # Match Claude Code's default
-            token_counter=summarization_token_counter,
-            trim_tokens_to_summarize=trim_tokens_to_summarize,
-            summary_prompt=SUMMARIZATION_PROMPT,
-        ),
+        # 1. Summarization for long conversations (shared factory: provider
+        #    fallback model, token-budgeted keep, first-user-messages + todo
+        #    preservation; REMOVE_ALL honored by the DeltaChannel reducer).
+        make_summarization_middleware(summary_prompt=SUMMARIZATION_PROMPT),
         # 2. Dynamic model selection based on state.llm_model from frontend
         DynamicModelMiddleware(),
         # 3. View path context injection - prepends page context to user messages

--- a/app/agents/leonardo/summarization.py
+++ b/app/agents/leonardo/summarization.py
@@ -1,0 +1,236 @@
+"""Shared summarization middleware for the Leonardo agent fleet.
+
+`make_summarization_middleware()` is the single source of truth for how every
+agent compacts long conversations. It wires together:
+
+- the provider fallback model (`make_summarization_model`: DeepSeek -> Gemini ->
+  OpenAI -> Anthropic),
+- a token-budgeted retention policy (`keep=("tokens", SUMMARIZATION_KEEP_TOKENS)`)
+  so the preserved recent tail is bounded by tokens and auto-trimmed by the
+  middleware's binary-search cutoff rather than a fixed message count,
+- a screenshot-stripping token counter so accumulated browser_inspect images
+  never inflate the count,
+- and `RailsSummarizationMiddleware`, which additionally preserves the first few
+  user messages verbatim and re-injects the most recent todo list.
+
+Why a subclass
+--------------
+Stock `SummarizationMiddleware` keeps only the recent suffix; the original user
+intent and the live todo list disappear into the summary text. After a long run
+that loses the thread's north star. `RailsSummarizationMiddleware` post-processes
+the stock output to:
+
+1. Re-add the first K human messages verbatim (the original ask), and
+2. Append the last `write_todos` payload to the summary with an instruction to
+   immediately restore it — keeping the todo list active across compaction.
+
+The stock middleware emits `[RemoveMessage(REMOVE_ALL_MESSAGES), summary, *tail]`.
+That `REMOVE_ALL_MESSAGES` only actually clears history because of the custom
+DeltaChannel reducer in `app/agents/utils/delta_state.py`; without it the whole
+thing loops (SupportIncident #106).
+"""
+from __future__ import annotations
+
+import json
+import logging
+
+from langchain.agents.middleware import SummarizationMiddleware
+from langchain_core.messages import HumanMessage
+
+logger = logging.getLogger(__name__)
+
+
+def _strip_images_then_count(counter):
+    """Wrap a token counter so old browser_inspect screenshots are stripped first.
+
+    Each screenshot is ~25-50k tokens; counting them keeps the conversation above
+    the summarization threshold on every turn. `ToolResultImageClearingMiddleware`
+    strips them from state, and counting the stripped view here keeps the trigger
+    check honest in the same turn that stripping happens.
+    """
+    from app.agents.utils.token_counter import _strip_old_images
+
+    def _counter(messages):
+        return counter(_strip_old_images(list(messages)))
+
+    return _counter
+
+
+class RailsSummarizationMiddleware(SummarizationMiddleware):
+    """`SummarizationMiddleware` that preserves original intent and the todo list.
+
+    On top of the stock summarize-and-keep-recent behavior it:
+      - re-adds the first ``keep_initial_human`` user messages verbatim, so the
+        agent never loses the original request, and
+      - appends the most recent ``write_todos`` payload to the summary with an
+        instruction to restore it immediately, so todos survive compaction.
+    """
+
+    def __init__(self, *args, keep_initial_human: int = 3, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.keep_initial_human = keep_initial_human
+
+    # -- hooks ----------------------------------------------------------------
+
+    def before_model(self, state, runtime):
+        original = list(state["messages"])
+        result = super().before_model(state, runtime)
+        if result is None:
+            return None
+        return self._augment(original, result)
+
+    async def abefore_model(self, state, runtime):
+        original = list(state["messages"])
+        result = await super().abefore_model(state, runtime)
+        if result is None:
+            return None
+        return self._augment(original, result)
+
+    # -- augmentation ---------------------------------------------------------
+
+    def _augment(self, original_messages, result):
+        """Rebuild the summarize write to also keep first-K humans + the todo list."""
+        msgs = list(result.get("messages", []))
+        if not msgs:
+            return result
+
+        # Stock shape: [RemoveMessage(REMOVE_ALL_MESSAGES), summary, *preserved]
+        remove_op = msgs[0]
+        body = msgs[1:]
+
+        summary_idx = next(
+            (
+                i
+                for i, m in enumerate(body)
+                if isinstance(m, HumanMessage)
+                and (getattr(m, "additional_kwargs", None) or {}).get("lc_source")
+                == "summarization"
+            ),
+            None,
+        )
+        if summary_idx is None:
+            # Unexpected shape (upstream changed); leave the stock result alone.
+            return result
+
+        summary_msg = body[summary_idx]
+        preserved = body[summary_idx + 1:]
+        preserved_ids = {getattr(m, "id", None) for m in preserved}
+
+        # (1) First-K human messages verbatim (skip any already in the tail).
+        initial = self._first_human_messages(original_messages, preserved_ids)
+
+        # (2) Restore the live todo list via the summary.
+        todos = self._extract_last_todos(original_messages)
+        if todos:
+            summary_msg = self._with_todo_restore(summary_msg, todos)
+            logger.info(
+                "RailsSummarizationMiddleware: re-injected %d todo(s) into summary",
+                len(todos),
+            )
+
+        if initial:
+            logger.info(
+                "RailsSummarizationMiddleware: preserved %d initial user message(s)",
+                len(initial),
+            )
+
+        return {"messages": [remove_op, *initial, summary_msg, *preserved]}
+
+    def _first_human_messages(self, messages, exclude_ids):
+        """First `keep_initial_human` real user messages, excluding the tail set."""
+        out = []
+        for m in messages:
+            if len(out) >= self.keep_initial_human:
+                break
+            if not isinstance(m, HumanMessage):
+                continue
+            if (getattr(m, "additional_kwargs", None) or {}).get("lc_source") == "summarization":
+                continue
+            if getattr(m, "id", None) in exclude_ids:
+                continue
+            out.append(m)
+        return out
+
+    @staticmethod
+    def _extract_last_todos(messages):
+        """Return the `todos` list from the most recent write_todos tool call, or None."""
+        for m in reversed(messages):
+            tool_calls = getattr(m, "tool_calls", None) or []
+            for tc in tool_calls:
+                name = tc.get("name") if isinstance(tc, dict) else None
+                if name != "write_todos":
+                    continue
+                args = tc.get("args") if isinstance(tc, dict) else None
+                if isinstance(args, str):
+                    try:
+                        args = json.loads(args)
+                    except (ValueError, TypeError):
+                        args = None
+                if isinstance(args, dict) and args.get("todos"):
+                    return args["todos"]
+        return None
+
+    @staticmethod
+    def _with_todo_restore(summary_msg, todos):
+        """Append an ACTIVE TODO LIST restore instruction to the summary message."""
+        try:
+            todos_json = json.dumps(todos, indent=2, default=str)
+        except (TypeError, ValueError):
+            todos_json = str(todos)
+
+        note = (
+            "\n\n## ACTIVE TODO LIST — RESTORE IMMEDIATELY\n"
+            "This was your most recent todo list before the conversation was compacted. "
+            "Compaction dropped the live todo state from view. As your VERY FIRST action, "
+            "call the `write_todos` tool with EXACTLY this list to restore it, then continue. "
+            "Do not skip this step.\n\n"
+            f"```json\n{todos_json}\n```"
+        )
+
+        content = summary_msg.content
+        if isinstance(content, str):
+            new_content = content + note
+        elif isinstance(content, list):
+            new_content = [*content, {"type": "text", "text": note}]
+        else:
+            new_content = note
+
+        return HumanMessage(
+            content=new_content,
+            id=getattr(summary_msg, "id", None),
+            additional_kwargs=dict(getattr(summary_msg, "additional_kwargs", None) or {}),
+        )
+
+
+def make_summarization_middleware(
+    *,
+    summary_prompt: str,
+    keep_initial_human: int = 3,
+    keep_tokens: int | None = None,
+):
+    """Build the shared `RailsSummarizationMiddleware` for an agent.
+
+    Args:
+        summary_prompt: the agent's summarization prompt (kept per-agent so each
+            mode can tune what it extracts).
+        keep_initial_human: number of leading user messages to preserve verbatim.
+        keep_tokens: token budget for the preserved recent tail. Defaults to
+            SUMMARIZATION_KEEP_TOKENS.
+    """
+    from app.agents.leonardo.llm_factory import make_summarization_model
+    from app.agents.utils.token_counter import (
+        SUMMARIZATION_KEEP_TOKENS,
+        SUMMARIZATION_TOKEN_THRESHOLD,
+    )
+
+    model, token_counter, trim_tokens_to_summarize = make_summarization_model()
+
+    return RailsSummarizationMiddleware(
+        model=model,
+        trigger=("tokens", SUMMARIZATION_TOKEN_THRESHOLD),
+        keep=("tokens", keep_tokens or SUMMARIZATION_KEEP_TOKENS),
+        token_counter=_strip_images_then_count(token_counter),
+        trim_tokens_to_summarize=trim_tokens_to_summarize,
+        summary_prompt=summary_prompt,
+        keep_initial_human=keep_initial_human,
+    )

--- a/app/agents/utils/delta_state.py
+++ b/app/agents/utils/delta_state.py
@@ -29,11 +29,71 @@ releases. Keep the version pins in `requirements.txt` in lockstep.
 """
 from typing import Annotated
 
-from langchain_core.messages import AnyMessage
+from langchain_core.messages import AnyMessage, RemoveMessage
 from typing_extensions import Required
 
 from langgraph.channels.delta import DeltaChannel
-from langgraph.graph.message import _messages_delta_reducer
+from langgraph.graph.message import _messages_delta_reducer, REMOVE_ALL_MESSAGES
+
+
+def messages_delta_reducer(state, writes):
+    """`_messages_delta_reducer` that also honors `RemoveMessage(REMOVE_ALL_MESSAGES)`.
+
+    Why this exists
+    ---------------
+    The upstream `_messages_delta_reducer` (LangGraph 1.2) explicitly does NOT
+    implement `REMOVE_ALL_MESSAGES` semantics — its docstring says so. When it
+    sees `RemoveMessage(id="__remove_all__")` it looks the id up in its index,
+    finds nothing (no real message has that id), and silently drops the marker.
+
+    `SummarizationMiddleware` (and our `ToolResultImageClearingMiddleware`) clear
+    history by writing::
+
+        [RemoveMessage(id=REMOVE_ALL_MESSAGES), summary, *preserved]
+
+    With the stock reducer the marker is dropped and `summary`/`preserved` are
+    appended on top of the *full* prior history (preserved ones updated in place
+    by id). The post-summary message list therefore never shrinks, its token
+    count stays above `SUMMARIZATION_TOKEN_THRESHOLD`, and summarization
+    re-triggers on every single turn — the production loop seen on
+    `mbc-preceptors` thread c77fce95 (SupportIncident #106), where the checkpoint
+    history raced from step ~193 to ~435 with repeated `loop` checkpoints.
+
+    Semantics
+    ---------
+    A `RemoveMessage(REMOVE_ALL_MESSAGES)` discards EVERYTHING accumulated before
+    it — both the prior `state` and any earlier messages in the same write batch —
+    keeping only the messages that follow the LAST such marker. The remainder is
+    then handed to the upstream reducer so its dedup-by-id / tombstoning / message
+    coercion behavior is preserved unchanged.
+
+    Batching invariance
+    -------------------
+    `DeltaChannel` requires the reducer to satisfy
+    ``reducer(reducer(s, xs), ys) == reducer(s, xs + ys)`` so it can replay deltas
+    from a snapshot. Treating REMOVE_ALL as "reset everything accumulated so far,
+    continue with what follows" preserves that property (verified for the marker
+    appearing in either batch, both, or neither). Without this invariant,
+    DeltaChannel reconstruction from snapshots would diverge.
+    """
+    # Flatten writes exactly like the upstream reducer does.
+    flat = []
+    for w in writes:
+        if isinstance(w, list):
+            flat.extend(w)
+        else:
+            flat.append(w)
+
+    # Find the LAST REMOVE_ALL marker. Everything up to and including it — the
+    # prior state plus earlier messages in this batch — is discarded.
+    last_remove_all = -1
+    for i, m in enumerate(flat):
+        if isinstance(m, RemoveMessage) and getattr(m, "id", None) == REMOVE_ALL_MESSAGES:
+            last_remove_all = i
+
+    if last_remove_all >= 0:
+        return _messages_delta_reducer([], [flat[last_remove_all + 1:]])
+    return _messages_delta_reducer(state, [flat])
 
 # Write a full snapshot every N updates to the channel. Higher = less storage but
 # more deltas to replay on resume; lower = bounded replay latency at the cost of
@@ -49,6 +109,6 @@ DELTA_SNAPSHOT_FREQUENCY = 50
 DeltaMessages = Required[
     Annotated[
         list[AnyMessage],
-        DeltaChannel(_messages_delta_reducer, snapshot_frequency=DELTA_SNAPSHOT_FREQUENCY),
+        DeltaChannel(messages_delta_reducer, snapshot_frequency=DELTA_SNAPSHOT_FREQUENCY),
     ]
 ]

--- a/app/agents/utils/token_counter.py
+++ b/app/agents/utils/token_counter.py
@@ -13,6 +13,15 @@ causing compaction to never trigger for DeepSeek conversations.
 # This value is used by both backend (SummarizationMiddleware) and frontend (TokenIndicator)
 SUMMARIZATION_TOKEN_THRESHOLD = 100000
 
+# Token budget for the recent-message tail kept verbatim AFTER a summarization.
+# SummarizationMiddleware is configured with keep=("tokens", SUMMARIZATION_KEEP_TOKENS)
+# so the preserved suffix is bounded by token count (and auto-trimmed via the
+# middleware's binary-search cutoff), not a fixed message count. Sized well under
+# SUMMARIZATION_TOKEN_THRESHOLD (~30%) so that summary + first user messages +
+# this tail leaves wide headroom and cannot immediately re-trigger summarization
+# on the next turn — the failure mode behind the production loop (SupportIncident #106).
+SUMMARIZATION_KEEP_TOKENS = 30000
+
 # How many recent browser_inspect screenshots to keep in the context window.
 # Older ones are stripped before token counting (and permanently from state via middleware)
 # to prevent the summarization-every-turn loop caused by screenshot accumulation.

--- a/app/frontend/chat.html
+++ b/app/frontend/chat.html
@@ -258,19 +258,15 @@
                             <span class="execution-mode-label" data-llamabot="execution-mode-label">Auto</span>
                         </button>
                         <div class="execution-mode-menu hidden" data-llamabot="execution-mode-menu">
-                            <div class="execution-mode-option" data-mode="ask">
-                                <div class="execution-mode-option-title">Ask before edits</div>
-                                <div class="execution-mode-option-desc">Leonardo will ask for approval before making each edit</div>
-                            </div>
                             <div class="execution-mode-option" data-mode="auto">
                                 <div class="execution-mode-option-title">
                                     <span class="execution-mode-check">✓</span> Edit automatically
                                 </div>
-                                <div class="execution-mode-option-desc">Leonardo will edit files without asking</div>
+                                <div class="execution-mode-option-desc">Leo will edit your app without asking. Best for rapid building</div>
                             </div>
                             <div class="execution-mode-option" data-mode="plan">
                                 <div class="execution-mode-option-title">Plan mode</div>
-                                <div class="execution-mode-option-desc">Leonardo will ask questions, make a plan, and build it for you</div>
+                                <div class="execution-mode-option-desc">Leo will ask questions & make a plan. Highest quality.</div>
                             </div>
                         </div>
                     </div>
@@ -300,7 +296,7 @@
                 </div>
                 <div class="browser-tabs">
                     <div class="tab active" data-target="liveSiteFrame">
-                        <span class="tab-text">Your App</span>
+                        <span class="tab-text"><span class="tab-text-full">Your App</span><span class="tab-text-short">App</span></span>
                         <button class="tab-external-link" data-iframe="liveSiteFrame" title="Open in new tab">
                             <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                                 <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path>

--- a/app/frontend/chat/index.js
+++ b/app/frontend/chat/index.js
@@ -235,14 +235,18 @@ class ChatApp {
     // error when retries are exhausted.
     window.addEventListener('websocketReconnectFailed', () => {
       this.pendingResendData = null;
+      this.webSocketManager?.clearQueue();
       this.hideThinkingIndicator();
       this.setAgentRunning(false);
     });
 
     // If the WS drops while the agent is running, queue the last payload for
-    // resend on the next successful (re)connect.
+    // resend on the next successful (re)connect — unless the manager's outbox
+    // already holds it (i.e. it never made it out in the first place), in which
+    // case the outbox will deliver it and we'd otherwise double-send.
     window.addEventListener('websocketDisconnected', () => {
-      if (this.isAgentRunning && this.lastSentMessageData) {
+      if (this.isAgentRunning && this.lastSentMessageData
+          && !this.webSocketManager?.hasQueued(this.lastSentMessageData)) {
         this.pendingResendData = this.lastSentMessageData;
       }
     });
@@ -811,10 +815,9 @@ class ChatApp {
    * Update execution mode UI and state
    */
   setExecutionMode(mode) {
-    const labels = { auto: 'Auto', ask: 'Ask', plan: 'Plan' };
+    const labels = { auto: 'Auto', plan: 'Plan' };
     const iconClasses = {
       auto: 'fa-solid fa-forward',
-      ask: 'fa-solid fa-shield-halved',
       plan: 'fa-solid fa-pause',
     };
     this.appState.setExecutionMode(mode);
@@ -1414,7 +1417,7 @@ class ChatApp {
 
     // Restore execution mode from cookie
     const savedExecMode = getCookie('executionMode');
-    if (savedExecMode && ['auto', 'ask', 'plan'].includes(savedExecMode)) {
+    if (savedExecMode && ['auto', 'plan'].includes(savedExecMode)) {
       this.setExecutionMode(savedExecMode);
     }
 

--- a/app/frontend/chat/ui/IframeManager.js
+++ b/app/frontend/chat/ui/IframeManager.js
@@ -201,8 +201,11 @@ export class IframeManager {
     overlay.style.display = 'flex';
     overlay.style.flexDirection = 'column';
     overlay.style.alignItems = 'center';
+    overlay.style.justifyContent = 'flex-start';
     overlay.style.zIndex = '10';
     overlay.style.borderRadius = '8px';
+    overlay.style.overflow = 'hidden';
+    overlay.style.paddingTop = '24px';
 
     // Add close button if requested
     if (showCloseButton) {
@@ -230,30 +233,42 @@ export class IframeManager {
       overlay.appendChild(closeBtn);
     }
 
-    // Create text
+    // Create text. Keep it on a single line (no ugly wrap in a narrow preview):
+    // if the title starts with "Your ", that prefix lives in its own span so we
+    // can drop just "Your" when the pane is too small, restoring it when it fits.
     const overlayText = document.createElement('div');
-    overlayText.textContent = text;
     overlayText.style.color = 'white';
-    overlayText.style.fontSize = '2.5rem';
+    overlayText.style.fontSize = '1.8rem';
     overlayText.style.fontWeight = 'bold';
     overlayText.style.fontFamily = 'Arial, sans-serif';
     overlayText.style.textShadow = '2px 2px 4px rgba(0,0,0,0.5)';
+    overlayText.style.whiteSpace = 'nowrap';
+
+    const titlePrefix = 'Your ';
+    if (text.startsWith(titlePrefix)) {
+      const prefixSpan = document.createElement('span');
+      prefixSpan.className = 'overlay-title-prefix';
+      prefixSpan.textContent = titlePrefix;
+      overlayText.appendChild(prefixSpan);
+      overlayText.appendChild(document.createTextNode(text.slice(titlePrefix.length)));
+    } else {
+      overlayText.textContent = text;
+    }
 
     const textContainer = document.createElement('div');
-    textContainer.style.padding = '30px';
-    textContainer.style.width = '100%';
+    textContainer.style.width = 'auto';
     textContainer.style.textAlign = 'center';
+    textContainer.style.overflow = 'hidden';
     textContainer.appendChild(overlayText);
 
-    // Create Lottie container
+    // Create Lottie container. The animation is big & centered before a plan
+    // exists, then shrinks to the top once the todo list takes over the pane.
     const lottieContainer = document.createElement('div');
     lottieContainer.id = 'lottieAnimation';
-    lottieContainer.style.width = '300px';
-    lottieContainer.style.height = '300px';
-    lottieContainer.style.position = 'absolute';
-    lottieContainer.style.top = '50%';
-    lottieContainer.style.left = '50%';
-    lottieContainer.style.transform = 'translate(-50%, -50%)';
+    lottieContainer.style.width = '100%';
+    lottieContainer.style.display = 'flex';
+    lottieContainer.style.alignItems = 'center';
+    lottieContainer.style.justifyContent = 'center';
 
     // Load Lottie script if needed
     if (!document.querySelector('script[src*="lottie-player"]')) {
@@ -267,23 +282,254 @@ export class IframeManager {
     lottiePlayer.src = "https://llamapress-ai-image-uploads.s3.us-west-2.amazonaws.com/hffa8kqjfn9yzfx28pogpvqhn7cd";
     lottiePlayer.background = "transparent";
     lottiePlayer.speed = "1";
-    lottiePlayer.style.width = "300px";
-    lottiePlayer.style.height = "300px";
     lottiePlayer.setAttribute("autoplay", "");
     lottiePlayer.setAttribute("loop", "");
-
     lottieContainer.appendChild(lottiePlayer);
-    overlay.appendChild(textContainer);
+
+    // Cycling tips under the title while Leo gets started (pre-plan only). One at
+    // a time, fading between three short hints, ~35% of the title size. Icons are
+    // the real toolbar icons (Font Awesome 6.5.1, loaded globally) so they match.
+    const tipsContainer = document.createElement('div');
+    tipsContainer.style.width = 'auto';
+    tipsContainer.style.maxWidth = '100%';
+    tipsContainer.style.textAlign = 'center';
+    tipsContainer.style.padding = '4px 0 0';
+    tipsContainer.style.boxSizing = 'border-box';
+    tipsContainer.style.color = 'rgba(255, 255, 255, 0.8)';
+    tipsContainer.style.fontFamily = 'Arial, sans-serif';
+    tipsContainer.style.fontSize = '0.7rem';
+    tipsContainer.style.fontWeight = 'bold';
+    tipsContainer.style.textShadow = '1px 1px 2px rgba(0,0,0,0.5)';
+
+    const tips = [
+      { icon: 'fa-mouse-pointer', text: 'Help Leo by pointing to an element' },
+      { icon: 'fa-paperclip', text: 'Upload files to include in your app' },
+      { icon: 'fa-forward', text: "Switching to Plan Mode can improve Leo's performance" },
+      { icon: 'fa-lightbulb', text: 'view more tips', href: 'https://llamapress.ai/wiki' },
+    ];
+    const tipEl = document.createElement('div');
+    tipEl.style.display = 'inline-flex';
+    tipEl.style.alignItems = 'center';
+    tipEl.style.gap = '6px';
+    tipEl.style.transition = 'opacity 0.4s ease';
+    tipEl.style.opacity = '1';
+    const renderTip = (i) => {
+      const t = tips[i];
+      // Each tip is prefixed with "Tip:" so the user knows it's a tip.
+      const body = t.href
+        ? `<a href="${t.href}" target="_blank" rel="noopener" style="color:inherit;text-decoration:underline;">${t.text}</a>`
+        : t.text;
+      tipEl.innerHTML = `<i class="fa-solid ${t.icon}"></i><span>Tip: ${body}</span>`;
+    };
+    tipsContainer.appendChild(tipEl);
+
+    // Cycle the tips in a shuffled order so it's different every time; reshuffle
+    // each pass (avoiding an immediate repeat) so every tip still gets shown.
+    const shuffle = (arr) => {
+      const a = arr.slice();
+      for (let i = a.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1));
+        [a[i], a[j]] = [a[j], a[i]];
+      }
+      return a;
+    };
+    let order = shuffle(tips.map((_, i) => i));
+    let pos = 0;
+    renderTip(order[pos]);
+
+    this._overlayTipInterval = setInterval(() => {
+      tipEl.style.opacity = '0';
+      setTimeout(() => {
+        pos++;
+        if (pos >= order.length) {
+          const last = order[order.length - 1];
+          order = shuffle(order);
+          if (order.length > 1 && order[0] === last) {
+            [order[0], order[order.length - 1]] = [order[order.length - 1], order[0]];
+          }
+          pos = 0;
+        }
+        renderTip(order[pos]);
+        tipEl.style.opacity = '1';
+      }, 400);
+    }, 20000);
+
+    // Cloned todo list panel (#0d0d1a box) — only shown once a plan exists.
+    const todoContainer = document.createElement('div');
+    todoContainer.id = 'overlayTodoList';
+    todoContainer.style.flex = '1 1 auto';
+    todoContainer.style.width = '100%';
+    todoContainer.style.maxWidth = '480px';
+    todoContainer.style.minHeight = '0';
+    todoContainer.style.overflowY = 'auto';
+    todoContainer.style.marginTop = '8px';
+    todoContainer.style.marginBottom = '16px';
+    todoContainer.style.boxSizing = 'border-box';
+    todoContainer.style.background = '#0d0d1a';
+    todoContainer.style.borderRadius = '10px';
+    todoContainer.style.border = '1px solid rgba(255, 255, 255, 0.08)';
+    todoContainer.style.padding = '16px 20px';
+    todoContainer.style.display = 'none';
+
+    // Toggle the two overlay layouts:
+    //   building → big centered animation + cycling tips, no box
+    //   plan     → small animation up top + the cloned todo list box
+    const setOverlayMode = (mode) => {
+      const isPlan = mode === 'plan';
+      // Building: title + tips + ball are centered as a group (animation doesn't
+      // grow). Plan: top-aligned with the todo box filling the space below.
+      overlay.style.justifyContent = isPlan ? 'flex-start' : 'center';
+      lottieContainer.style.flex = '0 0 auto';
+      // Title is large while building, then shrinks once the todo list takes over.
+      overlayText.style.fontSize = isPlan ? '1.8rem' : '2.5rem';
+      // Tips track ~35% of the current title size (bigger pre-plan, smaller after).
+      tipsContainer.style.fontSize = isPlan ? '0.63rem' : '0.875rem';
+      lottiePlayer.style.width = isPlan ? '140px' : '240px';
+      lottiePlayer.style.height = isPlan ? '140px' : '240px';
+      // Tips keep cycling in the pill in both states (incl. after the todo list).
+      tipsContainer.style.display = 'block';
+      todoContainer.style.display = isPlan ? 'block' : 'none';
+      // Re-evaluate the "Your " drop since the title size just changed.
+      this._fitOverlayTitle?.();
+    };
+    this._setOverlayMode = setOverlayMode;
+    setOverlayMode('building'); // start in the building state
+
+    // Wrap the title + tips in a semi-opaque "pill" so the white text reads
+    // clearly over the live site behind the overlay, without darkening the rest.
+    const headerBox = document.createElement('div');
+    headerBox.style.flex = '0 0 auto';
+    headerBox.style.display = 'flex';
+    headerBox.style.flexDirection = 'column';
+    headerBox.style.alignItems = 'center';
+    headerBox.style.maxWidth = '92%';
+    headerBox.style.boxSizing = 'border-box';
+    headerBox.style.padding = '12px 26px';
+    headerBox.style.borderRadius = '14px';
+    headerBox.style.background = 'rgba(0, 0, 0, 0.45)';
+    headerBox.appendChild(textContainer);
+    headerBox.appendChild(tipsContainer);
+
+    overlay.appendChild(headerBox);
     overlay.appendChild(lottieContainer);
+    overlay.appendChild(todoContainer);
     browserContent.appendChild(overlay);
 
     this.overlayElement = overlay;
+
+    // Keep the title on one line: drop the "Your " prefix when the pane is too
+    // narrow to fit the full title, and restore it when there's room again.
+    const prefixSpan = overlayText.querySelector('.overlay-title-prefix');
+    if (prefixSpan) {
+      const fitTitle = () => {
+        prefixSpan.style.display = 'inline';            // try the full title first
+        // Measure against the pane width (minus the pill's padding/margins), not
+        // the now content-hugging title container.
+        const available = browserContent.clientWidth - 70;
+        if (overlayText.scrollWidth > available) {
+          prefixSpan.style.display = 'none';            // too tight — drop "Your"
+        }
+      };
+      this._fitOverlayTitle = fitTitle; // let setOverlayMode re-fit after size changes
+      requestAnimationFrame(fitTitle); // measure once layout is settled
+      const titleObserver = new ResizeObserver(fitTitle);
+      titleObserver.observe(browserContent);
+      this._overlayTitleObserver = titleObserver;
+    }
+
+    // Mirror the chat's plan into the overlay and switch from the building layout
+    // to the todo-list layout the moment a plan is created.
+    this._startOverlayPlanMirror();
+  }
+
+  /**
+   * Keep the building overlay in sync with the chat:
+   *   • No plan yet → building layout (big centered animation + cycling tips).
+   *   • Plan (todo list) exists → clone the real chat plan node into the box,
+   *     which guarantees identical styling and syncs regardless of streaming path.
+   */
+  _startOverlayPlanMirror() {
+    const history = document.querySelector('[data-llamabot="message-history"]');
+    if (!history) return;
+
+    let scheduled = false;
+    let lastHtml = '';
+
+    const doMirror = () => {
+      scheduled = false;
+      const container = document.getElementById('overlayTodoList');
+      if (!container) return; // overlay gone
+
+      // Latest plan in the chat (exclude any clone living in the overlay itself)
+      const plans = Array.from(history.querySelectorAll('.plan-modern'));
+      const latest = plans[plans.length - 1];
+
+      if (!latest) {
+        // No plan yet → building layout; clear any stale clone.
+        if (lastHtml !== '') { lastHtml = ''; container.innerHTML = ''; }
+        this._setOverlayMode?.('building');
+        return;
+      }
+
+      // Plan exists → swap to the todo-list layout and clone the real plan node.
+      this._setOverlayMode?.('plan');
+      const html = latest.outerHTML;
+      if (html === lastHtml) return; // unchanged, skip redundant DOM write
+      lastHtml = html;
+
+      const clone = latest.cloneNode(true);
+      // Neutralize interactive bits so the read-only clone can't collide with the
+      // chat copy (duplicate ids) or toggle the wrong plan when clicked.
+      clone.removeAttribute('data-plan-id');
+      clone.querySelectorAll('[id]').forEach(el => el.removeAttribute('id'));
+      clone.querySelectorAll('[onclick]').forEach(el => el.removeAttribute('onclick'));
+      // Always show the full task list in the overlay, even if collapsed in chat.
+      clone.querySelectorAll('.plan-tasks-list').forEach(el => { el.style.display = 'block'; });
+
+      container.innerHTML = '';
+      container.appendChild(clone);
+    };
+
+    const schedule = () => {
+      if (scheduled) return;
+      scheduled = true;
+      requestAnimationFrame(doMirror);
+    };
+
+    this._overlayObservers = [];
+    const planObserver = new MutationObserver(schedule);
+    planObserver.observe(history, { childList: true, subtree: true, characterData: true, attributes: true });
+    this._overlayObservers.push(planObserver);
+
+    // Mirror immediately in case a plan already exists when the overlay opens.
+    doMirror();
+  }
+
+  /**
+   * Stop mirroring the chat into the overlay.
+   */
+  _stopOverlayPlanMirror() {
+    if (this._overlayObservers) {
+      this._overlayObservers.forEach(o => o.disconnect());
+      this._overlayObservers = null;
+    }
   }
 
   /**
    * Remove streaming overlay
    */
   removeStreamingOverlay() {
+    this._stopOverlayPlanMirror();
+    if (this._overlayTitleObserver) {
+      this._overlayTitleObserver.disconnect();
+      this._overlayTitleObserver = null;
+    }
+    this._fitOverlayTitle = null;
+    if (this._overlayTipInterval) {
+      clearInterval(this._overlayTipInterval);
+      this._overlayTipInterval = null;
+    }
+    this._setOverlayMode = null;
     const overlay = document.getElementById('streamingOverlay');
     if (overlay) {
       overlay.remove();

--- a/app/frontend/chat/websocket/MessageHandler.js
+++ b/app/frontend/chat/websocket/MessageHandler.js
@@ -669,7 +669,11 @@ export class MessageHandler {
     this.finalizeCurrentThinking();
 
     const { question, options, context, thread_id, agent_name } = data;
-    const opts = Array.isArray(options) ? options : [];
+    // Always append a synthetic "None of these" choice so the user can reject every
+    // suggestion (and optionally explain). It flows through to both the inline carousel
+    // and the expanded modal, since both render whatever is in `opts`.
+    const baseOpts = Array.isArray(options) ? options : [];
+    const opts = [...baseOpts, this._noneOfTheseOption()];
     const id = `uiux-${Date.now()}-${Math.random().toString(36).substr(2, 6)}`;
 
     const frames = opts.map((opt, i) =>
@@ -708,7 +712,6 @@ export class MessageHandler {
 
     const n = options.length;
     const labelFor = (i) => (options[i] && options[i].label != null) ? String(options[i].label) : String(i);
-    const idFor = (i) => (options[i] && options[i].id != null) ? String(options[i].id) : String(i);
 
     card.querySelectorAll('.uiux-car-frame').forEach(f => {
       const opt = options[+f.dataset.i];
@@ -731,8 +734,8 @@ export class MessageHandler {
     card.querySelector('.uiux-car-next')?.addEventListener('click', () => setActive(idx + 1));
 
     card.querySelector('.uiux-car-choose')?.addEventListener('click', () => {
-      const answer = `Selected option "${idFor(idx)}: ${labelFor(idx)}".`;
-      this._answerUiuxQuestion(answer, threadId, agentName, card, labelFor(idx));
+      const { answer, display } = this._uiuxAnswerForOption(options[idx]);
+      this._answerUiuxQuestion(answer, threadId, agentName, card, display);
     });
 
     card.querySelector('.uiux-car-seeall')?.addEventListener('click', () =>
@@ -740,10 +743,49 @@ export class MessageHandler {
   }
 
   /**
+   * The synthetic "None of these" choice appended to every UI/UX question so the user can
+   * reject all suggestions. Styled with plain inline styles (the preview iframe can't load
+   * Tailwind utility classes / external fonts — see _buildUiuxPreviewDoc).
+   */
+  _noneOfTheseOption() {
+    return {
+      id: 'none',
+      label: 'None of these',
+      html: `<div style="display:flex;align-items:center;justify-content:center;min-height:140px;font-family:sans-serif;text-align:center;color:#64748b">
+        <div>
+          <div style="font-size:15px;font-weight:bold;color:#475569">None of these</div>
+          <div style="font-size:12px;margin-top:6px">I'd like something different — I'll explain</div>
+        </div>
+      </div>`,
+    };
+  }
+
+  /**
+   * Build the resume answer + transcript display for a chosen UI/UX option, handling the
+   * synthetic "None of these" choice and an optional free-text message. Shared by the
+   * inline carousel ("Choose this") and the expanded modal ("Send response").
+   */
+  _uiuxAnswerForOption(option, text = '') {
+    const id = (option && option.id != null) ? String(option.id) : '';
+    const label = (option && option.label != null) ? String(option.label) : '';
+    const msg = (text || '').trim();
+    if (id === 'none') {
+      return msg
+        ? { answer: `User chose none of the provided options. Message: ${msg}`, display: `None of these — ${msg}` }
+        : { answer: 'User chose none of the provided options.', display: 'None of these' };
+    }
+    return msg
+      ? { answer: `Selected option "${id}: ${label}". Message: ${msg}`, display: `${label} — ${msg}` }
+      : { answer: `Selected option "${id}: ${label}".`, display: label };
+  }
+
+  /**
    * Wrap a raw snippet in a self-contained document for the sandboxed preview iframe.
-   * Loads the SAME Tailwind (v2) stylesheet the target app itself uses, so previews look
-   * like the real page (plain — no DaisyUI component theming). Pure CSS, no scripts, so
-   * the iframe can run fully locked down (sandbox="").
+   * Loads a precompiled Tailwind v2 stylesheet, but snippets should rely on INLINE styles
+   * (style="...") for anything visual: v3-style arbitrary-value classes (bg-[#hex],
+   * text-[20px], etc.) do NOT exist in the v2 build and render as nothing. See the
+   * ask_user_uiux_question tool description for the full styling rules of thumb.
+   * Pure CSS, no scripts, so the iframe can run fully locked down (sandbox="").
    */
   _buildUiuxPreviewDoc(snippet) {
     return `<!doctype html>
@@ -766,7 +808,6 @@ export class MessageHandler {
     document.querySelector('.uiux-modal')?.remove();
 
     const labelFor = (i) => (options[i] && options[i].label != null) ? String(options[i].label) : String(i);
-    const idFor = (i) => (options[i] && options[i].id != null) ? String(options[i].id) : String(i);
 
     const tabs = options.map((opt, i) =>
       `<button class="uiux-tab${i === 0 ? ' active' : ''}" data-i="${i}">${this._escapeHtml(labelFor(i))}</button>`
@@ -795,13 +836,12 @@ export class MessageHandler {
         </div>
         <div class="uiux-modal-footer">
           <div class="uiux-modal-selectrow">
-            <button class="uiux-use-option" type="button">Use this option</button>
-            <span class="uiux-modal-selected">No option selected — optional</span>
+            <span class="uiux-modal-selected"></span>
           </div>
-          <textarea class="uiux-modal-textarea" rows="3" placeholder="Write a message or instructions for Leo…"></textarea>
+          <textarea class="uiux-modal-textarea" rows="3" placeholder="Add a message or instructions for Leo (optional)…"></textarea>
           <div class="uiux-modal-actions">
-            <span class="uiux-modal-hint">Pick an option, write a message, or both · ⌘/Ctrl+Enter to send</span>
-            <button class="uiux-modal-send" disabled>Send response</button>
+            <span class="uiux-modal-hint">Browse with ← → — the option you're viewing is selected · ⌘/Ctrl+Enter to send</span>
+            <button class="uiux-modal-send">Send response</button>
           </div>
         </div>
       </div>`;
@@ -814,28 +854,15 @@ export class MessageHandler {
       f.srcdoc = this._buildUiuxPreviewDoc(opt && opt.html ? opt.html : '');
     });
 
+    // The option currently being viewed IS the selected one — navigating the tabs/arrows
+    // auto-selects it, so the user just hits "Send response". (Includes "None of these".)
     let activeIndex = 0;
-    let selectedIndex = null; // no option selected by default — selecting is optional
     const n = options.length;
     const selectedEl = overlay.querySelector('.uiux-modal-selected');
-    const useBtn = overlay.querySelector('.uiux-use-option');
-    const sendBtn = overlay.querySelector('.uiux-modal-send');
     const textarea = overlay.querySelector('.uiux-modal-textarea');
 
     const refreshSelectionUI = () => {
-      const hasText = (textarea?.value?.trim()?.length || 0) > 0;
-      const usingActive = selectedIndex === activeIndex;
-      if (useBtn) {
-        useBtn.textContent = usingActive ? '✓ Using this option' : 'Use this option';
-        useBtn.classList.toggle('active', usingActive);
-      }
-      if (selectedEl) {
-        selectedEl.textContent = selectedIndex === null
-          ? 'No option selected — optional'
-          : `Selected: ${labelFor(selectedIndex)}`;
-      }
-      // Can send if an option is selected OR a message was typed.
-      if (sendBtn) sendBtn.disabled = (selectedIndex === null && !hasText);
+      if (selectedEl) selectedEl.textContent = `Selected: ${labelFor(activeIndex)}`;
     };
 
     const setActive = (i) => {
@@ -852,32 +879,13 @@ export class MessageHandler {
     overlay.querySelector('.uiux-nav-prev')?.addEventListener('click', () => setActive(activeIndex - 1));
     overlay.querySelector('.uiux-nav-next')?.addEventListener('click', () => setActive(activeIndex + 1));
 
-    // Explicitly select/deselect the option currently being viewed.
-    useBtn?.addEventListener('click', () => {
-      selectedIndex = (selectedIndex === activeIndex) ? null : activeIndex;
-      refreshSelectionUI();
-    });
-    textarea?.addEventListener('input', refreshSelectionUI);
-
     const close = () => {
       document.removeEventListener('keydown', onKey);
       overlay.remove();
     };
     const submit = () => {
       const text = textarea?.value?.trim() || '';
-      const hasSel = selectedIndex !== null;
-      if (!hasSel && !text) return; // nothing to send
-      let answer, display;
-      if (hasSel && text) {
-        answer = `Selected option "${idFor(selectedIndex)}: ${labelFor(selectedIndex)}". Message: ${text}`;
-        display = `${labelFor(selectedIndex)} — ${text}`;
-      } else if (hasSel) {
-        answer = `Selected option "${idFor(selectedIndex)}: ${labelFor(selectedIndex)}".`;
-        display = labelFor(selectedIndex);
-      } else {
-        answer = text;
-        display = text;
-      }
+      const { answer, display } = this._uiuxAnswerForOption(options[activeIndex], text);
       close();
       this._answerUiuxQuestion(answer, threadId, agentName, chipEl, display);
     };

--- a/app/frontend/chat/websocket/WebSocketManager.js
+++ b/app/frontend/chat/websocket/WebSocketManager.js
@@ -7,6 +7,12 @@ import { getWebSocketUrl, getRailsUrl } from '../config.js';
 import { ActionCableAdapter } from './ActionCableAdapter.js';
 import { TokenManager } from '../auth/TokenManager.js';
 
+// Control messages that must NOT be queued for replay after a reconnect:
+//  - `auth` tokens are regenerated fresh on every (re)connect, so a stale one is useless.
+//  - `cancel` only means something for the run that was live when it was issued;
+//    replaying it after reconnect could cancel a brand-new run.
+const NON_QUEUEABLE_TYPES = new Set(['auth', 'cancel']);
+
 export class WebSocketManager {
   constructor(messageHandler, config = {}, elements = {}) {
     this.messageHandler = messageHandler;
@@ -18,6 +24,11 @@ export class WebSocketManager {
     this.isAuthenticated = false;
     this.reconnectAttempts = 0;
     this.maxReconnectAttempts = config.maxReconnectAttempts ?? 5;
+    // Messages sent while the socket is down wait here and are delivered once we
+    // reconnect & re-authenticate. Bounded so a runaway producer can't grow it
+    // without limit.
+    this.outbox = [];
+    this.maxQueueSize = config.maxQueueSize ?? 25;
   }
 
   /**
@@ -98,7 +109,12 @@ export class WebSocketManager {
     // Send authentication token (for native WebSocket connections only)
     // ActionCable connections handle auth via the Rails gem
     if (!this.isActionCable) {
+      // Native sockets authenticate first; the queued outbox is flushed on
+      // `auth_success` so user messages are never sent ahead of the handshake.
       this.sendAuthMessage();
+    } else {
+      // ActionCable is authenticated by the Rails gem, so it's ready immediately.
+      this.flushOutbox();
     }
   }
 
@@ -188,6 +204,9 @@ export class WebSocketManager {
     if (data.type === 'auth_success') {
       this.isAuthenticated = true;
       console.log('WebSocket authenticated as:', data.user);
+      // Now that we're live & authenticated, deliver anything that was queued
+      // while the connection was down.
+      this.flushOutbox();
       return;
     }
 
@@ -213,15 +232,91 @@ export class WebSocketManager {
   }
 
   /**
-   * Send message via WebSocket
+   * Send a message over the socket.
+   *
+   * If the socket is open, the message goes out immediately. If it's down, a
+   * user-meaningful message is queued and delivered automatically once we
+   * reconnect (and a reconnect is nudged into motion), so a transient drop
+   * never silently loses what the user sent. Ephemeral control messages
+   * (auth/cancel) are dropped instead — replaying them after reconnect is wrong.
    */
   send(data) {
     if (this.socket && this.socket.readyState === WebSocket.OPEN) {
       this.socket.send(JSON.stringify(data));
       return true;
     }
-    console.error('WebSocket is not connected');
-    return false;
+
+    if (data && NON_QUEUEABLE_TYPES.has(data.type)) {
+      console.warn(`WebSocket not connected; dropping "${data.type}" message`);
+      return false;
+    }
+
+    this.queueMessage(data);
+    this.ensureConnecting();
+    return true; // accepted — will be delivered on reconnect
+  }
+
+  /**
+   * Buffer an outbound message to deliver after we reconnect. Deduped by
+   * reference so the same payload can't be queued twice, and bounded so the
+   * oldest message is dropped if the queue overflows.
+   */
+  queueMessage(data) {
+    if (this.outbox.includes(data)) return;
+
+    this.outbox.push(data);
+    if (this.outbox.length > this.maxQueueSize) {
+      this.outbox.shift();
+      console.warn('Outbound WebSocket queue full; dropped oldest message');
+    } else {
+      console.warn(`WebSocket not connected; queued message (${this.outbox.length} pending)`);
+    }
+  }
+
+  /**
+   * True if this exact payload (by reference) is already waiting in the outbox.
+   * Lets the higher-level resume logic avoid double-sending a message the
+   * outbox already owns.
+   */
+  hasQueued(data) {
+    return this.outbox.includes(data);
+  }
+
+  /** Drop every queued message — used when we've given up reconnecting. */
+  clearQueue() {
+    this.outbox = [];
+  }
+
+  /**
+   * Nudge a reconnect when a send lands on a dead socket. An active user action
+   * is a strong signal to keep trying, so we refresh the retry budget even if
+   * earlier automatic attempts had been exhausted. ActionCable self-heals via
+   * the Rails gem, so we leave its reconnection alone.
+   */
+  ensureConnecting() {
+    if (this.isActionCable) return;
+
+    const state = this.socket ? this.socket.readyState : WebSocket.CLOSED;
+    if (state === WebSocket.OPEN || state === WebSocket.CONNECTING || this.reconnectTimer) {
+      return;
+    }
+
+    this.reconnectAttempts = 0; // user is actively trying — give a full budget
+    this.scheduleReconnect();
+  }
+
+  /**
+   * Deliver any queued messages once the connection is live and authenticated.
+   * Re-uses send(), so if the socket dies again mid-flush the remaining
+   * messages simply re-queue for the next reconnect.
+   */
+  flushOutbox() {
+    if (!this.outbox.length) return;
+
+    const pending = this.outbox;
+    this.outbox = [];
+    console.log(`Flushing ${pending.length} queued WebSocket message(s) after reconnect`);
+    pending.forEach((data) => this.send(data));
   }
 
   /**
@@ -296,6 +391,8 @@ export class WebSocketManager {
    * Disconnect WebSocket
    */
   disconnect() {
+    this.clearQueue();
+
     if (this.reconnectTimer) {
       clearTimeout(this.reconnectTimer);
       this.reconnectTimer = null;

--- a/app/frontend/style.css
+++ b/app/frontend/style.css
@@ -2533,27 +2533,6 @@ body {
     margin-bottom: 8px;
 }
 
-.uiux-use-option {
-    flex-shrink: 0;
-    background: transparent;
-    border: 1px solid rgba(139, 92, 246, 0.4);
-    color: #c4b5fd;
-    border-radius: 8px;
-    padding: 6px 14px;
-    font-size: 13px;
-    font-weight: 500;
-    cursor: pointer;
-    transition: all 0.15s ease;
-}
-
-.uiux-use-option:hover { background: rgba(139, 92, 246, 0.15); }
-
-.uiux-use-option.active {
-    background: rgba(139, 92, 246, 0.3);
-    border-color: #8b5cf6;
-    color: #fff;
-}
-
 .uiux-modal-selected {
     font-size: 13px;
     color: #94a3b8;
@@ -2819,6 +2798,12 @@ body {
 
 .tab-text {
     flex: 1;
+    white-space: nowrap; /* never wrap — wrapping changes the tab box height */
+}
+
+/* Short label only shows on narrow widths (see media query below) */
+.tab-text-short {
+    display: none;
 }
 
 .tab-external-link {
@@ -3096,7 +3081,7 @@ body {
     padding: 20px;
 }
 
-.browser-content.mobile-view #liveSiteFrame {
+.browser-content.mobile-view .content-iframe.active {
     width: 375px;
     height: 667px;
     border-radius: 20px;
@@ -4013,6 +3998,15 @@ body {
         flex-shrink: 0;
         font-size: 0.9rem;
         padding: 6px 12px;
+    }
+
+    /* Shorten multi-word tab labels so they don't wrap/overflow when narrow */
+    .tab-text-full {
+        display: none;
+    }
+
+    .tab-text-short {
+        display: inline;
     }
 
     /* Keep browser addressbar visible on mobile to show refresh button */

--- a/app/services/checkpoint_cleanup.py
+++ b/app/services/checkpoint_cleanup.py
@@ -133,6 +133,19 @@ async def cleanup_stale_thread_checkpoints(pool, stale_minutes: int = 30):
         stale_minutes: accepted for signature/backwards compatibility. Orphan
             collection is always safe, so it no longer gates deletion.
     """
+    # SCHEMA NOTE (LangGraph PostgresSaver):
+    #   checkpoint_blobs  PK (thread_id, checkpoint_ns, channel, version)  — NO checkpoint_id column
+    #   checkpoint_writes PK (thread_id, checkpoint_ns, checkpoint_id, task_id, idx)
+    #   checkpoints       PK (thread_id, checkpoint_ns, checkpoint_id)
+    #
+    # The previous query joined blobs on a per-checkpoint id column, which does
+    # not exist on checkpoint_blobs, so the whole sweep crashed with a
+    # missing-column error (SupportIncident #106). Blobs are versioned per channel, not per checkpoint,
+    # so the only orphan check that is both valid AND DeltaChannel-safe is at
+    # thread/ns granularity: a blob is debris only when its entire thread has no
+    # surviving checkpoint at all (a thread that was fully deleted or never
+    # committed). That can never delete a blob belonging to a live delta chain.
+    # Writes keep the precise per-checkpoint orphan check (they DO have checkpoint_id).
     async with pool.connection() as conn:
         # Count orphaned rows before cleanup (for logging)
         result = await conn.execute("""
@@ -140,7 +153,7 @@ async def cleanup_stale_thread_checkpoints(pool, stale_minutes: int = 30):
                 (SELECT COUNT(*) FROM checkpoint_blobs b
                  WHERE NOT EXISTS (
                      SELECT 1 FROM checkpoints c
-                     WHERE c.thread_id = b.thread_id AND c.checkpoint_id = b.checkpoint_id
+                     WHERE c.thread_id = b.thread_id AND c.checkpoint_ns = b.checkpoint_ns
                  )) AS orphan_blobs,
                 (SELECT COUNT(*) FROM checkpoint_writes w
                  WHERE NOT EXISTS (
@@ -150,16 +163,16 @@ async def cleanup_stale_thread_checkpoints(pool, stale_minutes: int = 30):
         """)
         orphan_blobs, orphan_writes = await result.fetchone()
 
-        # Delete orphaned blobs (the BIG storage consumers)
+        # Delete orphaned blobs: only blobs whose entire thread/ns has no checkpoint.
         await conn.execute("""
             DELETE FROM checkpoint_blobs b
             WHERE NOT EXISTS (
                 SELECT 1 FROM checkpoints c
-                WHERE c.thread_id = b.thread_id AND c.checkpoint_id = b.checkpoint_id
+                WHERE c.thread_id = b.thread_id AND c.checkpoint_ns = b.checkpoint_ns
             )
         """)
 
-        # Delete orphaned writes
+        # Delete orphaned writes: writes whose specific checkpoint no longer exists.
         await conn.execute("""
             DELETE FROM checkpoint_writes w
             WHERE NOT EXISTS (

--- a/app/tests/test_checkpoint_cleanup_sql.py
+++ b/app/tests/test_checkpoint_cleanup_sql.py
@@ -1,0 +1,64 @@
+"""Schema-level regression for the periodic checkpoint cleanup SQL.
+
+Guards SupportIncident #106's secondary bug: the orphan sweep referenced
+`b.checkpoint_id`, a column that does not exist on `checkpoint_blobs`
+(PK: thread_id, checkpoint_ns, channel, version), so every periodic run crashed
+with `column b.checkpoint_id does not exist`.
+
+A FakeConn unit test can't catch a column-existence error, so this executes the
+real sweep against the live PostgresSaver schema. Skips cleanly if no checkpoint
+DB is reachable (e.g. CI without Postgres).
+"""
+import os
+import inspect
+
+import pytest
+
+from app.services import checkpoint_cleanup
+from app.services.checkpoint_cleanup import cleanup_stale_thread_checkpoints
+
+
+def test_blob_orphan_query_does_not_reference_nonexistent_column():
+    """Static guard: the sweep must never join blobs on the missing checkpoint_id."""
+    src = inspect.getsource(cleanup_stale_thread_checkpoints)
+    assert "b.checkpoint_id" not in src, (
+        "checkpoint_blobs has no checkpoint_id column; the orphan-blob query must "
+        "key on (thread_id, checkpoint_ns)"
+    )
+
+
+def _checkpoint_db_uri():
+    return (
+        os.getenv("CHECKPOINTER_DB_URI")
+        or os.getenv("LEONARDO_DB_URI")
+        or os.getenv("AUTH_DB_URI")
+        or os.getenv("DB_URI")
+    )
+
+
+@pytest.mark.asyncio
+async def test_cleanup_runs_against_real_schema_without_error():
+    uri = _checkpoint_db_uri()
+    if not uri:
+        pytest.skip("no checkpoint DB URI in env")
+
+    from psycopg_pool import AsyncConnectionPool
+
+    pool = AsyncConnectionPool(uri, open=False)
+    await pool.open()
+    try:
+        # Confirm this DB actually has the PostgresSaver tables; otherwise skip
+        # (this URI might point at a non-checkpoint database).
+        async with pool.connection() as conn:
+            res = await conn.execute(
+                "SELECT to_regclass('public.checkpoint_blobs'), "
+                "to_regclass('public.checkpoints')"
+            )
+            blobs_tbl, ckpt_tbl = await res.fetchone()
+        if blobs_tbl is None or ckpt_tbl is None:
+            pytest.skip("checkpoint tables not present in this DB")
+
+        # The actual assertion: this used to raise ProgrammingError on b.checkpoint_id.
+        await cleanup_stale_thread_checkpoints(pool, stale_minutes=30)
+    finally:
+        await pool.close()

--- a/app/tests/test_checkpoint_cleanup_sql.py
+++ b/app/tests/test_checkpoint_cleanup_sql.py
@@ -44,17 +44,29 @@ async def test_cleanup_runs_against_real_schema_without_error():
 
     from psycopg_pool import AsyncConnectionPool
 
-    pool = AsyncConnectionPool(uri, open=False)
-    await pool.open()
+    # Short connect timeout: a URI may be set in env (e.g. CI's DB_URI) yet point
+    # at a host that isn't reachable from the test container. We want a clean,
+    # fast skip in that case — not a 30s hang followed by a PoolTimeout failure.
+    pool = AsyncConnectionPool(
+        uri, open=False, min_size=0, max_size=1, timeout=5,
+        kwargs={"connect_timeout": 5},
+    )
     try:
-        # Confirm this DB actually has the PostgresSaver tables; otherwise skip
-        # (this URI might point at a non-checkpoint database).
-        async with pool.connection() as conn:
-            res = await conn.execute(
-                "SELECT to_regclass('public.checkpoint_blobs'), "
-                "to_regclass('public.checkpoints')"
-            )
-            blobs_tbl, ckpt_tbl = await res.fetchone()
+        # Confirm we can reach the DB and that it actually has the PostgresSaver
+        # tables; skip cleanly otherwise (unreachable host, or a URI that points
+        # at a non-checkpoint database). The cleanup call below is deliberately
+        # left OUTSIDE this guard so a real regression still fails loudly.
+        try:
+            await pool.open(wait=True, timeout=5)
+            async with pool.connection() as conn:
+                res = await conn.execute(
+                    "SELECT to_regclass('public.checkpoint_blobs'), "
+                    "to_regclass('public.checkpoints')"
+                )
+                blobs_tbl, ckpt_tbl = await res.fetchone()
+        except Exception as exc:  # connection/pool failure → nothing to guard here
+            pytest.skip(f"checkpoint DB not reachable: {exc}")
+
         if blobs_tbl is None or ckpt_tbl is None:
             pytest.skip("checkpoint tables not present in this DB")
 

--- a/app/tests/test_delta_reducer_remove_all.py
+++ b/app/tests/test_delta_reducer_remove_all.py
@@ -1,0 +1,129 @@
+"""Regression tests for the DeltaChannel messages reducer honoring REMOVE_ALL.
+
+Reproduces and guards the SummarizationMiddleware loop seen in production on
+`mbc-preceptors` thread c77fce95 (SupportIncident #106): the stock
+`_messages_delta_reducer` silently drops `RemoveMessage(REMOVE_ALL_MESSAGES)`,
+so a summarize write `[RemoveMessage(ALL), summary, *preserved]` leaves the full
+prior history in place. The post-summary token count never drops below
+SUMMARIZATION_TOKEN_THRESHOLD, so summarization re-fires every turn.
+
+These assert *structure* (reducer in/out), no LLM and no DB needed.
+"""
+from langchain_core.messages import HumanMessage, AIMessage, RemoveMessage
+from langgraph.graph.message import _messages_delta_reducer, REMOVE_ALL_MESSAGES
+
+from app.agents.utils.delta_state import messages_delta_reducer
+
+
+def _base():
+    return [
+        HumanMessage(content="original user intent", id="h1"),
+        AIMessage(content="assistant turn 1", id="a1"),
+        HumanMessage(content="second user turn", id="h2"),
+        AIMessage(content="assistant turn 2", id="a2"),
+    ]
+
+
+def _summary_write(preserved):
+    summary = HumanMessage(content="Here is a summary of the conversation", id="sum1")
+    return [RemoveMessage(id=REMOVE_ALL_MESSAGES), summary, *preserved]
+
+
+# --- the bug: stock reducer leaves history in place ---------------------------
+
+def test_stock_reducer_drops_remove_all_marker():
+    """Documents the upstream defect this module works around."""
+    state = _base()
+    result = _messages_delta_reducer(state, [_summary_write([state[3]])])
+    # The summary is appended on top of all 4 originals instead of replacing them.
+    assert len(result) == 5
+    assert [m.id for m in result] == ["h1", "a1", "h2", "a2", "sum1"]
+
+
+# --- the fix: our reducer clears history on REMOVE_ALL ------------------------
+
+def test_remove_all_clears_prior_history():
+    state = _base()
+    result = messages_delta_reducer(state, [_summary_write([state[3]])])
+    assert [m.id for m in result] == ["sum1", "a2"], (
+        "after a summary write the reconstructed state must contain only the "
+        "summary + preserved tail, not the pre-summary history"
+    )
+
+
+def test_post_summary_state_is_smaller_so_loop_cannot_recur():
+    """The whole point: the post-summary list must shrink."""
+    state = _base()
+    result = messages_delta_reducer(state, [_summary_write([state[3]])])
+    assert len(result) < len(state)
+
+
+# --- normal (non REMOVE_ALL) behavior is unchanged ---------------------------
+
+def test_passthrough_matches_upstream_without_remove_all():
+    state = _base()
+    write = [[AIMessage(content="new", id="n1")]]
+    assert (
+        [m.id for m in messages_delta_reducer(state, write)]
+        == [m.id for m in _messages_delta_reducer(state, write)]
+    )
+
+
+def test_single_id_remove_still_tombstones():
+    state = _base()
+    result = messages_delta_reducer(state, [[RemoveMessage(id="h2")]])
+    ids = [m.id for m in result]
+    assert "h2" not in ids and ids == ["h1", "a1", "a2"]
+
+
+def test_dedup_by_id_preserved_after_remove_all():
+    # preserved tail keeps its original id; no duplicate should appear.
+    state = _base()
+    result = messages_delta_reducer(state, [_summary_write([state[2], state[3]])])
+    ids = [m.id for m in result]
+    assert ids == ["sum1", "h2", "a2"]
+    assert len(ids) == len(set(ids))
+
+
+# --- batching invariance: DeltaChannel replays deltas from snapshots ---------
+# reducer(reducer(s, xs), ys) MUST equal reducer(s, xs + ys) or snapshot replay
+# diverges from live state.
+
+def _ids(msgs):
+    return [m.id for m in msgs]
+
+
+def test_batching_invariance_remove_all_in_second_batch():
+    xs = [HumanMessage(content="x", id="x1")]
+    ys = [RemoveMessage(id=REMOVE_ALL_MESSAGES), HumanMessage(content="y", id="y1")]
+    combined = messages_delta_reducer(_base(), [xs + ys])
+    stepwise = messages_delta_reducer(messages_delta_reducer(_base(), [xs]), [ys])
+    assert _ids(combined) == _ids(stepwise) == ["y1"]
+
+
+def test_batching_invariance_remove_all_in_first_batch():
+    xs = [RemoveMessage(id=REMOVE_ALL_MESSAGES), HumanMessage(content="x", id="x1")]
+    ys = [AIMessage(content="y", id="y1")]
+    combined = messages_delta_reducer(_base(), [xs + ys])
+    stepwise = messages_delta_reducer(messages_delta_reducer(_base(), [xs]), [ys])
+    assert _ids(combined) == _ids(stepwise) == ["x1", "y1"]
+
+
+def test_batching_invariance_no_remove_all():
+    xs = [AIMessage(content="x", id="x1")]
+    ys = [AIMessage(content="y", id="y1")]
+    combined = messages_delta_reducer(_base(), [xs + ys])
+    stepwise = messages_delta_reducer(messages_delta_reducer(_base(), [xs]), [ys])
+    assert _ids(combined) == _ids(stepwise)
+
+
+def test_last_remove_all_wins_when_multiple():
+    state = _base()
+    write = [
+        RemoveMessage(id=REMOVE_ALL_MESSAGES),
+        HumanMessage(content="discarded", id="d1"),
+        RemoveMessage(id=REMOVE_ALL_MESSAGES),
+        HumanMessage(content="kept", id="k1"),
+    ]
+    result = messages_delta_reducer(state, [write])
+    assert _ids(result) == ["k1"]

--- a/app/tests/test_rails_summarization_middleware.py
+++ b/app/tests/test_rails_summarization_middleware.py
@@ -1,0 +1,186 @@
+"""Tests for RailsSummarizationMiddleware + make_summarization_middleware.
+
+Covers the user-facing retention contract: after a summarization the rebuilt
+message list must contain (a) the first K user messages verbatim, (b) the
+summary with the live todo list re-injected, and (c) the recent tail — and
+nothing else. Also proves it composes with the DeltaChannel REMOVE_ALL reducer so
+the reconstructed state actually shrinks (no loop).
+
+No real LLM: a fake chat model returns a fixed summary string.
+"""
+import pytest
+from langchain_core.language_models.chat_models import BaseChatModel
+from langchain_core.messages import (
+    AIMessage,
+    HumanMessage,
+    ToolMessage,
+    RemoveMessage,
+)
+from langchain_core.outputs import ChatGeneration, ChatResult
+from langgraph.graph.message import REMOVE_ALL_MESSAGES
+
+from app.agents.leonardo.summarization import (
+    RailsSummarizationMiddleware,
+    make_summarization_middleware,
+)
+from app.agents.utils.delta_state import messages_delta_reducer
+from app.agents.utils.token_counter import (
+    SUMMARIZATION_KEEP_TOKENS,
+    SUMMARIZATION_TOKEN_THRESHOLD,
+)
+
+
+class _FakeSummaryModel(BaseChatModel):
+    """Returns a fixed summary; counts every message as 1000 'tokens' via len."""
+
+    @property
+    def _llm_type(self):
+        return "fake-summary"
+
+    def _generate(self, messages, stop=None, run_manager=None, **kwargs):
+        return ChatResult(
+            generations=[ChatGeneration(message=AIMessage(content="FIXED SUMMARY TEXT"))]
+        )
+
+
+def _word_counter(messages):
+    """Cheap deterministic counter: 1000 'tokens' per message."""
+    return 1000 * len(list(messages))
+
+
+def _mw(keep_initial_human=3):
+    return RailsSummarizationMiddleware(
+        model=_FakeSummaryModel(),
+        trigger=("tokens", 5000),       # 5 messages
+        keep=("tokens", 2000),          # ~2 messages tail
+        token_counter=_word_counter,
+        trim_tokens_to_summarize=None,
+        summary_prompt="Summarize:\n{messages}",
+        keep_initial_human=keep_initial_human,
+    )
+
+
+def _long_convo():
+    """A realistic-ish thread with an early write_todos call."""
+    return [
+        HumanMessage(content="Build me a blog with posts and comments", id="h1"),
+        AIMessage(
+            content="",
+            id="a1",
+            tool_calls=[{
+                "name": "write_todos",
+                "id": "tc1",
+                "args": {"todos": [
+                    {"content": "scaffold Post model", "status": "completed"},
+                    {"content": "add Comment model", "status": "in_progress"},
+                    {"content": "wire routes", "status": "pending"},
+                ]},
+            }],
+        ),
+        ToolMessage(content="Updated todo list", tool_call_id="tc1", id="t1"),
+        HumanMessage(content="also add tags", id="h2"),
+        AIMessage(content="working on tags", id="a2"),
+        HumanMessage(content="how's it going?", id="h3"),
+        AIMessage(content="almost done", id="a3"),
+    ]
+
+
+class TestAugmentStructure:
+    def test_preserves_first_user_message_verbatim(self):
+        mw = _mw(keep_initial_human=1)
+        result = mw.before_model({"messages": _long_convo()}, runtime=None)
+        msgs = result["messages"]
+        assert isinstance(msgs[0], RemoveMessage) and msgs[0].id == REMOVE_ALL_MESSAGES
+        # first real human message, verbatim, right after the remove marker
+        assert isinstance(msgs[1], HumanMessage)
+        assert msgs[1].content == "Build me a blog with posts and comments"
+        assert msgs[1].id == "h1"
+
+    def test_summary_present_with_todo_restore_block(self):
+        mw = _mw()
+        result = mw.before_model({"messages": _long_convo()}, runtime=None)
+        summary = next(
+            m for m in result["messages"]
+            if isinstance(m, HumanMessage)
+            and (m.additional_kwargs or {}).get("lc_source") == "summarization"
+        )
+        assert "FIXED SUMMARY TEXT" in summary.content
+        assert "ACTIVE TODO LIST" in summary.content
+        assert "write_todos" in summary.content
+        # the actual todo content must be embedded so the model can restore it
+        assert "scaffold Post model" in summary.content
+        assert "add Comment model" in summary.content
+
+    def test_no_pre_summary_history_leaks(self):
+        mw = _mw(keep_initial_human=1)
+        result = mw.before_model({"messages": _long_convo()}, runtime=None)
+        # The mid-conversation messages that were summarized (h2/a2/t1) must not
+        # reappear verbatim outside the preserved tail.
+        ids = [getattr(m, "id", None) for m in result["messages"]]
+        assert "t1" not in ids  # the tool message in the middle was summarized away
+
+    def test_reconstruction_through_delta_reducer_shrinks(self):
+        """End-to-end: feed the summarize write through the real reducer."""
+        convo = _long_convo()
+        mw = _mw(keep_initial_human=1)
+        result = mw.before_model({"messages": convo}, runtime=None)
+        reconstructed = messages_delta_reducer(convo, [result["messages"]])
+        assert len(reconstructed) < len(convo), "post-summary state must shrink"
+        # first user message + summary survive
+        assert any(m.id == "h1" for m in reconstructed)
+        assert any(
+            isinstance(m, HumanMessage)
+            and (m.additional_kwargs or {}).get("lc_source") == "summarization"
+            for m in reconstructed
+        )
+
+    def test_no_summarization_below_trigger_returns_none(self):
+        mw = _mw()
+        short = [HumanMessage(content="hi", id="h1"), AIMessage(content="hello", id="a1")]
+        assert mw.before_model({"messages": short}, runtime=None) is None
+
+    def test_handles_thread_with_no_todos(self):
+        mw = _mw(keep_initial_human=1)
+        convo = [
+            HumanMessage(content="first", id="h1"),
+            AIMessage(content="a", id="a1"),
+            HumanMessage(content="second", id="h2"),
+            AIMessage(content="b", id="a2"),
+            HumanMessage(content="third", id="h3"),
+            AIMessage(content="c", id="a3"),
+        ]
+        result = mw.before_model({"messages": convo}, runtime=None)
+        summary = next(
+            m for m in result["messages"]
+            if isinstance(m, HumanMessage)
+            and (m.additional_kwargs or {}).get("lc_source") == "summarization"
+        )
+        assert "ACTIVE TODO LIST" not in summary.content
+
+
+class TestExtractTodos:
+    def test_extracts_most_recent(self):
+        msgs = [
+            AIMessage(content="", id="a1", tool_calls=[{
+                "name": "write_todos", "id": "x1",
+                "args": {"todos": [{"content": "old", "status": "pending"}]}}]),
+            AIMessage(content="", id="a2", tool_calls=[{
+                "name": "write_todos", "id": "x2",
+                "args": {"todos": [{"content": "new", "status": "pending"}]}}]),
+        ]
+        todos = RailsSummarizationMiddleware._extract_last_todos(msgs)
+        assert todos == [{"content": "new", "status": "pending"}]
+
+    def test_none_when_absent(self):
+        msgs = [HumanMessage(content="hi", id="h1"), AIMessage(content="yo", id="a1")]
+        assert RailsSummarizationMiddleware._extract_last_todos(msgs) is None
+
+
+class TestFactory:
+    def test_factory_builds_token_keyed_keep(self, monkeypatch):
+        monkeypatch.setenv("DEEPSEEK_API_KEY", "k")
+        mw = make_summarization_middleware(summary_prompt="Summarize {messages}")
+        assert isinstance(mw, RailsSummarizationMiddleware)
+        assert mw.trigger == ("tokens", SUMMARIZATION_TOKEN_THRESHOLD)
+        assert mw.keep == ("tokens", SUMMARIZATION_KEEP_TOKENS)
+        assert mw.keep_initial_human == 3

--- a/app/tests/test_repair_delta_snapshot.py
+++ b/app/tests/test_repair_delta_snapshot.py
@@ -1,0 +1,101 @@
+"""Repair path must normalize DeltaChannel `_DeltaSnapshot` message values.
+
+SupportIncident #106: on a DeltaChannel thread, `aget_state().values["messages"]`
+can surface as a `_DeltaSnapshot` whose list lives at `.value`. The repair scan
+iterated that object directly, silently seeing no messages and skipping a needed
+dangling-tool_call repair. These assert the normalization + that repair still
+fires for a dangling tool call hidden inside a snapshot.
+"""
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+
+from app.websocket.request_handler import RequestHandler
+
+
+class _Snapshot:
+    """Stand-in for langgraph's _DeltaSnapshot: real list lives at `.value`."""
+    def __init__(self, value):
+        self.value = value
+
+
+class TestNormalizeMessages:
+    def test_unwraps_delta_snapshot(self):
+        msgs = [HumanMessage(content="hi", id="h1")]
+        assert RequestHandler._normalize_messages(_Snapshot(msgs)) == msgs
+
+    def test_passthrough_plain_list(self):
+        msgs = [HumanMessage(content="hi", id="h1")]
+        assert RequestHandler._normalize_messages(msgs) == msgs
+
+    def test_none_and_empty(self):
+        assert RequestHandler._normalize_messages(None) == []
+        assert RequestHandler._normalize_messages([]) == []
+
+    def test_real_delta_snapshot_type_if_available(self):
+        try:
+            from langgraph.checkpoint.serde.types import _DeltaSnapshot
+        except Exception:
+            pytest.skip("_DeltaSnapshot not importable in this langgraph build")
+        msgs = [HumanMessage(content="hi", id="h1")]
+        snap = _DeltaSnapshot(value=msgs) if _has_kw(_DeltaSnapshot) else _DeltaSnapshot(msgs)
+        assert RequestHandler._normalize_messages(snap) == msgs
+
+
+def _has_kw(cls):
+    import inspect
+    try:
+        return "value" in inspect.signature(cls).parameters
+    except (ValueError, TypeError):
+        return False
+
+
+# --- repair fires through a snapshot-wrapped messages value ------------------
+
+class _FakeStateSnapshot:
+    def __init__(self, messages):
+        self.values = {"messages": messages}
+
+
+class _FakeApp:
+    def __init__(self, snapshot):
+        self._snapshot = snapshot
+        self.updated_with = None
+
+    async def aget_state(self, config):
+        return self._snapshot
+
+    async def aupdate_state(self, config, update):
+        self.updated_with = update
+
+
+@pytest.mark.asyncio
+async def test_repair_fires_for_dangling_toolcall_inside_snapshot():
+    # AIMessage with a tool_call that has no following ToolMessage.
+    dangling = AIMessage(
+        content="",
+        id="a1",
+        tool_calls=[{"name": "bash_command", "id": "call_1", "args": {}}],
+    )
+    messages = [HumanMessage(content="do it", id="h1"), dangling]
+    app = _FakeApp(_FakeStateSnapshot(_Snapshot(messages)))
+
+    handler = RequestHandler.__new__(RequestHandler)  # skip __init__ (needs FastAPI)
+    await handler._repair_thread_state_if_needed(app, {"configurable": {"thread_id": "t"}})
+
+    assert app.updated_with is not None, "repair should have run through the snapshot"
+    injected = app.updated_with["messages"]
+    assert any(
+        isinstance(m, ToolMessage) and m.tool_call_id == "call_1" for m in injected
+    ), "a synthetic ToolMessage must be injected for the dangling tool_call"
+
+
+@pytest.mark.asyncio
+async def test_no_repair_for_clean_snapshot():
+    messages = [
+        HumanMessage(content="hi", id="h1"),
+        AIMessage(content="hello", id="a1"),
+    ]
+    app = _FakeApp(_FakeStateSnapshot(_Snapshot(messages)))
+    handler = RequestHandler.__new__(RequestHandler)
+    await handler._repair_thread_state_if_needed(app, {"configurable": {"thread_id": "t"}})
+    assert app.updated_with is None

--- a/app/tests/test_summarization_fallback.py
+++ b/app/tests/test_summarization_fallback.py
@@ -1,71 +1,88 @@
-"""Tests for make_summarization_model() — DeepSeek fallback when no Gemini key.
+"""Tests for make_summarization_model() — provider fallback chain.
 
-Regression guard for the fleet-wide graph-compile failure that occurred when
-GOOGLE_API_KEY / GEMINI_API_KEY were absent (SupportIncident #93).
+Priority: DeepSeek -> Gemini 3 Flash -> OpenAI -> Anthropic (first key present
+wins). Also a fleet-wide graph-compile guard: compilation must never raise just
+because a key is missing (SupportIncident #93).
 """
 import pytest
 
 from app.agents.leonardo.llm_factory import ChatDeepSeekWithReasoning, make_summarization_model
 from langchain_google_genai import ChatGoogleGenerativeAI
+from langchain_openai import ChatOpenAI
+from langchain_anthropic import ChatAnthropic
 
 
 @pytest.fixture(autouse=True)
-def _clear_google_keys(monkeypatch):
-    """Strip Google key env vars by default; individual tests opt back in.
-    Always set a dummy DEEPSEEK_API_KEY so ChatDeepSeekWithReasoning can
-    instantiate in CI (where no real key is present). In production the real
-    key is always configured — this mirrors that assumption in tests."""
-    monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
-    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
-    monkeypatch.setenv("DEEPSEEK_API_KEY", "sk-ci-placeholder")
+def _clear_all_provider_keys(monkeypatch):
+    """Strip every provider key by default; each test opts the ones it needs
+    back in. This lets us assert the exact priority order of the fallback chain."""
+    for var in ("DEEPSEEK_API_KEY", "GOOGLE_API_KEY", "GEMINI_API_KEY",
+                "OPENAI_API_KEY", "ANTHROPIC_API_KEY"):
+        monkeypatch.delenv(var, raising=False)
 
 
-class TestMakeSummarizationModelNoKey:
-    def test_returns_deepseek_model_when_no_google_key(self):
-        model, token_counter, trim = make_summarization_model()
+class TestFallbackPriority:
+    def test_deepseek_wins_when_all_keys_present(self, monkeypatch):
+        for var in ("DEEPSEEK_API_KEY", "GOOGLE_API_KEY", "OPENAI_API_KEY", "ANTHROPIC_API_KEY"):
+            monkeypatch.setenv(var, "k")
+        model, _, _ = make_summarization_model()
         assert isinstance(model, ChatDeepSeekWithReasoning)
 
-    def test_no_raise_when_no_google_key(self):
-        # Must not raise — this is the fleet-wide compile-time guard
-        make_summarization_model()
+    def test_gemini_when_no_deepseek(self, monkeypatch):
+        monkeypatch.setenv("GOOGLE_API_KEY", "k")
+        monkeypatch.setenv("OPENAI_API_KEY", "k")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "k")
+        model, _, _ = make_summarization_model()
+        assert isinstance(model, ChatGoogleGenerativeAI)
 
-    def test_token_counter_is_callable(self):
-        _, token_counter, _ = make_summarization_model()
+    def test_gemini_api_key_alias(self, monkeypatch):
+        monkeypatch.setenv("GEMINI_API_KEY", "k")
+        model, _, _ = make_summarization_model()
+        assert isinstance(model, ChatGoogleGenerativeAI)
+
+    def test_openai_when_no_deepseek_or_gemini(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "k")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "k")
+        model, _, _ = make_summarization_model()
+        assert isinstance(model, ChatOpenAI)
+
+    def test_anthropic_when_only_anthropic(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "k")
+        model, _, _ = make_summarization_model()
+        assert isinstance(model, ChatAnthropic)
+
+
+class TestCompileGuard:
+    def test_no_raise_when_no_key_at_all(self):
+        # Fleet-wide compile-time guard: must return a model, never raise.
+        model, token_counter, trim = make_summarization_model()
+        assert isinstance(model, ChatDeepSeekWithReasoning)
         assert callable(token_counter)
 
-    def test_token_counter_does_not_call_gemini_api(self, monkeypatch):
-        """tiktoken-only path must work without any Google API call."""
-        from app.agents.utils import token_counter as tc_module
-        called = []
-        monkeypatch.setattr(tc_module, "_get_genai_client", lambda: called.append(1) or (_ for _ in ()).throw(AssertionError("Gemini API called on DeepSeek path")))
-        from langchain_core.messages import HumanMessage
-        _, token_counter, _ = make_summarization_model()
-        count = token_counter([HumanMessage(content="hello world")])
-        assert count > 0
-        assert called == [], "tiktoken_token_counter must not call Gemini API"
-
-    def test_trim_tokens_is_set_for_deepseek(self):
+    def test_deepseek_path_trim_is_set(self, monkeypatch):
+        monkeypatch.setenv("DEEPSEEK_API_KEY", "k")
         _, _, trim = make_summarization_model()
-        assert trim is not None
-        assert isinstance(trim, int)
-        assert trim > 0
+        assert isinstance(trim, int) and trim > 0
 
-
-class TestMakeSummarizationModelWithGeminiKey:
-    def test_returns_gemini_model_when_google_api_key_set(self, monkeypatch):
-        monkeypatch.setenv("GOOGLE_API_KEY", "fake-key-for-test")
-        model, token_counter, trim = make_summarization_model()
-        assert isinstance(model, ChatGoogleGenerativeAI)
-
-    def test_returns_gemini_model_when_gemini_api_key_set(self, monkeypatch):
-        monkeypatch.setenv("GEMINI_API_KEY", "fake-key-for-test")
-        model, token_counter, trim = make_summarization_model()
-        assert isinstance(model, ChatGoogleGenerativeAI)
-
-    def test_trim_is_none_for_gemini_path(self, monkeypatch):
-        monkeypatch.setenv("GOOGLE_API_KEY", "fake-key-for-test")
+    def test_gemini_path_trim_is_none(self, monkeypatch):
+        monkeypatch.setenv("GOOGLE_API_KEY", "k")
         _, _, trim = make_summarization_model()
         assert trim is None
+
+    def test_token_counter_does_not_call_gemini_api_on_deepseek_path(self, monkeypatch):
+        """tiktoken-only path must work without any Google API call."""
+        monkeypatch.setenv("DEEPSEEK_API_KEY", "k")
+        from app.agents.utils import token_counter as tc_module
+        called = []
+        monkeypatch.setattr(
+            tc_module, "_get_genai_client",
+            lambda: called.append(1) or (_ for _ in ()).throw(
+                AssertionError("Gemini API called on DeepSeek path")),
+        )
+        from langchain_core.messages import HumanMessage
+        _, token_counter, _ = make_summarization_model()
+        assert token_counter([HumanMessage(content="hello world")]) > 0
+        assert called == []
 
 
 class TestAgentGraphCompileNoGeminiKey:

--- a/app/websocket/request_handler.py
+++ b/app/websocket/request_handler.py
@@ -113,6 +113,26 @@ class RequestHandler:
                     return value
         return None
 
+    @staticmethod
+    def _normalize_messages(raw):
+        """Return a plain message list from a possibly DeltaChannel-wrapped value.
+
+        DeltaChannel-backed `messages` can surface as a `_DeltaSnapshot` whose
+        actual list lives at `.value` (seen on production thread c77fce95,
+        SupportIncident #106) instead of a resolved list. Scanning that object
+        directly would silently see zero messages and skip a needed repair, or
+        crash. Unwrap `.value` when present; otherwise pass the list through.
+        """
+        if raw is None:
+            return []
+        # `_DeltaSnapshot` is a NamedTuple (a `tuple` subclass) whose real message
+        # list lives at `.value`, so this check MUST come before the list/tuple
+        # coercion below — `isinstance(snapshot, tuple)` is True and would
+        # otherwise wrap the whole snapshot into a one-element list.
+        if not isinstance(raw, list) and hasattr(raw, "value"):
+            return list(raw.value) if raw.value is not None else []
+        return list(raw) if isinstance(raw, (list, tuple)) else raw
+
     async def _repair_thread_state_if_needed(self, app, config):
         """
         Detect and repair two shapes of corrupted thread state that violate
@@ -139,7 +159,7 @@ class RequestHandler:
             if not state_snapshot or not state_snapshot.values:
                 return
 
-            messages = state_snapshot.values.get("messages", [])
+            messages = self._normalize_messages(state_snapshot.values.get("messages", []))
             if not messages:
                 return
 

--- a/docs/dev_logs/0.5.2
+++ b/docs/dev_logs/0.5.2
@@ -1,3 +1,27 @@
 0.5.2:
 - [x] Improve UI/UX for engineer mode with animation and condensed tool messages similar to beginner mode
 - [x] improve thinking verb experience when asking and answering questions
+
+0.5.2a:
+- [x] Add the active todo list on the "Your App is Building" animation screen.
+- [x] Fix summarization/compaction bug, swap order of summarization LLM to go DeepSeek -> Gemini -> OpenAI -> Anthropic
+      Root cause: DeltaChannel's _messages_delta_reducer silently dropped
+      RemoveMessage(REMOVE_ALL_MESSAGES), so SummarizationMiddleware never cleared
+      history and re-fired every turn past ~100k tokens (SupportIncident #106).
+      Fixed the reducer (app/agents/utils/delta_state.py), centralized summarization
+      into app/agents/leonardo/summarization.py with a token-budgeted keep policy
+      that preserves the first user messages + recent tail, and rewrote
+      make_summarization_model() to the DeepSeek->Gemini->OpenAI->Anthropic chain.
+- [x] Have summarization/compaction prompt include the last TODO item
+      RailsSummarizationMiddleware extracts the most recent write_todos payload and
+      appends an "ACTIVE TODO LIST — RESTORE IMMEDIATELY" block to the summary,
+      instructing the agent to re-call write_todos first so todos survive compaction.
+- [x] Fix our delta blobs issue to try and make tool repair thread better.
+      checkpoint_cleanup periodic sweep no longer references the nonexistent
+      checkpoint_blobs.checkpoint_id column (orphan-blob check is now thread/ns
+      scoped, DeltaChannel-safe). Repair path normalizes _DeltaSnapshot message
+      values (.value) so dangling-tool_call repair fires on delta threads.
+- [x] Add more aggressive websocket retries when the websocket dies.
+- [x] Fix the mobile button on the fake browser to actually apply mobile screen dimensions
+- [x] Mobile responsiveness improvements. 
+- [x] Add tips during the loading screen.


### PR DESCRIPTION
- [x] Add the active todo list on the "Your App is Building" animation screen.
- [x] Fix summarization/compaction bug, swap order of summarization LLM to go DeepSeek -> Gemini -> OpenAI -> Anthropic Root cause: DeltaChannel's _messages_delta_reducer silently dropped RemoveMessage(REMOVE_ALL_MESSAGES), so SummarizationMiddleware never cleared history and re-fired every turn past ~100k tokens (SupportIncident #106). Fixed the reducer (app/agents/utils/delta_state.py), centralized summarization into app/agents/leonardo/summarization.py with a token-budgeted keep policy that preserves the first user messages + recent tail, and rewrote make_summarization_model() to the DeepSeek->Gemini->OpenAI->Anthropic chain.
- [x] Have summarization/compaction prompt include the last TODO item RailsSummarizationMiddleware extracts the most recent write_todos payload and appends an "ACTIVE TODO LIST — RESTORE IMMEDIATELY" block to the summary, instructing the agent to re-call write_todos first so todos survive compaction.
- [x] Fix our delta blobs issue to try and make tool repair thread better. checkpoint_cleanup periodic sweep no longer references the nonexistent checkpoint_blobs.checkpoint_id column (orphan-blob check is now thread/ns scoped, DeltaChannel-safe). Repair path normalizes _DeltaSnapshot message values (.value) so dangling-tool_call repair fires on delta threads.
- [x] Add more aggressive websocket retries when the websocket dies.
- [x] Fix the mobile button on the fake browser to actually apply mobile screen dimensions
- [x] Mobile responsiveness improvements.
- [x] Add tips during the loading screen.