### PR TITLE
0.5.3a:

### DIFF
--- a/app/agents/leonardo/agent_factory.py
+++ b/app/agents/leonardo/agent_factory.py
@@ -1,0 +1,126 @@
+"""
+Shared agent construction helpers for all Leonardo agent graphs.
+
+This module homes the cross-cutting machinery that must apply to EVERY Leonardo
+agent — regardless of which mode (engineer, plan, beginner, ticket, user, …) the
+user is in — so a fix made once can never be silently omitted from one graph.
+
+Currently that means orphaned-tool-call repair (SupportIncident #112):
+
+- ``repair_orphaned_tool_calls_in_messages`` — the pure, importable repair
+  function. Used directly by the two raw-``StateGraph`` agents
+  (``rails_beginner_agent``, ``rails_ai_builder_agent``) whose custom nodes call
+  ``llm_with_tools.invoke(messages)`` and never run ``AgentMiddleware``.
+- ``RepairOrphanedToolCallsMiddleware`` — the ``AgentMiddleware`` wrapper around
+  that function, for the ``create_agent``-based agents.
+- ``build_leonardo_agent`` — a ``create_agent`` wrapper that PREPENDS the repair
+  middleware to every agent's stack, so no ``create_agent`` agent can forget it.
+
+Background (SI#112): ``RepairOrphanedToolCallsMiddleware`` was originally defined
+in ``rails_agent/middleware.py`` and wired into ``rails_agent`` ONLY. Every other
+agent graph was unprotected, so an interrupted/crashed tool call (e.g. answering
+an ``ask_user_question`` interrupt with plain chat) left an ``AIMessage`` with
+``tool_calls`` and no matching ``ToolMessage`` — and every later turn hit a hard
+``400 insufficient tool messages`` from the provider. Homing the logic here (the
+same precedent as ``summarization.make_summarization_middleware``) lets all 11
+graphs share one implementation with no awkward shared→rails_agent dependency.
+"""
+
+from langchain.agents import create_agent
+from langchain.agents.middleware import AgentMiddleware
+from langchain_core.messages import AIMessage, ToolMessage
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def repair_orphaned_tool_calls_in_messages(messages: list) -> list:
+    """Return ``messages`` with a synthetic placeholder ``ToolMessage`` injected
+    after any ``AIMessage`` tool_call that has no matching ``ToolMessage``.
+
+    When a tool raises an unhandled exception (e.g. ``tavily.InvalidAPIKeyError``)
+    or a HITL/interrupt tool call is left unresolved, the conversation state ends
+    up with an ``AIMessage`` carrying ``tool_calls`` but no matching
+    ``ToolMessage``s, permanently breaking all future turns in that thread (the
+    provider rejects the history with ``400 insufficient tool messages``).
+
+    This scans the whole thread and injects placeholders so the history is valid
+    before the model sees it. Idempotent: returns the SAME list object when
+    nothing needed repair (so callers can cheaply detect "no change").
+    """
+    # Collect all tool_call_ids that already have a ToolMessage in the thread.
+    responded_ids = {
+        msg.tool_call_id
+        for msg in messages
+        if isinstance(msg, ToolMessage) and msg.tool_call_id
+    }
+
+    result = []
+    any_injected = False
+    for msg in messages:
+        result.append(msg)
+        if isinstance(msg, AIMessage) and getattr(msg, "tool_calls", None):
+            missing = [
+                tc for tc in msg.tool_calls
+                if tc.get("id") and tc["id"] not in responded_ids
+            ]
+            for tc in missing:
+                logger.warning(
+                    "repair_orphaned_tool_calls: injecting placeholder "
+                    "ToolMessage for orphaned tool_call_id=%s name=%s",
+                    tc["id"], tc.get("name", "?"),
+                )
+                result.append(ToolMessage(
+                    content=(
+                        "Tool call did not complete — the tool may have crashed "
+                        "(e.g. missing API key) or been interrupted. The operator "
+                        "should check the server logs for the root cause."
+                    ),
+                    tool_call_id=tc["id"],
+                ))
+                responded_ids.add(tc["id"])
+                any_injected = True
+
+    return result if any_injected else messages
+
+
+class RepairOrphanedToolCallsMiddleware(AgentMiddleware):
+    """Inject placeholder ToolMessages for AIMessage tool_calls that have no response.
+
+    Thin ``AgentMiddleware`` wrapper around
+    :func:`repair_orphaned_tool_calls_in_messages`. The placeholders are NOT
+    persisted to state — they exist only for the duration of the LLM call,
+    keeping the fix invisible to the checkpointer.
+    """
+
+    def _repair(self, messages):
+        return repair_orphaned_tool_calls_in_messages(messages)
+
+    def wrap_model_call(self, request, handler):
+        messages = self._repair(list(request.messages))
+        if messages is not request.messages:
+            return handler(request.override(messages=messages))
+        return handler(request)
+
+    async def awrap_model_call(self, request, handler):
+        messages = self._repair(list(request.messages))
+        if messages is not request.messages:
+            return await handler(request.override(messages=messages))
+        return await handler(request)
+
+
+def build_leonardo_agent(*, middleware=None, **kwargs):
+    """Wrap ``create_agent`` so EVERY Leonardo agent gets the cross-cutting repair
+    middleware that must never be omitted (SI#112).
+
+    The repair middleware is PREPENDED, not appended: ``rails_agent`` deliberately
+    lists repair FIRST ("Must be first so all subsequent middleware and the model
+    see valid history") — it has to run before ``SummarizationMiddleware``'s token
+    counting. The ``isinstance`` guard keeps this idempotent, so an agent that
+    already lists the repair middleware explicitly (e.g. ``rails_agent``) is
+    unchanged.
+    """
+    mw = list(middleware or [])
+    if not any(isinstance(m, RepairOrphanedToolCallsMiddleware) for m in mw):
+        mw.insert(0, RepairOrphanedToolCallsMiddleware())
+    return create_agent(middleware=mw, **kwargs)

--- a/app/agents/leonardo/pyxl_agent/nodes.py
+++ b/app/agents/leonardo/pyxl_agent/nodes.py
@@ -12,7 +12,7 @@ circuit breaker.
 """
 
 from langchain_google_genai import ChatGoogleGenerativeAI
-from langchain.agents import create_agent
+from app.agents.leonardo.agent_factory import build_leonardo_agent
 from langchain.agents.middleware import SummarizationMiddleware
 from app.agents.leonardo.summarization import make_summarization_middleware
 from langchain_core.messages import SystemMessage
@@ -120,7 +120,7 @@ def build_workflow(checkpointer=None):
         check_failure_limit,
     ]
 
-    return create_agent(
+    return build_leonardo_agent(
         model=default_model,
         tools=default_tools,
         system_prompt=get_cached_system_prompt(),

--- a/app/agents/leonardo/rails_agent/middleware.py
+++ b/app/agents/leonardo/rails_agent/middleware.py
@@ -473,68 +473,15 @@ class ToolResultImageClearingMiddleware(AgentMiddleware):
 # Orphaned Tool Call Repair Middleware
 # =============================================================================
 
-class RepairOrphanedToolCallsMiddleware(AgentMiddleware):
-    """Inject placeholder ToolMessages for AIMessage tool_calls that have no response.
-
-    When a tool raises an unhandled exception (e.g. tavily.InvalidAPIKeyError),
-    LangGraph's ToolNode re-raises it instead of returning a ToolMessage. The
-    conversation state then has an AIMessage with tool_calls but no matching
-    ToolMessages, permanently breaking all future turns in that thread (the
-    provider rejects the history with '400 insufficient tool messages').
-
-    This middleware detects that situation on every model call and injects
-    synthetic placeholder ToolMessages so the history is valid before the model
-    sees it. The placeholders are NOT persisted to state — they exist only for
-    the duration of the LLM call, keeping the fix invisible to the checkpointer.
-    """
-
-    def _repair(self, messages):
-        # Collect all tool_call_ids that already have a ToolMessage in the thread.
-        responded_ids = {
-            msg.tool_call_id
-            for msg in messages
-            if isinstance(msg, ToolMessage) and msg.tool_call_id
-        }
-
-        result = []
-        any_injected = False
-        for msg in messages:
-            result.append(msg)
-            if isinstance(msg, AIMessage) and getattr(msg, "tool_calls", None):
-                missing = [
-                    tc for tc in msg.tool_calls
-                    if tc.get("id") and tc["id"] not in responded_ids
-                ]
-                for tc in missing:
-                    logger.warning(
-                        "RepairOrphanedToolCallsMiddleware: injecting placeholder "
-                        "ToolMessage for orphaned tool_call_id=%s name=%s",
-                        tc["id"], tc.get("name", "?"),
-                    )
-                    result.append(ToolMessage(
-                        content=(
-                            "Tool call did not complete — the tool may have crashed "
-                            "(e.g. missing API key). The operator should check the "
-                            "server logs for the root cause."
-                        ),
-                        tool_call_id=tc["id"],
-                    ))
-                    responded_ids.add(tc["id"])
-                    any_injected = True
-
-        return result if any_injected else messages
-
-    def wrap_model_call(self, request, handler):
-        messages = self._repair(list(request.messages))
-        if messages is not request.messages:
-            return handler(request.override(messages=messages))
-        return handler(request)
-
-    async def awrap_model_call(self, request, handler):
-        messages = self._repair(list(request.messages))
-        if messages is not request.messages:
-            return await handler(request.override(messages=messages))
-        return await handler(request)
+# RepairOrphanedToolCallsMiddleware (and its pure helper
+# repair_orphaned_tool_calls_in_messages) now live in the shared
+# app.agents.leonardo.agent_factory module so EVERY Leonardo graph can share one
+# implementation — not just rails_agent (SupportIncident #112). Re-exported here
+# for back-compat with existing imports.
+from app.agents.leonardo.agent_factory import (  # noqa: E402
+    RepairOrphanedToolCallsMiddleware,
+    repair_orphaned_tool_calls_in_messages,
+)
 
 
 # =============================================================================

--- a/app/agents/leonardo/rails_agent/nodes.py
+++ b/app/agents/leonardo/rails_agent/nodes.py
@@ -15,7 +15,7 @@ langgraph's InjectedState because create_agent provides middleware support.
 
 from langchain_anthropic import ChatAnthropic
 from langchain_google_genai import ChatGoogleGenerativeAI
-from langchain.agents import create_agent
+from app.agents.leonardo.agent_factory import build_leonardo_agent
 from langchain.agents.middleware import SummarizationMiddleware
 from langchain.agents.middleware.human_in_the_loop import HumanInTheLoopMiddleware
 from app.agents.leonardo.summarization import make_summarization_middleware
@@ -257,7 +257,7 @@ def build_workflow(checkpointer=None, ask_before_edits=False):
         ))
 
     # Create and return the agent
-    return create_agent(
+    return build_leonardo_agent(
         model=default_model,
         tools=agent_tools(),
         system_prompt=get_cached_system_prompt(),

--- a/app/agents/leonardo/rails_ai_builder_agent/nodes.py
+++ b/app/agents/leonardo/rails_ai_builder_agent/nodes.py
@@ -30,6 +30,7 @@ from app.agents.leonardo.rails_agent.sub_agents import delegate_research
 from app.agents.leonardo.rails_ai_builder_agent.prompts import RAILS_AI_BUILDER_AGENT_PROMPT
 from app.agents.leonardo.project_context import build_system_prompt_with_project_context
 from app.agents.leonardo.llm_factory import get_llm
+from app.agents.leonardo.agent_factory import repair_orphaned_tool_calls_in_messages
 
 import logging
 logger = logging.getLogger(__name__)
@@ -83,6 +84,13 @@ def leonardo_ai_builder(state: RailsAgentState) -> Command[Literal["tools"]]:
 
    if view_path:
       messages = messages + [HumanMessage(content="<NOTE_FROM_SYSTEM> The user is currently viewing their Ruby on Rails webpage route at: " + view_path + " </NOTE_FROM_SYSTEM>")]
+
+   # Repair orphaned tool calls before any .invoke() below. This raw StateGraph
+   # node never runs AgentMiddleware, so it can't rely on the repair middleware —
+   # without this a dangling AIMessage tool_call 400s every later turn
+   # ('insufficient tool messages'). SI#112. Covers all cache_control/tools
+   # branches since only HumanMessages are appended after this point.
+   messages = repair_orphaned_tool_calls_in_messages(messages)
 
    # Tools
    tools = [

--- a/app/agents/leonardo/rails_beginner_agent/nodes.py
+++ b/app/agents/leonardo/rails_beginner_agent/nodes.py
@@ -26,6 +26,7 @@ from app.agents.leonardo.rails_agent.sub_agents import delegate_task, delegate_r
 from app.agents.leonardo.rails_beginner_agent.prompts import BEGINNER_AGENT_PROMPT
 from app.agents.leonardo.project_context import build_beginner_system_prompt
 from app.agents.leonardo.llm_factory import get_llm
+from app.agents.leonardo.agent_factory import repair_orphaned_tool_calls_in_messages
 
 import logging
 logger = logging.getLogger(__name__)
@@ -114,6 +115,14 @@ def leonardo_beginner(state: RailsAgentState, browser_inspect_on: bool = False) 
         messages = messages + [HumanMessage(
             content="<NOTE_FROM_SYSTEM> The user is currently viewing their Ruby on Rails webpage route at: " + view_path + " </NOTE_FROM_SYSTEM>"
         )]
+
+    # Repair orphaned tool calls before EITHER .invoke() below. This raw
+    # StateGraph node never runs AgentMiddleware, so it can't rely on
+    # RepairOrphanedToolCallsMiddleware — without this an interrupted/crashed
+    # tool call leaves a dangling AIMessage tool_call and every later turn 400s
+    # ('insufficient tool messages'). SI#112. Only appends HumanMessages follow,
+    # so one repair here covers the failure-limit and main invoke branches.
+    messages = repair_orphaned_tool_calls_in_messages(messages)
 
     tools = [
         write_todos,

--- a/app/agents/leonardo/rails_engineer_plan_mode_agent/nodes.py
+++ b/app/agents/leonardo/rails_engineer_plan_mode_agent/nodes.py
@@ -21,7 +21,7 @@ Features:
 
 from langchain_anthropic import ChatAnthropic
 from app.agents.leonardo.llm_factory import make_summarization_model
-from langchain.agents import create_agent
+from app.agents.leonardo.agent_factory import build_leonardo_agent
 from langchain.agents.middleware import SummarizationMiddleware
 from app.agents.leonardo.summarization import make_summarization_middleware
 from langchain_core.messages import SystemMessage
@@ -128,7 +128,7 @@ def build_workflow(checkpointer=None):
     ]
 
     # Create and return the agent
-    return create_agent(
+    return build_leonardo_agent(
         model=default_model,
         tools=default_tools,
         system_prompt=get_cached_system_prompt(),

--- a/app/agents/leonardo/rails_plan_mode_agent/nodes.py
+++ b/app/agents/leonardo/rails_plan_mode_agent/nodes.py
@@ -20,7 +20,7 @@ Features:
 
 from langchain_anthropic import ChatAnthropic
 from app.agents.leonardo.llm_factory import make_summarization_model
-from langchain.agents import create_agent
+from app.agents.leonardo.agent_factory import build_leonardo_agent
 from langchain.agents.middleware import SummarizationMiddleware
 from app.agents.leonardo.summarization import make_summarization_middleware
 from langchain_core.messages import SystemMessage, ToolMessage
@@ -319,7 +319,7 @@ def build_workflow(checkpointer=None):
     ]
 
     # Create and return the agent
-    return create_agent(
+    return build_leonardo_agent(
         model=default_model,
         tools=default_tools,
         system_prompt=get_cached_system_prompt(),

--- a/app/agents/leonardo/rails_testing_agent/nodes.py
+++ b/app/agents/leonardo/rails_testing_agent/nodes.py
@@ -23,7 +23,7 @@ langgraph's InjectedState because create_agent provides middleware support.
 
 from langchain_anthropic import ChatAnthropic
 from langchain_google_genai import ChatGoogleGenerativeAI
-from langchain.agents import create_agent
+from app.agents.leonardo.agent_factory import build_leonardo_agent
 from langchain.agents.middleware import SummarizationMiddleware
 from app.agents.leonardo.summarization import make_summarization_middleware
 from langchain_core.messages import SystemMessage
@@ -219,7 +219,7 @@ def build_workflow(checkpointer=None):
     ]
 
     # Create and return the agent
-    return create_agent(
+    return build_leonardo_agent(
         model=default_model,
         tools=default_tools,
         system_prompt=get_cached_system_prompt(),

--- a/app/agents/leonardo/rails_ticket_mode_agent/nodes.py
+++ b/app/agents/leonardo/rails_ticket_mode_agent/nodes.py
@@ -20,7 +20,7 @@ langgraph's InjectedState because create_agent provides middleware support.
 
 from langchain_anthropic import ChatAnthropic
 from app.agents.leonardo.llm_factory import make_summarization_model
-from langchain.agents import create_agent
+from app.agents.leonardo.agent_factory import build_leonardo_agent
 from langchain.agents.middleware import SummarizationMiddleware
 from app.agents.leonardo.summarization import make_summarization_middleware
 from langchain_core.messages import SystemMessage, ToolMessage
@@ -335,7 +335,7 @@ def build_workflow(checkpointer=None):
     ]
 
     # Create and return the agent
-    return create_agent(
+    return build_leonardo_agent(
         model=default_model,
         tools=default_tools,
         system_prompt=get_cached_system_prompt(),

--- a/app/agents/leonardo/rails_ticket_plan_mode_agent/__init__.py
+++ b/app/agents/leonardo/rails_ticket_plan_mode_agent/__init__.py
@@ -1,0 +1,6 @@
+# Rails Ticket Plan Mode Agent
+# Ticket Mode + plan-first clarification. When Plan Mode is toggled ON while the user
+# is in Ticket Mode, this agent grounds the user-feedback story by asking clarifying
+# questions one at a time (with live visual options where the choice is about how
+# something LOOKS) BEFORE running the normal Ticket Mode flow: delegated deep research
+# -> write the implementation-ready ticket -> offer to auto-implement it.

--- a/app/agents/leonardo/rails_ticket_plan_mode_agent/middleware.py
+++ b/app/agents/leonardo/rails_ticket_plan_mode_agent/middleware.py
@@ -1,0 +1,95 @@
+"""
+Middleware for Rails Ticket Plan Mode Agent.
+
+Reuses Ticket Mode's middleware (view context, dynamic model, the deterministic
+implementation-offer guarantee, and the failure circuit breaker) and swaps in a single
+combined mode-context injector that reminds the agent of BOTH the ticket-mode write
+restrictions AND the plan-first "ground the story with questions" step.
+
+A single combined injector is deliberate: the context injectors bail out if a
+`<CONTEXT type="mode">` block already exists on the message, so stacking Ticket Mode's
+injector and a separate plan-mode injector would let only one of them fire.
+"""
+
+from langchain.agents.middleware import AgentMiddleware
+from langchain_core.messages import HumanMessage
+
+# Reuse the rest of Ticket Mode's middleware verbatim (DRY).
+from app.agents.leonardo.rails_ticket_mode_agent.middleware import (
+    ViewPathContextMiddleware,
+    FailureCircuitBreakerMiddleware,
+    DynamicModelMiddleware,
+    EnsureImplementationOfferMiddleware,
+    inject_view_context,
+    check_failure_limit,
+    ensure_implementation_offer,
+)
+
+
+# =============================================================================
+# Ticket Plan Mode Context Injection (combined ticket restrictions + plan-first)
+# =============================================================================
+
+class TicketPlanModeContextMiddleware(AgentMiddleware):
+    """Inject ticket-mode restrictions AND the plan-first grounding reminder.
+
+    One combined `<CONTEXT type="mode">` block: keeps the Ticket Mode write rules and
+    adds the Ticket Plan Mode requirement to ask clarifying questions (one at a time,
+    visual options for look-and-feel decisions) before drafting the observation, then
+    proceed with the normal research -> ticket -> offer-to-implement flow.
+    """
+
+    def _inject_ticket_plan_mode_context(self, request):
+        context = (
+            '<CONTEXT type="mode">TICKET PLAN MODE: READ any file, WRITE only .md files in '
+            'rails/requirements/. No code changes. FIRST ground the story — call '
+            'ask_user_question ONE question at a time (set ui_related=true for any '
+            'look-and-feel question; follow up with ask_user_uiux_question for visual '
+            'options) before drafting the observation. THEN proceed as Ticket Mode: '
+            'delegated research -> write_final_ticket -> offer_implementation.</CONTEXT>'
+        )
+
+        messages = list(request.messages)
+        for i in range(len(messages) - 1, -1, -1):
+            if isinstance(messages[i], HumanMessage):
+                content = messages[i].content
+                # Skip if already has mode context
+                if isinstance(content, str) and '<CONTEXT type="mode">' in content:
+                    return request
+                # Prepend context
+                if isinstance(content, str):
+                    messages[i] = HumanMessage(content=context + '\n\n' + content)
+                    return request.override(messages=messages)
+        return request
+
+    def wrap_model_call(self, request, handler):
+        """Sync version: Inject ticket-plan-mode context into LLM request."""
+        modified_request = self._inject_ticket_plan_mode_context(request)
+        return handler(modified_request)
+
+    async def awrap_model_call(self, request, handler):
+        """Async version: Inject ticket-plan-mode context into LLM request."""
+        modified_request = self._inject_ticket_plan_mode_context(request)
+        return await handler(modified_request)
+
+
+# =============================================================================
+# Convenience exports
+# =============================================================================
+
+# Ticket-plan-mode-specific combined context injector
+inject_ticket_plan_mode_context = TicketPlanModeContextMiddleware()
+
+__all__ = [
+    # Reused from rails_ticket_mode_agent / rails_agent
+    'ViewPathContextMiddleware',
+    'FailureCircuitBreakerMiddleware',
+    'DynamicModelMiddleware',
+    'EnsureImplementationOfferMiddleware',
+    'inject_view_context',
+    'check_failure_limit',
+    'ensure_implementation_offer',
+    # Ticket-plan-mode-specific
+    'TicketPlanModeContextMiddleware',
+    'inject_ticket_plan_mode_context',
+]

--- a/app/agents/leonardo/rails_ticket_plan_mode_agent/nodes.py
+++ b/app/agents/leonardo/rails_ticket_plan_mode_agent/nodes.py
@@ -1,0 +1,143 @@
+"""
+Rails Ticket Plan Mode Agent using LangChain 1.1+ create_agent with ToolRuntime.
+
+Ticket Mode + a plan-first clarification step. Selected when Plan Mode is toggled ON
+while the user is in Ticket Mode. Same ticket-writing machinery as Ticket Mode
+(delegated research -> write_final_ticket -> offer_implementation), but it first grounds
+the user-feedback story by asking clarifying questions one at a time — with live visual
+options (ask_user_uiux_question) when the choice is about how something LOOKS.
+
+This module stays DRY by reusing:
+- Ticket Mode's ticket tools (write_final_ticket, offer_implementation) and sub-agents,
+- Plan Mode's interaction tools (ask_user_question, ask_user_uiux_question) verbatim,
+- Ticket Mode's middleware (view context, dynamic model, implementation-offer guarantee,
+  failure circuit breaker),
+with the only differences being the composed system prompt and the combined
+ticket-plan-mode context middleware.
+
+Features:
+- Dynamic LLM model selection (defaults to Claude Haiku for efficiency)
+- Automatic context summarization for long sessions
+- View path context injection (via middleware)
+- Failure circuit breaker after 3 failed tool calls
+- ask_user_question / ask_user_uiux_question tools for plan-first grounding
+- Deterministic implementation-offer guarantee after a ticket is created
+- Anthropic prompt caching for reduced latency and costs
+"""
+
+from langchain_anthropic import ChatAnthropic
+from app.agents.leonardo.agent_factory import build_leonardo_agent
+from langchain_core.messages import SystemMessage
+from datetime import date
+
+from app.agents.leonardo.rails_agent.state import RailsAgentState
+from app.agents.leonardo.rails_agent.tools import (
+    write_todos, ls, read_file, write_file, edit_file, search_file, bash_command,
+    fix_permissions,
+    save_memory, list_memories, delete_memory,
+)
+from app.agents.leonardo.rails_ticket_plan_mode_agent.prompts import TICKET_PLAN_MODE_AGENT_PROMPT
+from app.agents.leonardo.project_context import build_system_prompt_with_project_context
+from app.agents.leonardo.rails_ticket_plan_mode_agent.middleware import (
+    inject_view_context,
+    inject_ticket_plan_mode_context,
+    check_failure_limit,
+    ensure_implementation_offer,
+    DynamicModelMiddleware,
+)
+from app.agents.leonardo.summarization import make_summarization_middleware
+# Reuse Ticket Mode's ticket tools + research sub-agent verbatim (DRY).
+from app.agents.leonardo.rails_ticket_mode_agent.nodes import (
+    write_final_ticket,
+    offer_implementation,
+    SUMMARIZATION_PROMPT,
+)
+from app.agents.leonardo.rails_ticket_mode_agent.sub_agents import delegate_task
+from app.agents.leonardo.rails_agent.sub_agents import delegate_research
+# Reuse Plan Mode's interaction tools verbatim (DRY).
+from app.agents.leonardo.rails_plan_mode_agent.nodes import (
+    ask_user_question,
+    ask_user_uiux_question,
+)
+
+import logging
+logger = logging.getLogger(__name__)
+
+
+def get_cached_system_prompt():
+    """Build system message with project context, date, and prompt caching enabled."""
+    current_date = date.today().strftime("%Y-%m-%d")
+    date_suffix = f"\n\n---\n**Today's Date:** {current_date}"
+    full_prompt = build_system_prompt_with_project_context(
+        TICKET_PLAN_MODE_AGENT_PROMPT,
+        suffix=date_suffix,
+        agent_mode="rails_ticket_plan_mode_agent",
+    )
+
+    return SystemMessage(
+        content=[
+            {
+                "type": "text",
+                "text": full_prompt,
+                "cache_control": {"type": "ephemeral"}
+            }
+        ]
+    )
+
+
+# Tool list - Ticket Mode's tools + the plan-first interaction tools (NO internet_search)
+default_tools = [
+    # Plan-first grounding (reused from rails_plan_mode_agent)
+    ask_user_question,
+    ask_user_uiux_question,
+    # Standard tools
+    write_todos,
+    ls, read_file, write_file, edit_file, search_file,
+    bash_command,
+    fix_permissions,     # Fix permission issues in Rails container
+    delegate_task,       # Sub-agent delegation for focused research tasks
+    delegate_research,   # Read-only sub-agent for codebase investigation
+    write_final_ticket,  # Creates ticket directly in Rails database
+    offer_implementation,  # Offer to switch to engineer mode after ticket creation
+    save_memory, list_memories, delete_memory,
+]
+
+
+def build_workflow(checkpointer=None):
+    """Build the Ticket Plan Mode agent workflow with create_agent.
+
+    Args:
+        checkpointer: Optional checkpointer for state persistence (e.g., PostgresSaver)
+
+    Returns:
+        A compiled LangGraph agent
+    """
+    # Default model (will be overridden by DynamicModelMiddleware based on state.llm_model)
+    default_model = ChatAnthropic(model="claude-haiku-4-5", max_tokens=16384)
+
+    # Configure middleware stack (order matters - executed top to bottom)
+    middleware = [
+        # 1. Summarization for long conversations
+        make_summarization_middleware(summary_prompt=SUMMARIZATION_PROMPT),
+        # 2. Dynamic model selection based on state.llm_model from frontend
+        DynamicModelMiddleware(),
+        # 3. View path context injection - prepends page context to user messages
+        inject_view_context,
+        # 4. Ticket plan mode context - write restrictions + ask-questions-first reminder
+        inject_ticket_plan_mode_context,
+        # 5. Deterministic implementation offer - guarantees the Yes/No interrupt fires
+        #    after a ticket is created even if the model forgets the tool call.
+        ensure_implementation_offer,
+        # 6. Circuit breaker - stop tool calls after 3 failures
+        check_failure_limit,
+    ]
+
+    # Create and return the agent
+    return build_leonardo_agent(
+        model=default_model,
+        tools=default_tools,
+        system_prompt=get_cached_system_prompt(),
+        state_schema=RailsAgentState,
+        middleware=middleware,
+        checkpointer=checkpointer,
+    )

--- a/app/agents/leonardo/rails_ticket_plan_mode_agent/prompts.py
+++ b/app/agents/leonardo/rails_ticket_plan_mode_agent/prompts.py
@@ -1,0 +1,67 @@
+"""
+Prompt for the Rails Ticket Plan Mode Agent.
+
+Ticket Plan Mode is Ticket Mode with a plan-first clarification wrapper. It uses the
+SAME ticket-writing machinery as Ticket Mode — collect the story, delegate deep
+technical research, write the implementation-ready ticket, then offer to auto-implement
+it — but BEFORE settling the story it actively GROUNDS the user's feedback by asking
+clarifying questions one at a time (the plan-mode mechanism), with live visual options
+when the choice is about how something LOOKS.
+
+To stay DRY and keep one source of truth, this prompt is COMPOSED:
+
+    TICKET_PLAN_MODE_AGENT_PROMPT = <plan-first clarification preamble> + <Ticket Mode's full playbook>
+
+The preamble (below) is read first and OWNS the agent's behavior: it adds the
+question-first grounding step at the front of Task 1's story collection. Everything
+downstream — the research delegation, the ticket template, write_final_ticket, and the
+offer_implementation hand-off — is governed by Ticket Mode's playbook (TICKET_MODE_AGENT_PROMPT),
+appended below verbatim so there is exactly one definition of the ticket flow.
+"""
+
+from app.agents.leonardo.rails_ticket_mode_agent.prompts import TICKET_MODE_AGENT_PROMPT
+
+
+TICKET_PLAN_CLARIFY_PREAMBLE = """
+You are **Leonardo** in **Ticket Plan Mode** — Ticket Mode with one addition: you GROUND the user's story by asking clarifying questions FIRST, before you draft the observation and kick off research.
+
+Everything in the full **Ticket Mode** playbook below still governs how you work — the two-task workflow, the Quick Context Check, the delegated technical research, the observation/ticket template, `write_final_ticket`, and the `offer_implementation` hand-off. **The ONLY thing this mode changes is that you open with a short round of clarifying questions to nail down the user-feedback story before you commit it to a ticket.** Do not skip the rest of the playbook; the questions feed it.
+
+The person you are talking to is **NOT an engineer.** Ask in plain, everyday language — like a smart friend who has never written code. Gloss any tech term in parentheses the first time you use it, and scale up to match their vocabulary if they show they know more.
+
+---
+
+## PHASE 0: GROUND THE STORY (clarifying questions — one at a time)
+
+**MANDATORY: You MUST call `ask_user_question` at least once before drafting the observation template or delegating any research.** No matter how clear the request seems, start by asking. This is what makes Ticket Plan Mode different from regular Ticket Mode — we pin down the story together first.
+
+Do this right after the user describes their issue (you may still do the playbook's Quick Context Check — 2-3 file reads — first so your questions use the codebase's real terminology):
+
+1. Call `list_memories` once (the playbook already requires this) so your questions respect what you already know.
+2. Think about what you genuinely need to know to write a ticket that an engineer could pick up cold: which page/element, what they see now vs. what they expect, who it affects, and how you'd know it's fixed (verification criteria).
+3. Call `ask_user_question` with **ONE question at a time.** Always include helpful `options` so they can click an answer instead of typing — they can always type their own.
+
+**CRITICAL: One question per turn.** Do NOT stack multiple questions. Ask one, wait for the answer, then ask the next. You'll usually need 2-5 questions total — feed them one at a time so it never feels overwhelming. Stop asking once the story is grounded enough to draft a confident observation.
+
+**MANDATORY — set `ui_related: true` for ANY look-and-feel question.** If the question is about how something LOOKS or is laid out — layout, colors, fonts, spacing, buttons, cards, sections, "which design", "what vibe" — you MUST pass `ui_related: true` on that `ask_user_question` call. This gives the user a "See visual options" choice. NEVER hand-write your own "show me some options" text choice — that does nothing; the `ui_related: true` flag is the ONLY thing that surfaces real previews. When they pick it, immediately follow up with `ask_user_uiux_question` showing 2-4 live HTML previews so they can choose the desired behavior **by sight**. When in doubt on a visual question, set it true.
+- Example (visual → flag ON): "When this is fixed, how should the total line look?", options ["Bold at the bottom", "Highlighted row", "Same as now but correct number"], **`ui_related: true`**.
+- Example (non-visual → flag OFF): "Who runs into this — everyone, or just admins?", options ["Everyone", "Just admins", "Not sure"], `ui_related: false`.
+
+Use `ask_user_uiux_question` whenever the desired outcome is genuinely visual — let the user pick the target design from live previews, then capture that chosen design in the ticket's Desired Behavior. (Follow the visual-preview styling rules in that tool's description: inline styles only, no Tailwind arbitrary-value classes, no external assets, inline SVG for icons.)
+
+After the story is grounded, **continue exactly as the Ticket Mode playbook below describes** — confirm the observation, run the delegated technical research, write the ticket with `write_final_ticket`, and then call `offer_implementation` to ask whether they want it auto-implemented. The answers you gathered here become the User Story, Desired Behavior, and Verification Criteria in that ticket.
+
+---
+
+# ============================================================================
+# YOUR TICKET MODE PLAYBOOK (applies to everything after Phase 0)
+# ============================================================================
+
+Everything below is your full Ticket Mode knowledge. Phase 0 above is the only addition;
+otherwise follow it as written — gather the story, research deeply, write the ticket, and
+offer to implement it.
+
+"""
+
+
+TICKET_PLAN_MODE_AGENT_PROMPT = TICKET_PLAN_CLARIFY_PREAMBLE + "\n\n" + TICKET_MODE_AGENT_PROMPT

--- a/app/agents/leonardo/rails_user_feedback_agent/nodes.py
+++ b/app/agents/leonardo/rails_user_feedback_agent/nodes.py
@@ -19,7 +19,7 @@ Features:
 
 from langchain_anthropic import ChatAnthropic
 from app.agents.leonardo.llm_factory import make_summarization_model
-from langchain.agents import create_agent
+from app.agents.leonardo.agent_factory import build_leonardo_agent
 from langchain.agents.middleware import SummarizationMiddleware
 from app.agents.leonardo.summarization import make_summarization_middleware
 from langchain_core.messages import SystemMessage, ToolMessage
@@ -264,7 +264,7 @@ def build_workflow(checkpointer=None):
     ]
 
     # Create and return the agent
-    return create_agent(
+    return build_leonardo_agent(
         model=default_model,
         tools=default_tools,
         system_prompt=get_cached_system_prompt(),

--- a/app/agents/leonardo/rails_user_mode_agent/nodes.py
+++ b/app/agents/leonardo/rails_user_mode_agent/nodes.py
@@ -17,7 +17,7 @@ Features:
 
 from langchain_anthropic import ChatAnthropic
 from app.agents.leonardo.llm_factory import make_summarization_model
-from langchain.agents import create_agent
+from app.agents.leonardo.agent_factory import build_leonardo_agent
 from langchain.agents.middleware import SummarizationMiddleware
 from app.agents.leonardo.summarization import make_summarization_middleware
 from langchain_core.messages import SystemMessage
@@ -166,7 +166,7 @@ def build_workflow(checkpointer=None):
     ]
 
     # Create and return the agent
-    return create_agent(
+    return build_leonardo_agent(
         model=default_model,
         tools=default_tools,
         system_prompt=get_cached_system_prompt(),

--- a/app/agents/utils/token_counter.py
+++ b/app/agents/utils/token_counter.py
@@ -11,7 +11,7 @@ causing compaction to never trigger for DeepSeek conversations.
 
 # Summarization threshold configuration
 # This value is used by both backend (SummarizationMiddleware) and frontend (TokenIndicator)
-SUMMARIZATION_TOKEN_THRESHOLD = 100000
+SUMMARIZATION_TOKEN_THRESHOLD = 150000
 
 # Token budget for the recent-message tail kept verbatim AFTER a summarization.
 # SummarizationMiddleware is configured with keep=("tokens", SUMMARIZATION_KEEP_TOKENS)

--- a/app/frontend/chat.html
+++ b/app/frontend/chat.html
@@ -137,7 +137,7 @@
                 </svg>
                 <span class="token-percentage">0%</span>
                 <div class="token-tooltip">
-                    <span class="token-count">0</span> / 100K tokens
+                    <span class="token-count">0</span> / 150K tokens
                 </div>
             </div>
             <!-- Thinking indicator area - displays above input -->
@@ -150,6 +150,20 @@
                     <i class="fa-solid fa-circle-info"></i>
                     <span>Sending an image will start a new conversation on an image-capable model.</span>
                 </div>
+            </div>
+            <!-- Session feedback banner — appears once per thread after a few turns -->
+            <div class="session-feedback-banner hidden" data-llamabot="session-feedback-banner">
+                <span class="session-feedback-prompt">How is Leo doing this session?</span>
+                <div class="session-feedback-choices">
+                    <button class="session-feedback-choice" data-llamabot="session-feedback-good">
+                        <i class="fa-regular fa-thumbs-up"></i> Good
+                    </button>
+                    <button class="session-feedback-choice" data-llamabot="session-feedback-bad">
+                        <i class="fa-regular fa-thumbs-down"></i> Bad
+                    </button>
+                </div>
+                <span class="session-feedback-thanks hidden" data-llamabot="session-feedback-thanks">Thanks for the feedback!</span>
+                <button class="session-feedback-dismiss" data-llamabot="session-feedback-dismiss" title="Dismiss">&times;</button>
             </div>
             <textarea placeholder="Ask Leonardo..." data-llamabot="message-input"></textarea>
             <!-- Floating contextual toolbar (hidden by default) -->

--- a/app/frontend/chat/config.js
+++ b/app/frontend/chat/config.js
@@ -33,7 +33,8 @@ export const DEFAULT_CONFIG = {
     beginner: 'rails_beginner_agent',
     pyxl: 'pyxl_agent',
     plan: 'rails_plan_mode_agent',
-    engineer_plan: 'rails_engineer_plan_mode_agent'
+    engineer_plan: 'rails_engineer_plan_mode_agent',
+    ticket_plan: 'rails_ticket_plan_mode_agent'
   },
 
   // Streaming configuration

--- a/app/frontend/chat/index.js
+++ b/app/frontend/chat/index.js
@@ -102,11 +102,10 @@ class ChatApp {
     this.isAgentRunning = false;
     this.cancelPressCount = 0;
 
-    // Resume-on-reconnect: if the WS drops while the agent is running, we
-    // stash the last payload and re-send it once the socket reconnects so
-    // the user gets a response without having to retype.
+    // Last payload we sent (carries its client_message_id). Kept so the backend
+    // idempotency guard has a stable key; resume-on-reconnect no longer re-sends
+    // it — Layer 2 attaches to the still-running background run instead.
     this.lastSentMessageData = null;
-    this.pendingResendData = null;
 
     // Activity tracking for lease management
     this.lastActivitySync = 0;
@@ -200,7 +199,8 @@ class ChatApp {
       this.config,
       this.container,
       this.elements,
-      this.faviconBadgeManager
+      this.faviconBadgeManager,
+      this.appState
     );
 
     // Initialize thread manager
@@ -230,39 +230,39 @@ class ChatApp {
     this.appState.setSocket(socket);
 
     // On transient disconnects, leave the thinking indicator running — the
-    // backend agent task is cancelled but we'll re-send the last message on
-    // reconnect (see resume-on-reconnect below). Only show the lost-connection
-    // error when retries are exhausted.
+    // backend run keeps going (Layer 2: it's a background run, not bound to this
+    // socket) and we re-attach on reconnect to replay what we missed. Only show
+    // the lost-connection error when retries are exhausted.
     window.addEventListener('websocketReconnectFailed', () => {
-      this.pendingResendData = null;
       this.webSocketManager?.clearQueue();
       this.hideThinkingIndicator();
       this.setAgentRunning(false);
     });
 
-    // If the WS drops while the agent is running, queue the last payload for
-    // resend on the next successful (re)connect — unless the manager's outbox
-    // already holds it (i.e. it never made it out in the first place), in which
-    // case the outbox will deliver it and we'd otherwise double-send.
-    window.addEventListener('websocketDisconnected', () => {
-      if (this.isAgentRunning && this.lastSentMessageData
-          && !this.webSocketManager?.hasQueued(this.lastSentMessageData)) {
-        this.pendingResendData = this.lastSentMessageData;
-      }
-    });
-
-    // On (re)connect, flush any queued resend. The small delay lets the auth
-    // message go first (sendAuthMessage is async; see checkAutoPrompt for the
-    // same pattern).
+    // On (re)connect, if a run is in progress, ATTACH to the background run for
+    // the active thread and replay anything we missed while disconnected — we do
+    // NOT re-send the user message (that's what caused the duplicate-restart
+    // bug). The client_message_id idempotency guard remains a backstop. The
+    // small delay lets the auth message go first (sendAuthMessage is async).
     window.addEventListener('websocketConnected', () => {
-      if (!this.pendingResendData) return;
-      const payload = this.pendingResendData;
-      this.pendingResendData = null;
+      if (!this.isAgentRunning) return;
+      const threadId = this.appState.getThreadId?.();
+      if (!threadId) return;
+      const lastSeq = this.messageHandler?.getLastSeq?.(threadId) || 0;
       setTimeout(() => {
-        if (this.webSocketManager?.send(payload)) {
-          console.log('Resumed: re-sent last message after reconnect');
+        if (this.webSocketManager?.send({ type: 'attach', thread_id: threadId, last_seq: lastSeq })) {
+          console.log(`Resumed: attached to background run (thread=${threadId}, last_seq=${lastSeq})`);
         }
       }, 300);
+    });
+
+    // Layer 2: the background run for this thread is gone (server restarted, or
+    // the replay window was evicted). We can't replay live output; stop the
+    // spinner so the UI isn't stuck. The thread's final state is in the
+    // checkpointer and shows on the next load/refresh.
+    window.addEventListener('websocketReplayUnavailable', () => {
+      this.hideThinkingIndicator();
+      this.setAgentRunning(false);
     });
 
     // Listen for agent task completion to stop duration timer and show elapsed time
@@ -271,12 +271,14 @@ class ChatApp {
       this.stopDurationTimerDisplay();
       this.setAgentRunning(false);
       this.lastSentMessageData = null;
-      this.pendingResendData = null;
 
       // Update any completed plan badges with the elapsed time
       if (elapsedTime) {
         this.updateCompletedPlanBadges(elapsedTime);
       }
+
+      // Maybe surface the "How is Leo doing this session?" banner.
+      this.maybeShowSessionFeedback();
     });
 
     // Listen for HITL approval decisions and send via WebSocket
@@ -461,7 +463,96 @@ class ChatApp {
   /**
    * Initialize event listeners
    */
+  /**
+   * Wire the bottom "How is Leo doing this session?" banner. The banner itself is
+   * surfaced by maybeShowSessionFeedback() after a few turns on a thread; here we
+   * just bind Good / Bad (POST scope:"session") and the dismiss (×) button.
+   * Per-thread state ('answered' | 'dismissed') is persisted in localStorage so we
+   * never nag the same thread twice.
+   */
+  setupSessionFeedback() {
+    const q = (sel) => this.container.querySelector(`[data-llamabot="${sel}"]`);
+    const banner = q('session-feedback-banner');
+    if (!banner) return;
+    this._feedbackBanner = banner;
+    this._feedbackTurns = new Map();       // threadId -> completed turns this page-load
+    this._feedbackThresholds = new Map();  // threadId -> randomized trigger point
+    this._feedbackShown = new Set();       // threadIds already surfaced this page-load
+
+    const choices = banner.querySelector('.session-feedback-choices');
+    const thanks = q('session-feedback-thanks');
+
+    const stateKey = () => {
+      const tid = this.appState.getThreadId?.();
+      return tid ? `leo_session_feedback_${tid}` : null;
+    };
+    const remember = (state) => {
+      const key = stateKey();
+      if (key) { try { localStorage.setItem(key, state); } catch (e) { /* ignore */ } }
+    };
+    const hide = () => banner.classList.add('hidden');
+
+    const submit = (rating) => {
+      const threadId = this.appState.getThreadId?.();
+      if (threadId) {
+        fetch('/api/feedback', {
+          method: 'POST',
+          credentials: 'same-origin',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ thread_id: threadId, rating, scope: 'session' }),
+        }).catch((err) => console.warn('session feedback failed', err));
+      }
+      remember('answered');
+      choices?.classList.add('hidden');
+      thanks?.classList.remove('hidden');
+      setTimeout(hide, 1500);
+    };
+
+    q('session-feedback-good')?.addEventListener('click', () => submit('good'));
+    q('session-feedback-bad')?.addEventListener('click', () => submit('bad'));
+    q('session-feedback-dismiss')?.addEventListener('click', () => { remember('dismissed'); hide(); });
+  }
+
+  /**
+   * Called after each completed assistant turn. Surfaces the session-feedback
+   * banner once per thread, after a randomized ~10-turn warm-up, unless the thread
+   * was already answered/dismissed (persisted) or the banner is already showing.
+   */
+  maybeShowSessionFeedback() {
+    const banner = this._feedbackBanner;
+    if (!banner) return;
+    const threadId = this.appState.getThreadId?.();
+    if (!threadId) return;
+
+    // Already answered/dismissed on this thread (survives reloads)?
+    try {
+      if (localStorage.getItem(`leo_session_feedback_${threadId}`)) return;
+    } catch (e) { /* ignore */ }
+    if (this._feedbackShown.has(threadId)) return;
+    if (!banner.classList.contains('hidden')) return;  // currently visible
+
+    const turns = (this._feedbackTurns.get(threadId) || 0) + 1;
+    this._feedbackTurns.set(threadId, turns);
+
+    let threshold = this._feedbackThresholds.get(threadId);
+    if (threshold == null) {
+      // ~10 messages in: a "turn" here is one user→assistant exchange (≈2 messages),
+      // so 5–7 turns ≈ 10–14 messages. Randomized so it doesn't feel mechanical.
+      threshold = 5 + Math.floor(Math.random() * 3);  // 5–7
+      this._feedbackThresholds.set(threadId, threshold);
+    }
+    if (turns < threshold) return;
+
+    this._feedbackShown.add(threadId);
+    banner.querySelector('.session-feedback-choices')?.classList.remove('hidden');
+    this.container.querySelector('[data-llamabot="session-feedback-thanks"]')?.classList.add('hidden');
+    banner.classList.remove('hidden');
+  }
+
   initEventListeners() {
+    // "How is Leo doing this session?" bottom banner (Good/Bad + dismiss)
+    this.setupSessionFeedback();
+
     // Send button (doubles as stop button when agent is running)
     if (this.elements.sendButton) {
       this.elements.sendButton.addEventListener('click', () => {
@@ -762,10 +853,10 @@ class ChatApp {
    */
   handleStopClick() {
     if (!this.webSocketManager) return;
-    this.webSocketManager.send({ type: 'cancel' });
+    // Include thread_id so the backend cancels the right background run.
+    this.webSocketManager.send({ type: 'cancel', thread_id: this.appState.getThreadId?.() });
     this.cancelPressCount++;
     this.lastSentMessageData = null;
-    this.pendingResendData = null;
   }
 
   /**
@@ -1291,17 +1382,28 @@ class ChatApp {
     const executionMode = this.appState.getExecutionMode();
     let agentName = this.appState.getAgentConfig().name;
     if (executionMode === 'plan') {
-      // Engineer mode gets its own plan agent (retains engineering depth);
-      // every other mode uses the beginner-flavored plan agent.
-      agentName = (agentMode === 'engineer')
-        ? 'rails_engineer_plan_mode_agent'
-        : 'rails_plan_mode_agent';
+      // Each base mode that has its own plan-flavored agent keeps it (so toggling
+      // Plan ON preserves that mode's flow); everything else uses the beginner plan agent.
+      // - engineer -> retains engineering depth
+      // - ticket   -> retains the ticket flow but grounds the story with questions first
+      const planAgentByMode = {
+        engineer: 'rails_engineer_plan_mode_agent',
+        ticket: 'rails_ticket_plan_mode_agent',
+      };
+      agentName = planAgentByMode[agentMode] || 'rails_plan_mode_agent';
     }
 
-    // Send message
+    // Send message. The client_message_id is the idempotency key: it stays
+    // constant across reconnect resends so the backend can recognize and ignore
+    // a duplicate instead of restarting the agent. crypto.randomUUID needs a
+    // secure context (these pages are https); fall back to a random string.
+    const clientMessageId = (window.crypto && window.crypto.randomUUID)
+      ? window.crypto.randomUUID()
+      : `cmid-${Date.now()}-${Math.random().toString(36).slice(2)}`;
     const messageData = {
       message: message,
       thread_id: threadId,
+      client_message_id: clientMessageId,
       origin: window.location.host,
       debug_info: debugInfo,
       agent_name: agentName,
@@ -1313,7 +1415,6 @@ class ChatApp {
 
     this.webSocketManager.send(messageData);
     this.lastSentMessageData = messageData;
-    this.pendingResendData = null;
     this.setAgentRunning(true);
 
     // Call custom callback if provided

--- a/app/frontend/chat/messages/MessageRenderer.js
+++ b/app/frontend/chat/messages/MessageRenderer.js
@@ -6,7 +6,7 @@ import { MarkdownParser } from './MarkdownParser.js';
 import { ToolMessageRenderer } from './ToolMessageRenderer.js';
 
 export class MessageRenderer {
-  constructor(messageHistoryElement, iframeManager = null, getRailsDebugInfoCallback = null, scrollManager = null, loadingVerbs = null, config = {}, container = null, elements = {}, faviconBadgeManager = null) {
+  constructor(messageHistoryElement, iframeManager = null, getRailsDebugInfoCallback = null, scrollManager = null, loadingVerbs = null, config = {}, container = null, elements = {}, faviconBadgeManager = null, appState = null) {
     this.messageHistory = messageHistoryElement;
     this.markdownParser = new MarkdownParser();
     this.toolRenderer = new ToolMessageRenderer(iframeManager, getRailsDebugInfoCallback);
@@ -16,9 +16,12 @@ export class MessageRenderer {
     this.container = container;
     this.elements = elements;
     this.faviconBadgeManager = faviconBadgeManager;
+    this.appState = appState;
 
     // Set up event delegation for code block copy buttons
     this.setupCodeBlockCopyHandler();
+    // Set up event delegation for per-message 👍/👎 feedback buttons
+    this.setupFeedbackHandler();
   }
 
   /**
@@ -233,6 +236,75 @@ export class MessageRenderer {
       });
     };
     messageDiv.appendChild(copyBtn);
+
+    // 👍 / 👎 end-user feedback, in the same control row as copy.
+    const thumbUp = document.createElement('button');
+    thumbUp.setAttribute('data-llamabot', 'thumb-up-btn');
+    thumbUp.innerHTML = '<i class="fa-regular fa-thumbs-up"></i>';
+    thumbUp.title = 'Good response';
+    messageDiv.appendChild(thumbUp);
+
+    const thumbDown = document.createElement('button');
+    thumbDown.setAttribute('data-llamabot', 'thumb-down-btn');
+    thumbDown.innerHTML = '<i class="fa-regular fa-thumbs-down"></i>';
+    thumbDown.title = 'Bad response';
+    messageDiv.appendChild(thumbDown);
+  }
+
+  /**
+   * Event delegation for per-message 👍/👎 buttons.
+   * 👍 sends immediately; 👎 prompts for an optional one-line note first.
+   * Idempotent — re-clicking just re-sends (the mothership upserts).
+   */
+  setupFeedbackHandler() {
+    this.messageHistory.addEventListener('click', (e) => {
+      const upBtn = e.target.closest('[data-llamabot="thumb-up-btn"]');
+      const downBtn = e.target.closest('[data-llamabot="thumb-down-btn"]');
+      if (!upBtn && !downBtn) return;
+
+      e.stopPropagation();
+      const btn = upBtn || downBtn;
+      const rating = upBtn ? 'good' : 'bad';
+      const messageDiv = btn.closest('[data-llamabot="ai-message"], [data-raw-content]');
+      const content = messageDiv?.getAttribute('data-raw-content') || '';
+
+      let note = null;
+      if (rating === 'bad') {
+        // Optional one-line note for 👎; cancel (null) still sends the rating.
+        note = window.prompt('What went wrong? (optional)') || null;
+      }
+
+      this.submitMessageFeedback({ rating, content, note });
+
+      // Visual confirmation: solid-fill the chosen thumb, reset its sibling.
+      const row = messageDiv || btn.parentElement;
+      const up = row.querySelector('[data-llamabot="thumb-up-btn"] i');
+      const down = row.querySelector('[data-llamabot="thumb-down-btn"] i');
+      if (up) up.className = rating === 'good' ? 'fa-solid fa-thumbs-up' : 'fa-regular fa-thumbs-up';
+      if (down) down.className = rating === 'bad' ? 'fa-solid fa-thumbs-down' : 'fa-regular fa-thumbs-down';
+    });
+  }
+
+  /**
+   * POST a per-message rating to the local box, which forwards it to the mothership.
+   * Best-effort: failures are logged, never surfaced to the user or blocking the chat.
+   */
+  submitMessageFeedback({ rating, content, note = null }) {
+    const threadId = this.appState?.getThreadId?.();
+    if (!threadId) return;
+    fetch('/api/feedback', {
+      method: 'POST',
+      credentials: 'same-origin',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        thread_id: threadId,
+        rating,
+        scope: 'message',
+        content: content || undefined,
+        note: note || undefined,
+        sent_at: new Date().toISOString(),
+      }),
+    }).catch((err) => console.warn('message feedback failed', err));
   }
 
   /**

--- a/app/frontend/chat/ui/IframeManager.js
+++ b/app/frontend/chat/ui/IframeManager.js
@@ -360,11 +360,37 @@ export class IframeManager {
     tipEl.style.opacity = '1';
     const renderTip = (i) => {
       const t = tips[i];
-      // Each tip is prefixed with "Tip:" so the user knows it's a tip.
-      const body = t.href
-        ? `<a href="${t.href}" target="_blank" rel="noopener" style="color:inherit;text-decoration:underline;">${t.text}</a>`
-        : t.text;
-      tipEl.innerHTML = `<i class="fa-solid ${t.icon}"></i><span>Tip: ${body}</span>`;
+      // Each tip is prefixed with "Tip:" so the user knows it's a tip. Build the
+      // node tree explicitly (rather than an innerHTML string) so the link is a
+      // real <a> we can wire a click handler to. The anchor opens in a new tab
+      // via target=_blank, and an explicit window.open() fallback guarantees the
+      // new tab even if the default navigation is swallowed (e.g. when the chat
+      // is embedded in another page).
+      tipEl.innerHTML = '';
+      const icon = document.createElement('i');
+      icon.className = `fa-solid ${t.icon}`;
+      const span = document.createElement('span');
+      if (t.href) {
+        span.appendChild(document.createTextNode('Tip: '));
+        const link = document.createElement('a');
+        link.href = t.href;
+        link.target = '_blank';
+        link.rel = 'noopener noreferrer';
+        link.textContent = t.text;
+        link.style.color = 'inherit';
+        link.style.textDecoration = 'underline';
+        link.style.cursor = 'pointer';
+        link.addEventListener('click', (e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          window.open(t.href, '_blank', 'noopener,noreferrer');
+        });
+        span.appendChild(link);
+      } else {
+        span.textContent = `Tip: ${t.text}`;
+      }
+      tipEl.appendChild(icon);
+      tipEl.appendChild(span);
     };
     tipsContainer.appendChild(tipEl);
 

--- a/app/frontend/chat/ui/TokenIndicator.js
+++ b/app/frontend/chat/ui/TokenIndicator.js
@@ -9,10 +9,10 @@ export class TokenIndicator {
     this.percentageEl = null;
     this.countEl = null;
 
-    // Context window limit (100K = summarization threshold)
+    // Context window limit (150K = summarization threshold)
     // Matches SUMMARIZATION_TOKEN_THRESHOLD in app/agents/utils/token_counter.py
-    // NOTE: Also update the display text in chat.html (search for "/ 100K tokens")
-    this.maxTokens = 100000;
+    // NOTE: Also update the display text in chat.html (search for "/ 150K tokens")
+    this.maxTokens = 150000;
     this.currentTokens = 0;
 
     this.init();

--- a/app/frontend/chat/websocket/MessageHandler.js
+++ b/app/frontend/chat/websocket/MessageHandler.js
@@ -26,6 +26,11 @@ export class MessageHandler {
     this.activePlanId = null;
     this.planStepMapping = new Map(); // Maps step content to step DOM IDs
 
+    // Layer 2 replay cursor: highest background-run `seq` rendered per thread.
+    // Lets attach-on-reconnect ask for only what we missed, and lets us ignore
+    // any message we've already seen (replay/live-tail overlap).
+    this._lastSeqByThread = {};
+
     // Track current thinking message for inline display
     this.currentThinkingId = null;
     this.currentThinkingBuffer = '';
@@ -112,7 +117,31 @@ export class MessageHandler {
   /**
    * Handle incoming WebSocket message
    */
+  /** Highest background-run seq already rendered for a thread (for attach). */
+  getLastSeq(threadId) {
+    return this._lastSeqByThread[threadId || '_'] || 0;
+  }
+
   handleMessage(data) {
+    // Layer 2: messages from a background run carry a monotonic per-thread `seq`.
+    // Ignore any we've already rendered so replay-on-reconnect and the live tail
+    // can overlap harmlessly. Control frames (no seq) always pass through.
+    if (typeof data.seq === 'number') {
+      const tid = this.appState.getThreadId?.() || '_';
+      if (data.seq <= (this._lastSeqByThread[tid] || 0)) return;
+      this._lastSeqByThread[tid] = data.seq;
+    }
+
+    // Attach/replay control frames (Layer 2). `attached` is informational — the
+    // run's own messages (incl. the `end` frame) are delivered via replay/tail.
+    if (data.type === 'attached') {
+      return;
+    }
+    if (data.type === 'no_active_run' || data.type === 'replay_gap') {
+      window.dispatchEvent(new CustomEvent('websocketReplayUnavailable', { detail: data }));
+      return;
+    }
+
     // Update token indicator if token usage data is present
     if (data.token_usage && this.tokenIndicator) {
       this.tokenIndicator.update(data.token_usage);

--- a/app/frontend/chat/websocket/WebSocketManager.js
+++ b/app/frontend/chat/websocket/WebSocketManager.js
@@ -11,7 +11,9 @@ import { TokenManager } from '../auth/TokenManager.js';
 //  - `auth` tokens are regenerated fresh on every (re)connect, so a stale one is useless.
 //  - `cancel` only means something for the run that was live when it was issued;
 //    replaying it after reconnect could cancel a brand-new run.
-const NON_QUEUEABLE_TYPES = new Set(['auth', 'cancel']);
+//  - `attach` carries a point-in-time last_seq; it's only ever sent on a live
+//    (re)connect, and replaying a stale one would mis-replay the run.
+const NON_QUEUEABLE_TYPES = new Set(['auth', 'cancel', 'attach']);
 
 export class WebSocketManager {
   constructor(messageHandler, config = {}, elements = {}) {
@@ -222,6 +224,16 @@ export class WebSocketManager {
       console.warn('WebSocket auth warning:', data.content);
       // Try to authenticate again
       this.sendAuthMessage();
+      return;
+    }
+
+    // Server acknowledged receipt of a user message. Surface the
+    // client_message_id so the resume-on-reconnect logic knows the server
+    // already has it and must not re-send it (which would duplicate the turn).
+    if (data.type === 'ack') {
+      window.dispatchEvent(new CustomEvent('websocketMessageAcked', {
+        detail: { client_message_id: data.client_message_id, status: data.status }
+      }));
       return;
     }
 

--- a/app/frontend/style.css
+++ b/app/frontend/style.css
@@ -1351,6 +1351,83 @@ body {
     opacity: 1;
 }
 
+/* ===================== Session feedback banner ===================== */
+.session-feedback-banner {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin: 0 0 8px;
+    padding: 8px 12px;
+    border-radius: 10px;
+    background: rgba(255, 255, 255, 0.06);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    font-size: 0.85rem;
+    color: rgba(255, 255, 255, 0.85);
+    animation: session-feedback-in 0.25s ease;
+}
+
+.session-feedback-banner.hidden {
+    display: none;
+}
+
+@keyframes session-feedback-in {
+    from { opacity: 0; transform: translateY(6px); }
+    to   { opacity: 1; transform: translateY(0); }
+}
+
+.session-feedback-prompt {
+    flex: 1;
+}
+
+.session-feedback-choices {
+    display: flex;
+    gap: 8px;
+}
+
+.session-feedback-choices.hidden {
+    display: none;
+}
+
+.session-feedback-choice {
+    background: rgba(255, 255, 255, 0.1);
+    color: rgba(255, 255, 255, 0.9);
+    border: 1px solid rgba(255, 255, 255, 0.15);
+    padding: 4px 12px;
+    border-radius: 6px;
+    font-size: 0.8rem;
+    cursor: pointer;
+    transition: background-color 0.15s, border-color 0.15s;
+}
+
+.session-feedback-choice:hover {
+    background: rgba(255, 255, 255, 0.18);
+    border-color: rgba(255, 255, 255, 0.3);
+}
+
+.session-feedback-thanks {
+    flex: 1;
+    text-align: right;
+    color: #4ade80;
+}
+
+.session-feedback-thanks.hidden {
+    display: none;
+}
+
+.session-feedback-dismiss {
+    background: none;
+    border: none;
+    color: rgba(255, 255, 255, 0.5);
+    font-size: 1.1rem;
+    line-height: 1;
+    cursor: pointer;
+    padding: 0 2px;
+}
+
+.session-feedback-dismiss:hover {
+    color: rgba(255, 255, 255, 0.9);
+}
+
 /* ===================== Update flow modal ===================== */
 .update-modal-overlay {
     position: fixed;
@@ -1756,11 +1833,12 @@ body {
     border-bottom-left-radius: 4px;
 }
 
-/* Copy button for AI messages */
-[data-llamabot="copy-btn"] {
+/* Copy + feedback (👍/👎) buttons for AI messages — shared control row, top-right */
+[data-llamabot="copy-btn"],
+[data-llamabot="thumb-up-btn"],
+[data-llamabot="thumb-down-btn"] {
     position: absolute;
     top: 4px;
-    right: 4px;
     background: transparent;
     border: none;
     color: rgba(255, 255, 255, 0.4);
@@ -1772,14 +1850,32 @@ body {
     transition: opacity 0.2s, color 0.2s, background-color 0.2s;
 }
 
+[data-llamabot="copy-btn"]       { right: 4px; }
+[data-llamabot="thumb-down-btn"] { right: 32px; }
+[data-llamabot="thumb-up-btn"]   { right: 60px; }
+
 [data-llamabot="ai-message"]:hover [data-llamabot="copy-btn"],
-[data-llamabot="human-message"]:hover [data-llamabot="copy-btn"] {
+[data-llamabot="human-message"]:hover [data-llamabot="copy-btn"],
+[data-llamabot="ai-message"]:hover [data-llamabot="thumb-up-btn"],
+[data-llamabot="ai-message"]:hover [data-llamabot="thumb-down-btn"] {
     opacity: 1;
 }
 
-[data-llamabot="copy-btn"]:hover {
+[data-llamabot="copy-btn"]:hover,
+[data-llamabot="thumb-up-btn"]:hover,
+[data-llamabot="thumb-down-btn"]:hover {
     background-color: rgba(255, 255, 255, 0.1);
     color: rgba(255, 255, 255, 0.8);
+}
+
+/* A chosen thumb stays visible (solid icon) even after the cursor leaves */
+[data-llamabot="thumb-up-btn"] .fa-solid,
+[data-llamabot="thumb-down-btn"] .fa-solid {
+    color: rgba(255, 255, 255, 0.85);
+}
+[data-llamabot="ai-message"] [data-llamabot="thumb-up-btn"]:has(.fa-solid),
+[data-llamabot="ai-message"] [data-llamabot="thumb-down-btn"]:has(.fa-solid) {
+    opacity: 1;
 }
 
 [data-llamabot="tool-message"] {

--- a/app/langgraph.json
+++ b/app/langgraph.json
@@ -7,6 +7,7 @@
       "rails_ai_builder_agent": "./agents/leonardo/rails_ai_builder_agent/nodes.py:build_workflow",
       "rails_testing_agent": "./agents/leonardo/rails_testing_agent/nodes.py:build_workflow",
       "rails_ticket_mode_agent": "./agents/leonardo/rails_ticket_mode_agent/nodes.py:build_workflow",
+      "rails_ticket_plan_mode_agent": "./agents/leonardo/rails_ticket_plan_mode_agent/nodes.py:build_workflow",
       "rails_user_mode_agent": "./agents/leonardo/rails_user_mode_agent/nodes.py:build_workflow",
       "rails_beginner_agent": "./agents/leonardo/rails_beginner_agent/nodes.py:build_workflow",
       "rails_plan_mode_agent": "./agents/leonardo/rails_plan_mode_agent/nodes.py:build_workflow",

--- a/app/main.py
+++ b/app/main.py
@@ -124,6 +124,12 @@ app.state.async_checkpointer = None
 app.state.timestamp = datetime.now(timezone.utc)
 app.state.compiled_graphs = {}  # Cache for pre-compiled LangGraph workflows
 
+# Layer 2: background LangGraph runs survive socket drops; the live socket is a
+# subscriber that replays on reconnect. Shared across all connections. See
+# app/websocket/run_manager.py and docs/dev/websocket_background_runs.md.
+from app.websocket.run_manager import RunManager
+app.state.run_manager = RunManager()
+
 # Mothership integration for lease management
 app.state.mothership_client = MothershipClient()
 app.state.lease_manager = LeaseManager(app, app.state.mothership_client)

--- a/app/routers/api.py
+++ b/app/routers/api.py
@@ -761,6 +761,45 @@ async def update_activity(request: Request, username: str = Depends(auth)):
     return {"timestamp": request.app.state.timestamp.isoformat()}
 
 
+class FeedbackRequest(BaseModel):
+    thread_id: str
+    rating: str
+    scope: str = "message"
+    note: str | None = None
+    content: str | None = None
+    sent_at: str | None = None
+
+
+@router.post("/api/feedback", response_class=JSONResponse)
+async def api_submit_feedback(request: Request, body: FeedbackRequest, username: str = Depends(auth)):
+    """
+    Forward an end-user 👍/👎 to the mothership.
+
+    Thin same-origin passthrough (the browser is already authed to this box),
+    mirroring /api/update-activity. Best-effort: a reporting hiccup must never
+    500 the browser, so any failure returns {"success": False}.
+    """
+    if body.rating not in ("good", "bad"):
+        return {"success": False, "error": "rating must be 'good' or 'bad'"}
+
+    mothership = getattr(request.app.state, "mothership_client", None)
+    if mothership is None:
+        from app.services.mothership_client import MothershipClient
+        mothership = MothershipClient()
+    if not mothership.enabled:
+        return {"success": False, "reason": "mothership_not_configured"}
+
+    result = await mothership.submit_feedback(
+        thread_id=body.thread_id,
+        rating=body.rating,
+        scope=body.scope,
+        note=body.note,
+        content=body.content,
+        sent_at=body.sent_at,
+    )
+    return {"success": bool(result and result.get("success"))}
+
+
 @router.get("/api/lease-status", response_class=JSONResponse)
 async def get_lease_status(request: Request):
     """Debug endpoint: show lease manager status."""

--- a/app/services/mothership_client.py
+++ b/app/services/mothership_client.py
@@ -148,6 +148,62 @@ class MothershipClient:
             logger.warning(f"Message report unexpected error: {e}")
             return None
 
+    async def submit_feedback(
+        self,
+        *,
+        thread_id: str,
+        rating: str,
+        scope: str = "message",
+        note: Optional[str] = None,
+        content: Optional[str] = None,
+        sent_at: Optional[str] = None,
+    ) -> Optional[dict]:
+        """
+        POST /api/leonardo/submit_feedback
+
+        End-user 👍/👎 on a single AI message (scope="message") or the whole
+        session (scope="session"). Lands on the mothership as an
+        InstanceMessageAnnotation tagged source="end_user".
+
+        Best-effort, exactly like report_message: never raises, returns None on
+        any failure so a reporting hiccup never blocks the chat.
+        """
+        if not self.enabled:
+            return None
+
+        try:
+            async with httpx.AsyncClient(timeout=5.0) as client:
+                payload = {
+                    "instance_name": self.config["instance_name"],
+                    "thread_id": thread_id,
+                    "rating": rating,
+                    "scope": scope,
+                }
+                if note:
+                    payload["note"] = note
+                if content:
+                    payload["content"] = content
+                if sent_at:
+                    payload["sent_at"] = sent_at
+                response = await client.post(
+                    f"{self.config['mothership_url']}/api/leonardo/submit_feedback",
+                    json=payload,
+                    headers={"Authorization": f"Bearer {self.config['mothership_api_token']}"},
+                )
+                response.raise_for_status()
+                body = response.json()
+                logger.info(f"submit_feedback response (scope={scope}, rating={rating}): {body}")
+                return body
+        except httpx.HTTPStatusError as e:
+            logger.warning(f"submit_feedback failed (HTTP {e.response.status_code}): {e.response.text}")
+            return None
+        except httpx.RequestError as e:
+            logger.warning(f"submit_feedback request failed: {e}")
+            return None
+        except Exception as e:
+            logger.warning(f"submit_feedback unexpected error: {e}")
+            return None
+
     async def check_paywall(self) -> Optional[dict]:
         """
         POST /api/leonardo/check_paywall

--- a/app/tests/test_message_deduplicator.py
+++ b/app/tests/test_message_deduplicator.py
@@ -1,0 +1,56 @@
+"""Tests for the WebSocket idempotency guard (Layer 1 seatbelt).
+
+Reproduces the 0.5.3a duplicate-restart bug: a reconnect re-sends the same chat
+message and the backend must NOT process it twice.
+"""
+from app.websocket.message_deduplicator import MessageDeduplicator
+
+
+def test_first_message_is_new():
+    d = MessageDeduplicator()
+    assert d.register("t1", "abc") is True
+
+
+def test_duplicate_same_thread_and_id_is_rejected():
+    d = MessageDeduplicator()
+    assert d.register("t1", "abc") is True
+    assert d.register("t1", "abc") is False
+    assert d.register("t1", "abc") is False
+
+
+def test_same_id_different_thread_is_new():
+    """Idempotency is scoped per thread; the same id on another thread is new."""
+    d = MessageDeduplicator()
+    assert d.register("t1", "abc") is True
+    assert d.register("t2", "abc") is True
+
+
+def test_missing_client_message_id_always_new():
+    """Legacy clients / Rails gem (no client_message_id) opt out of the guard."""
+    d = MessageDeduplicator()
+    assert d.register("t1", None) is True
+    assert d.register("t1", None) is True
+    assert d.register("t1", "") is True
+
+
+def test_thread_id_coerced_so_int_and_str_match():
+    """thread_id arrives as a string over the wire; coercion keeps keys stable."""
+    d = MessageDeduplicator()
+    assert d.register(123, "abc") is True
+    assert d.register("123", "abc") is False
+
+
+def test_eviction_bounds_memory():
+    d = MessageDeduplicator(max_entries=2)
+    assert d.register("t", "a") is True
+    assert d.register("t", "b") is True
+    assert d.register("t", "c") is True  # evicts oldest ("a")
+    assert d.register("t", "a") is True  # "a" looks new again after eviction
+    assert d.register("t", "c") is False  # "c" still remembered
+
+
+def test_seen_does_not_record():
+    d = MessageDeduplicator()
+    assert d.seen("t1", "abc") is False
+    assert d.register("t1", "abc") is True
+    assert d.seen("t1", "abc") is True

--- a/app/tests/test_orphaned_toolcall_repair_all_agents.py
+++ b/app/tests/test_orphaned_toolcall_repair_all_agents.py
@@ -1,0 +1,196 @@
+"""Backstop tests for orphaned-tool-call repair across ALL Leonardo agents.
+
+SupportIncident #112: `RepairOrphanedToolCallsMiddleware` was wired into
+`rails_agent` ONLY. Every other agent graph was unprotected, so an
+interrupted/crashed tool call (e.g. answering an `ask_user_question` interrupt
+with plain chat in Plan mode) left an `AIMessage` with `tool_calls` and no
+matching `ToolMessage` — and every later turn hit a hard
+`400 insufficient tool messages`.
+
+These tests assert three things:
+1. The pure repair function does the right thing (behavior).
+2. `build_leonardo_agent` always prepends the repair middleware (the create_agent path).
+3. STRUCTURAL backstop: every Leonardo agent `nodes.py` is wired for repair — so a
+   NEW agent added later that forgets the wiring fails the suite. This is the real
+   guarantee (it catches the whole class), and it's intentionally a static scan so
+   it doesn't have to build graphs (build_workflow() clears the asyncio loop — see
+   the team's CI memo on that landmine).
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+
+from app.agents.leonardo.agent_factory import (
+    RepairOrphanedToolCallsMiddleware,
+    build_leonardo_agent,
+    repair_orphaned_tool_calls_in_messages,
+)
+
+LEONARDO_DIR = Path(__file__).resolve().parents[1] / "agents" / "leonardo"
+
+# Leonardo graphs registered in app/langgraph.json (llamabot/llamapress are a
+# different agent/prompt mechanism and intentionally out of scope for SI#112).
+LEONARDO_GRAPH_KEYS = [
+    "rails_agent",
+    "rails_ai_builder_agent",
+    "rails_testing_agent",
+    "rails_ticket_mode_agent",
+    "rails_ticket_plan_mode_agent",
+    "rails_user_mode_agent",
+    "rails_beginner_agent",
+    "rails_plan_mode_agent",
+    "rails_engineer_plan_mode_agent",
+    "pyxl_agent",
+]
+
+
+def _orphan_history():
+    """An AIMessage with a tool_call and no following ToolMessage — the exact
+    shape that 400s the provider on the next turn."""
+    return [
+        HumanMessage(content="please run the migration"),
+        AIMessage(
+            content="",
+            tool_calls=[{"id": "call_1", "name": "bash_command", "args": {}}],
+        ),
+    ]
+
+
+# --------------------------------------------------------------------------
+# 1. Pure repair function behaviour
+# --------------------------------------------------------------------------
+
+def test_repair_injects_placeholder_for_orphan():
+    msgs = _orphan_history()
+    out = repair_orphaned_tool_calls_in_messages(msgs)
+
+    assert out is not msgs  # changed -> new list
+    tool_msgs = [m for m in out if isinstance(m, ToolMessage)]
+    assert len(tool_msgs) == 1
+    assert tool_msgs[0].tool_call_id == "call_1"
+
+    # placeholder lands immediately after the AIMessage that owns the tool_call
+    ai_idx = next(i for i, m in enumerate(out) if isinstance(m, AIMessage))
+    assert isinstance(out[ai_idx + 1], ToolMessage)
+
+
+def test_repair_is_noop_when_tool_call_already_answered():
+    msgs = [
+        AIMessage(content="", tool_calls=[{"id": "call_1", "name": "x", "args": {}}]),
+        ToolMessage(content="done", tool_call_id="call_1"),
+    ]
+    out = repair_orphaned_tool_calls_in_messages(msgs)
+    assert out is msgs  # unchanged -> same object (idempotent / cheap no-op signal)
+
+
+def test_repair_handles_multiple_orphans_in_one_message():
+    msgs = [
+        AIMessage(
+            content="",
+            tool_calls=[
+                {"id": "a", "name": "x", "args": {}},
+                {"id": "b", "name": "y", "args": {}},
+            ],
+        ),
+    ]
+    out = repair_orphaned_tool_calls_in_messages(msgs)
+    ids = {m.tool_call_id for m in out if isinstance(m, ToolMessage)}
+    assert ids == {"a", "b"}
+
+
+def test_repair_noop_without_tool_calls():
+    msgs = [HumanMessage(content="hi"), AIMessage(content="hello")]
+    assert repair_orphaned_tool_calls_in_messages(msgs) is msgs
+
+
+# --------------------------------------------------------------------------
+# 2. Middleware + factory wiring
+# --------------------------------------------------------------------------
+
+class _FakeRequest:
+    def __init__(self, messages):
+        self.messages = messages
+        self.overridden = None
+
+    def override(self, messages):
+        self.overridden = messages
+        return self
+
+
+def test_middleware_repairs_via_wrap_model_call():
+    mw = RepairOrphanedToolCallsMiddleware()
+    req = _FakeRequest(_orphan_history())
+    mw.wrap_model_call(req, lambda r: "ok")
+    assert req.overridden is not None
+    assert any(isinstance(m, ToolMessage) for m in req.overridden)
+
+
+def test_factory_prepends_repair_when_absent(monkeypatch):
+    import app.agents.leonardo.agent_factory as af
+    captured = {}
+    monkeypatch.setattr(af, "create_agent", lambda **kw: captured.update(kw) or "AGENT")
+
+    af.build_leonardo_agent(model="m", tools=[])
+    mw = captured["middleware"]
+    assert isinstance(mw[0], af.RepairOrphanedToolCallsMiddleware)  # PREPENDED, first
+
+
+def test_factory_is_idempotent_when_repair_already_present(monkeypatch):
+    import app.agents.leonardo.agent_factory as af
+    captured = {}
+    monkeypatch.setattr(af, "create_agent", lambda **kw: captured.update(kw) or "AGENT")
+
+    existing = af.RepairOrphanedToolCallsMiddleware()
+    af.build_leonardo_agent(model="m", tools=[], middleware=[existing, "other"])
+    mw = captured["middleware"]
+    assert sum(isinstance(m, af.RepairOrphanedToolCallsMiddleware) for m in mw) == 1
+    assert mw[0] is existing  # not duplicated; original order preserved
+
+
+# --------------------------------------------------------------------------
+# 3. Structural backstop — every Leonardo agent must be wired for repair
+# --------------------------------------------------------------------------
+
+def _agent_nodes_files():
+    return sorted(LEONARDO_DIR.glob("*/nodes.py"))
+
+
+@pytest.mark.parametrize(
+    "nodes_file", _agent_nodes_files(), ids=lambda p: p.parent.name
+)
+def test_every_leonardo_agent_is_wired_for_repair(nodes_file):
+    """A new agent that forgets the cross-cutting repair wiring fails here."""
+    text = nodes_file.read_text()
+
+    uses_factory = "build_leonardo_agent(" in text
+    uses_raw_create_agent = bool(re.search(r"\bcreate_agent\(", text))
+    uses_stategraph = "StateGraph(" in text and ".invoke(" in text
+
+    if not (uses_factory or uses_raw_create_agent or uses_stategraph):
+        pytest.skip(f"{nodes_file.parent.name} does not construct an agent")
+
+    # create_agent path: must go through the factory (which prepends repair).
+    if uses_factory:
+        return
+    if uses_raw_create_agent:
+        pytest.fail(
+            f"{nodes_file.parent.name} calls create_agent() directly — use "
+            f"build_leonardo_agent() so orphaned tool calls are repaired (SI#112)."
+        )
+
+    # raw StateGraph path: must call the pure repair fn before .invoke().
+    assert "repair_orphaned_tool_calls_in_messages" in text, (
+        f"{nodes_file.parent.name} is a raw StateGraph agent but never calls "
+        f"repair_orphaned_tool_calls_in_messages() before .invoke() (SI#112)."
+    )
+
+
+def test_scan_covers_all_registered_leonardo_graphs():
+    """Guards the scan above: every graph in langgraph.json has a nodes.py the
+    parametrized test actually visited."""
+    present = {p.parent.name for p in _agent_nodes_files()}
+    missing = [k for k in LEONARDO_GRAPH_KEYS if k not in present]
+    assert not missing, f"registered Leonardo graphs missing a nodes.py: {missing}"

--- a/app/tests/test_run_manager.py
+++ b/app/tests/test_run_manager.py
@@ -1,0 +1,254 @@
+"""Tests for Layer 2: background runs + reconnect replay.
+
+Core guarantees:
+- A run keeps going after its socket detaches (the build doesn't die on disconnect).
+- Output is logged with monotonic seq and replayable via since(last_seq).
+- A reconnecting subscriber replays missed messages, then live-tails.
+- A new message supersedes (cancels) the prior run for the same thread.
+"""
+import asyncio
+import pytest
+from starlette.websockets import WebSocketState
+
+from app.websocket.run_manager import (
+    ThreadOutputLog,
+    RunHandle,
+    RunSink,
+    RunManager,
+)
+
+
+class FakeWS:
+    """Minimal websocket double: records send_json payloads; state is toggleable."""
+
+    def __init__(self):
+        self.sent = []
+        self.client_state = WebSocketState.CONNECTED
+
+    async def send_json(self, msg):
+        if self.client_state != WebSocketState.CONNECTED:
+            raise RuntimeError("socket closed")
+        self.sent.append(msg)
+
+    def close(self):
+        self.client_state = WebSocketState.DISCONNECTED
+
+
+# ---------------------------------------------------------------- ThreadOutputLog
+
+def test_log_assigns_monotonic_seq():
+    log = ThreadOutputLog()
+    a = log.append({"type": "ai", "content": "one"})
+    b = log.append({"type": "ai", "content": "two"})
+    assert a["seq"] == 1 and b["seq"] == 2
+    assert log.last_seq == 2
+
+
+def test_log_since_returns_only_newer():
+    log = ThreadOutputLog()
+    for i in range(5):
+        log.append({"type": "ai", "content": i})
+    got = log.since(3)
+    assert [e["seq"] for e in got] == [4, 5]
+
+
+def test_log_eviction_and_gap_detection():
+    log = ThreadOutputLog(maxlen=3)
+    for i in range(5):
+        log.append({"type": "ai", "content": i})  # seqs 1..5, only 3,4,5 retained
+    assert log.min_seq == 3
+    # Client last saw seq 1 → seq 2 was evicted → gap.
+    assert log.has_gap(1) is True
+    # Client last saw seq 4 → only seq 5 missing, still retained → no gap.
+    assert log.has_gap(4) is False
+
+
+# ----------------------------------------------------------------------- RunSink
+
+@pytest.mark.asyncio
+async def test_sink_logs_and_forwards_to_attached_socket():
+    ws = FakeWS()
+    handle = RunHandle("t1", ThreadOutputLog())
+    handle.attached_ws = ws
+    sink = RunSink(handle)
+
+    await sink.send_json({"type": "ai", "content": "hi"})
+
+    assert handle.log.last_seq == 1
+    assert ws.sent[0]["content"] == "hi"
+    assert ws.sent[0]["seq"] == 1  # forwarded copy carries the seq
+
+
+@pytest.mark.asyncio
+async def test_sink_logs_when_no_socket_attached():
+    handle = RunHandle("t1", ThreadOutputLog())
+    sink = RunSink(handle)  # attached_ws is None
+    await sink.send_json({"type": "ai", "content": "hi"})
+    assert handle.log.last_seq == 1  # logged for later replay
+
+
+@pytest.mark.asyncio
+async def test_sink_run_continues_when_forward_raises():
+    ws = FakeWS()
+    ws.close()  # send_json will raise
+    handle = RunHandle("t1", ThreadOutputLog())
+    handle.attached_ws = ws
+    sink = RunSink(handle)
+
+    # Must not raise — the run keeps going, message stays in the log.
+    await sink.send_json({"type": "ai", "content": "hi"})
+    assert handle.log.last_seq == 1
+
+
+@pytest.mark.asyncio
+async def test_sink_reports_connected_for_is_open_checks():
+    sink = RunSink(RunHandle("t1", ThreadOutputLog()))
+    assert sink.client_state == WebSocketState.CONNECTED
+
+
+# --------------------------------------------------------------------- RunManager
+
+@pytest.mark.asyncio
+async def test_run_continues_after_socket_detaches():
+    """The build keeps running and logging even after the browser drops."""
+    rm = RunManager()
+    ws = FakeWS()
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def factory(sink):
+        await sink.send_json({"type": "ai", "content": "chunk-1"})
+        started.set()
+        await release.wait()  # simulate a long-running build
+        await sink.send_json({"type": "ai", "content": "chunk-2"})
+        await sink.send_json({"type": "end"})
+
+    handle = await rm.start("t1", factory, websocket=ws)
+    await started.wait()
+    assert ws.sent[0]["content"] == "chunk-1"
+
+    # Browser drops mid-run.
+    ws.close()
+    rm.detach("t1", ws)
+
+    # The run finishes on its own.
+    release.set()
+    await handle.task
+
+    assert handle.log.status == "done"
+    # All three messages are in the log even though the socket was gone for 2 of them.
+    assert [e.get("content", e.get("type")) for e in handle.log.since(0)] == [
+        "chunk-1", "chunk-2", "end",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_reconnect_replays_missed_messages():
+    rm = RunManager()
+    ws1 = FakeWS()
+    release = asyncio.Event()
+    mid = asyncio.Event()
+
+    async def factory(sink):
+        await sink.send_json({"type": "ai", "content": "c1"})
+        mid.set()
+        await release.wait()
+        await sink.send_json({"type": "ai", "content": "c2"})
+
+    handle = await rm.start("t1", factory, websocket=ws1)
+    await mid.wait()
+    ws1.close()
+    rm.detach("t1", ws1)
+
+    # Reconnect: new socket attaches, replays everything after last_seq=1.
+    ws2 = FakeWS()
+    h = rm.attach("t1", ws2)
+    assert h is handle
+    missed = handle.log.since(1)
+    assert missed == []  # nothing emitted after seq 1 yet
+
+    # Now the run emits c2 — it live-tails to ws2.
+    release.set()
+    await handle.task
+    assert ws2.sent[-1]["content"] == "c2"
+
+
+@pytest.mark.asyncio
+async def test_new_message_supersedes_prior_run():
+    rm = RunManager()
+    cancelled = asyncio.Event()
+    started = asyncio.Event()
+
+    async def long_run(sink):
+        started.set()
+        try:
+            await asyncio.sleep(10)
+        except asyncio.CancelledError:
+            cancelled.set()
+            raise
+
+    await rm.start("t1", long_run)
+    await started.wait()
+
+    async def quick(sink):
+        await sink.send_json({"type": "ai", "content": "new"})
+
+    # Starting a new run for the same thread cancels the old one first.
+    handle = await rm.start("t1", quick)
+    await handle.task
+    assert cancelled.is_set()
+    assert handle.log.status == "done"
+    # seq is monotonic across the supersede (log reused).
+    assert handle.log.last_seq >= 1
+
+
+@pytest.mark.asyncio
+async def test_explicit_cancel_stops_run():
+    rm = RunManager()
+    started = asyncio.Event()
+
+    async def long_run(sink):
+        started.set()
+        await asyncio.sleep(10)
+
+    await rm.start("t1", long_run)
+    await started.wait()
+    assert await rm.cancel("t1") is True
+    assert rm.get("t1").log.status == "cancelled"
+    # Cancelling an already-finished/absent run is a no-op.
+    assert await rm.cancel("nonexistent") is False
+
+
+@pytest.mark.asyncio
+async def test_detach_does_not_cancel():
+    rm = RunManager()
+    ws = FakeWS()
+    started = asyncio.Event()
+
+    async def run(sink):
+        started.set()
+        await asyncio.sleep(0.05)
+        await sink.send_json({"type": "end"})
+
+    handle = await rm.start("t1", run, websocket=ws)
+    await started.wait()
+    rm.detach("t1", ws)  # disconnect
+    await handle.task
+    assert handle.log.status == "done"  # ran to completion despite detach
+
+
+@pytest.mark.asyncio
+async def test_finished_runs_evicted_under_pressure_running_kept():
+    rm = RunManager(max_threads=2)
+
+    async def quick(sink):
+        await sink.send_json({"type": "end"})
+
+    h1 = await rm.start("t1", quick)
+    await h1.task
+    h2 = await rm.start("t2", quick)
+    await h2.task
+    # Third finished run should evict an older finished one, staying within bound.
+    h3 = await rm.start("t3", quick)
+    await h3.task
+    assert len(rm._runs) <= 2

--- a/app/tests/test_submit_feedback.py
+++ b/app/tests/test_submit_feedback.py
@@ -1,0 +1,159 @@
+"""
+Unit tests for MothershipClient.submit_feedback — end-user 👍/👎 reporting.
+
+Mirrors the report_message contract: POST to /api/leonardo/submit_feedback with a
+Bearer token, never raises, returns None on any failure.
+"""
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+import httpx
+
+from app.services.mothership_client import MothershipClient
+
+
+FAKE_CONFIG = {
+    "instance_name": "test-instance",
+    "mothership_url": "https://mothership.example.com",
+    "mothership_api_token": "tok-test",
+    "lease_duration_seconds": 300,
+}
+
+
+def _make_client() -> MothershipClient:
+    client = MothershipClient.__new__(MothershipClient)
+    client.config = FAKE_CONFIG
+    return client
+
+
+def _mock_response(status=200, body=None):
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = status
+    resp.json.return_value = body or {}
+    resp.raise_for_status = MagicMock()
+    return resp
+
+
+def _mock_http(post_side_effect):
+    mock_http = MagicMock()
+    mock_http.__aenter__ = AsyncMock(return_value=mock_http)
+    mock_http.__aexit__ = AsyncMock(return_value=False)
+    mock_http.post = AsyncMock(side_effect=post_side_effect)
+    return mock_http
+
+
+@pytest.mark.asyncio
+async def test_submit_feedback_message_scope_payload_and_headers():
+    """scope=message: correct URL, Bearer header, and required body fields."""
+    client = _make_client()
+    captured = {}
+
+    async def fake_post(url, *, json, headers):
+        captured["url"] = url
+        captured["payload"] = json
+        captured["headers"] = headers
+        return _mock_response(body={"success": True, "annotation_id": 1, "message_id": 2})
+
+    with patch("app.services.mothership_client.httpx.AsyncClient", return_value=_mock_http(fake_post)):
+        result = await client.submit_feedback(
+            thread_id="thread-abc",
+            rating="bad",
+            scope="message",
+            note="this was wrong",
+            content="raw markdown of the message",
+            sent_at="2026-06-29T00:00:00+00:00",
+        )
+
+    assert result == {"success": True, "annotation_id": 1, "message_id": 2}
+    assert captured["url"] == "https://mothership.example.com/api/leonardo/submit_feedback"
+    assert captured["headers"]["Authorization"] == "Bearer tok-test"
+    p = captured["payload"]
+    assert p["instance_name"] == "test-instance"
+    assert p["thread_id"] == "thread-abc"
+    assert p["rating"] == "bad"
+    assert p["scope"] == "message"
+    assert p["note"] == "this was wrong"
+    assert p["content"] == "raw markdown of the message"
+    assert p["sent_at"] == "2026-06-29T00:00:00+00:00"
+
+
+@pytest.mark.asyncio
+async def test_submit_feedback_session_scope_omits_optional_fields():
+    """scope=session with no note/content/sent_at: those keys are absent."""
+    client = _make_client()
+    captured = {}
+
+    async def fake_post(url, *, json, headers):
+        captured["payload"] = json
+        return _mock_response(body={"success": True})
+
+    with patch("app.services.mothership_client.httpx.AsyncClient", return_value=_mock_http(fake_post)):
+        await client.submit_feedback(thread_id="thread-xyz", rating="good", scope="session")
+
+    p = captured["payload"]
+    assert p["scope"] == "session"
+    assert p["rating"] == "good"
+    assert p["thread_id"] == "thread-xyz"
+    assert "note" not in p
+    assert "content" not in p
+    assert "sent_at" not in p
+
+
+@pytest.mark.asyncio
+async def test_submit_feedback_defaults_to_message_scope():
+    """scope defaults to 'message' when not provided."""
+    client = _make_client()
+    captured = {}
+
+    async def fake_post(url, *, json, headers):
+        captured["payload"] = json
+        return _mock_response(body={"success": True})
+
+    with patch("app.services.mothership_client.httpx.AsyncClient", return_value=_mock_http(fake_post)):
+        await client.submit_feedback(thread_id="t", rating="good")
+
+    assert captured["payload"]["scope"] == "message"
+
+
+@pytest.mark.asyncio
+async def test_submit_feedback_returns_none_on_http_error():
+    """An HTTP 500 must be swallowed → returns None, never raises."""
+    client = _make_client()
+
+    def raise_500():
+        raise httpx.HTTPStatusError(
+            "500", request=MagicMock(), response=MagicMock(status_code=500, text="boom")
+        )
+
+    async def fake_post(url, *, json, headers):
+        resp = _mock_response(status=500)
+        resp.raise_for_status = MagicMock(side_effect=raise_500)
+        return resp
+
+    with patch("app.services.mothership_client.httpx.AsyncClient", return_value=_mock_http(fake_post)):
+        result = await client.submit_feedback(thread_id="t", rating="bad")
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_submit_feedback_returns_none_on_network_error():
+    """A network error must be swallowed → returns None, never raises."""
+    client = _make_client()
+
+    async def fake_post(url, *, json, headers):
+        raise httpx.RequestError("connection refused", request=MagicMock())
+
+    with patch("app.services.mothership_client.httpx.AsyncClient", return_value=_mock_http(fake_post)):
+        result = await client.submit_feedback(thread_id="t", rating="good")
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_submit_feedback_disabled_client_returns_none():
+    """When mothership integration is disabled, submit_feedback is a no-op."""
+    client = MothershipClient.__new__(MothershipClient)
+    client.config = None  # disabled
+
+    result = await client.submit_feedback(thread_id="t", rating="good")
+    assert result is None

--- a/app/tests/test_ticket_plan_mode.py
+++ b/app/tests/test_ticket_plan_mode.py
@@ -1,0 +1,99 @@
+"""
+Tests for Ticket Plan Mode.
+
+Ticket Plan Mode is selected when Plan Mode is toggled ON while the user is in Ticket
+Mode. It grounds the user-feedback story by asking clarifying questions (one at a time,
+with live visual options for look-and-feel decisions) BEFORE running the normal Ticket
+Mode flow: delegated deep research -> write the ticket -> offer to auto-implement it.
+
+Structural assertions only — we never assert exact LLM output, and we never call
+build_workflow() in a unit test (it clears the asyncio event loop; see memory
+`ci_build_workflow_event_loop`). We assert registration, importability, prompt
+composition (DRY: the full Ticket Mode playbook is reused verbatim), tool wiring, and
+the frontend routing that selects this agent for ticket+plan.
+"""
+import json
+from pathlib import Path
+
+# app/langgraph.json is the runtime-authoritative graph registry (request_handler walks
+# up from app/websocket/ and finds this one first).
+LANGGRAPH_JSON = Path(__file__).resolve().parents[1] / "langgraph.json"
+FRONTEND = Path(__file__).resolve().parents[1] / "frontend" / "chat"
+
+AGENT_NAME = "rails_ticket_plan_mode_agent"
+
+
+class TestTicketPlanRegistration:
+    """The new agent is registered so it can actually route at runtime."""
+
+    def test_agent_in_langgraph_json(self):
+        graphs = json.loads(LANGGRAPH_JSON.read_text())["graphs"]
+        assert AGENT_NAME in graphs, f"{AGENT_NAME} must be registered in {LANGGRAPH_JSON}"
+        assert graphs[AGENT_NAME].endswith(
+            "rails_ticket_plan_mode_agent/nodes.py:build_workflow"
+        )
+
+    def test_module_importable_with_build_workflow(self):
+        # Import only — do NOT call build_workflow() (clears the asyncio loop).
+        from app.agents.leonardo.rails_ticket_plan_mode_agent import nodes
+
+        assert hasattr(nodes, "build_workflow")
+        assert callable(nodes.build_workflow)
+
+
+class TestTicketPlanComposition:
+    """Plan-first preamble + the full Ticket Mode playbook (DRY compose)."""
+
+    def test_prompt_composes_clarify_preamble_plus_ticket_playbook(self):
+        from app.agents.leonardo.rails_ticket_plan_mode_agent.prompts import (
+            TICKET_PLAN_MODE_AGENT_PROMPT,
+        )
+        from app.agents.leonardo.rails_ticket_mode_agent.prompts import (
+            TICKET_MODE_AGENT_PROMPT,
+        )
+
+        # Plan-first clarification preamble.
+        assert "Ticket Plan Mode" in TICKET_PLAN_MODE_AGENT_PROMPT
+        assert "PHASE 0" in TICKET_PLAN_MODE_AGENT_PROMPT
+        assert "ask_user_question" in TICKET_PLAN_MODE_AGENT_PROMPT
+        assert "ui_related" in TICKET_PLAN_MODE_AGENT_PROMPT
+        # Full Ticket Mode playbook is composed in verbatim (single source of truth):
+        # the research -> ticket -> offer flow is inherited, not re-described.
+        assert TICKET_MODE_AGENT_PROMPT in TICKET_PLAN_MODE_AGENT_PROMPT
+
+    def test_interaction_and_ticket_tools_are_wired(self):
+        from app.agents.leonardo.rails_ticket_plan_mode_agent.nodes import default_tools
+
+        tool_names = [t.name for t in default_tools]
+        # Plan-first grounding mechanism (reused verbatim from plan mode).
+        assert "ask_user_question" in tool_names
+        assert "ask_user_uiux_question" in tool_names
+        # Ticket flow preserved: research delegation, ticket creation, implement offer.
+        assert "delegate_task" in tool_names
+        assert "delegate_research" in tool_names
+        assert "write_final_ticket" in tool_names
+        assert "offer_implementation" in tool_names
+
+    def test_implementation_offer_guarantee_middleware_reused(self):
+        """The deterministic 'offer to implement' guarantee carries over from Ticket Mode."""
+        from app.agents.leonardo.rails_ticket_plan_mode_agent.middleware import (
+            ensure_implementation_offer,
+            inject_ticket_plan_mode_context,
+        )
+
+        assert ensure_implementation_offer is not None
+        assert inject_ticket_plan_mode_context is not None
+
+
+class TestTicketPlanRouting:
+    """Frontend selects this agent only when ticket+plan are both on."""
+
+    def test_config_maps_ticket_plan_mode(self):
+        config = (FRONTEND / "config.js").read_text()
+        assert "ticket_plan: 'rails_ticket_plan_mode_agent'" in config
+
+    def test_index_routes_ticket_to_ticket_plan_agent(self):
+        index = (FRONTEND / "index.js").read_text()
+        # Plan toggle in ticket mode must resolve to the ticket-plan agent,
+        # not silently drop to the generic plan agent.
+        assert "ticket: 'rails_ticket_plan_mode_agent'" in index

--- a/app/tests/test_websocket.py
+++ b/app/tests/test_websocket.py
@@ -245,6 +245,172 @@ class TestWebSocketDisconnectScenarios:
                 "Handler is looping on error instead of exiting gracefully."
 
 
+class TestWebSocketIdempotency:
+    """Reproduces the 0.5.3a duplicate-restart bug at the handler level."""
+
+    @pytest.mark.asyncio
+    async def test_resent_message_with_same_client_id_is_not_reprocessed(self):
+        """
+        Reproduces: a WebSocket drop causes the browser to re-send the same chat
+        message on reconnect. With no idempotency guard the backend cancels the
+        in-flight run and starts a brand-new one, restarting the agent from
+        scratch ("Let me start by reading...").
+
+        The identical message arrives twice (same client_message_id); the agent
+        run must be started exactly ONCE. The second arrival is a reconnect
+        resend and must be ignored.
+        """
+        from app.websocket.message_deduplicator import MessageDeduplicator
+
+        mock_websocket = AsyncMock()
+        mock_websocket.client_state = WebSocketState.CONNECTED
+        mock_manager = AsyncMock()
+        mock_manager.connect = AsyncMock()
+        mock_manager.disconnect = MagicMock()
+        mock_manager.send_personal_message = AsyncMock()
+        mock_manager.deduplicator = MessageDeduplicator()
+
+        payload = {
+            "message": "build me an app from this spreadsheet",
+            "thread_id": "thread-1",
+            "client_message_id": "msg-abc",
+        }
+        # Same message twice (reconnect resend), then disconnect to end the loop.
+        events = [dict(payload), dict(payload),
+                  WebSocketDisconnect(code=1000, reason="bye")]
+
+        async def fake_receive_json():
+            item = events.pop(0)
+            if isinstance(item, Exception):
+                raise item
+            return item
+
+        mock_websocket.receive_json = fake_receive_json
+        from app.websocket.run_manager import RunManager
+        mock_manager.app = MagicMock()
+        mock_manager.app.state.run_manager = RunManager()
+
+        handler = WebSocketHandler(mock_websocket, mock_manager)
+        handler.authenticated = True
+
+        # Patch start_chat_run (the background-run entry) so we assert the
+        # idempotency guard's decision directly, independent of run timing.
+        with patch.object(handler.request_handler, "start_chat_run",
+                          new=AsyncMock()) as mock_start, \
+             patch.object(handler.request_handler, "cleanup_connection",
+                          MagicMock()):
+            await handler.handle_websocket()
+
+        assert mock_start.call_count == 1, (
+            f"Expected one run to start, got {mock_start.call_count} — the "
+            f"resent message was reprocessed (no idempotency guard)."
+        )
+
+    @pytest.mark.asyncio
+    async def test_distinct_messages_both_start_a_run(self):
+        """Two genuinely different messages (distinct ids) must both pass the guard."""
+        from app.websocket.message_deduplicator import MessageDeduplicator
+
+        mock_websocket = AsyncMock()
+        mock_websocket.client_state = WebSocketState.CONNECTED
+        mock_manager = AsyncMock()
+        mock_manager.connect = AsyncMock()
+        mock_manager.disconnect = MagicMock()
+        mock_manager.send_personal_message = AsyncMock()
+        mock_manager.deduplicator = MessageDeduplicator()
+
+        events = [
+            {"message": "first", "thread_id": "t", "client_message_id": "id-1"},
+            {"message": "second", "thread_id": "t", "client_message_id": "id-2"},
+            WebSocketDisconnect(code=1000, reason="bye"),
+        ]
+
+        async def fake_receive_json():
+            item = events.pop(0)
+            if isinstance(item, Exception):
+                raise item
+            return item
+
+        mock_websocket.receive_json = fake_receive_json
+        from app.websocket.run_manager import RunManager
+        mock_manager.app = MagicMock()
+        mock_manager.app.state.run_manager = RunManager()
+
+        handler = WebSocketHandler(mock_websocket, mock_manager)
+        handler.authenticated = True
+
+        with patch.object(handler.request_handler, "start_chat_run",
+                          new=AsyncMock()) as mock_start, \
+             patch.object(handler.request_handler, "cleanup_connection",
+                          MagicMock()):
+            await handler.handle_websocket()
+
+        assert mock_start.call_count == 2
+
+
+class TestWebSocketLayer2Attach:
+    """Handler-level wiring for attach/replay (Layer 2 background runs)."""
+
+    def _make_handler(self):
+        from app.websocket.run_manager import RunManager
+        mock_websocket = AsyncMock()
+        mock_websocket.client_state = WebSocketState.CONNECTED
+        mock_manager = AsyncMock()
+        mock_manager.app = MagicMock()
+        mock_manager.app.state.run_manager = RunManager()
+        mock_manager.send_personal_message = AsyncMock()
+        handler = WebSocketHandler(mock_websocket, mock_manager)
+        handler.authenticated = True
+        return handler, mock_manager
+
+    @pytest.mark.asyncio
+    async def test_attach_replays_missed_messages_then_attached(self):
+        from app.websocket.run_manager import RunHandle, ThreadOutputLog
+        handler, mock_manager = self._make_handler()
+        rm = mock_manager.app.state.run_manager
+
+        handle = RunHandle("t1", ThreadOutputLog())
+        for i in range(3):
+            handle.log.append({"type": "ai", "content": f"c{i}"})  # seqs 1,2,3
+        rm._runs["t1"] = handle
+
+        await handler._handle_attach({"thread_id": "t1", "last_seq": 1})
+
+        sent = [c.args[0] for c in mock_manager.send_personal_message.call_args_list]
+        # Replays seq 2 and 3 (not seq 1), then an "attached" control frame.
+        assert [m.get("seq") for m in sent[:2]] == [2, 3]
+        assert sent[-1]["type"] == "attached"
+        assert sent[-1]["status"] == "running"
+        assert sent[-1]["last_seq"] == 3
+        # The socket is now the live subscriber.
+        assert handle.attached_ws is handler.websocket
+
+    @pytest.mark.asyncio
+    async def test_attach_no_active_run(self):
+        handler, mock_manager = self._make_handler()
+        await handler._handle_attach({"thread_id": "ghost", "last_seq": 0})
+        sent = [c.args[0] for c in mock_manager.send_personal_message.call_args_list]
+        assert sent[-1]["type"] == "no_active_run"
+
+    @pytest.mark.asyncio
+    async def test_attach_signals_gap_when_window_evicted(self):
+        from app.websocket.run_manager import RunHandle, ThreadOutputLog
+        handler, mock_manager = self._make_handler()
+        rm = mock_manager.app.state.run_manager
+
+        handle = RunHandle("t1", ThreadOutputLog(maxlen=2))
+        for i in range(5):
+            handle.log.append({"type": "ai", "content": i})  # only seqs 4,5 retained
+        rm._runs["t1"] = handle
+
+        # Client last saw seq 1 → 2,3 evicted → gap, must reload from checkpoint.
+        await handler._handle_attach({"thread_id": "t1", "last_seq": 1})
+        sent = [c.args[0] for c in mock_manager.send_personal_message.call_args_list]
+        assert any(m["type"] == "replay_gap" for m in sent)
+        # No raw message entries were replayed (only control frames).
+        assert all(m.get("type") in ("replay_gap", "attached") for m in sent)
+
+
 class TestWebSocketIntegration:
     """Integration tests for WebSocket functionality."""
     

--- a/app/websocket/message_deduplicator.py
+++ b/app/websocket/message_deduplicator.py
@@ -1,0 +1,72 @@
+"""Idempotency guard for inbound WebSocket chat messages.
+
+A dropped WebSocket connection can cause the browser to re-send a chat message
+it had already delivered (see the resend-on-reconnect logic in
+``app/frontend/chat/index.js``). Without a guard the backend treats that re-send
+as a brand-new turn: it cancels the in-flight run, appends a duplicate
+HumanMessage to the thread, and restarts the agent from scratch — producing the
+"Let me start by reading..." restart loop reported in 0.5.3a.
+
+This registry enforces the invariant:
+
+    A user message may be retried, but it may not be processed twice.
+
+Keyed by ``(thread_id, client_message_id)``. Messages without a
+``client_message_id`` (older browser builds, the Rails gem) are always treated
+as new — they opt out of the guard rather than being blocked, so legacy clients
+keep working unchanged.
+
+This is the Layer 1 "seatbelt": an in-memory guard shared across connections via
+the app-level :class:`WebSocketConnectionManager`, so a reconnect (which creates
+a fresh handler) still sees messages registered by the previous connection. It
+is intentionally process-local and not durable across restarts — durable replay
+is Layer 2 (see docs/dev/websocket_background_runs.md).
+"""
+from collections import OrderedDict
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class MessageDeduplicator:
+    """Tracks recently-seen ``(thread_id, client_message_id)`` pairs (LRU-bounded)."""
+
+    def __init__(self, max_entries: int = 2048):
+        self._max_entries = max_entries
+        # Insertion-ordered; oldest evicted first once we exceed max_entries.
+        self._seen: "OrderedDict[tuple, bool]" = OrderedDict()
+
+    def register(self, thread_id, client_message_id) -> bool:
+        """Record a message and report whether it is new.
+
+        Returns ``True`` if this ``(thread_id, client_message_id)`` has not been
+        seen before — the caller should process it. Returns ``False`` if it is a
+        duplicate re-send — the caller should ignore it (do NOT cancel the
+        in-flight run or append the message again).
+
+        Messages with a falsy ``client_message_id`` are always reported new and
+        are never recorded, so clients that don't send the key are unaffected.
+        """
+        if not client_message_id:
+            return True
+
+        key = (str(thread_id), str(client_message_id))
+        if key in self._seen:
+            # Refresh recency so a long-lived hot key isn't evicted mid-use.
+            self._seen.move_to_end(key)
+            logger.info(
+                f"Duplicate WebSocket message ignored (thread={thread_id}, "
+                f"client_message_id={client_message_id})"
+            )
+            return False
+
+        self._seen[key] = True
+        while len(self._seen) > self._max_entries:
+            self._seen.popitem(last=False)
+        return True
+
+    def seen(self, thread_id, client_message_id) -> bool:
+        """Read-only check (no recording). Used by tests/introspection."""
+        if not client_message_id:
+            return False
+        return (str(thread_id), str(client_message_id)) in self._seen

--- a/app/websocket/request_handler.py
+++ b/app/websocket/request_handler.py
@@ -73,12 +73,55 @@ class RequestHandler:
         self.locks: Dict[int, Lock] = {}
         self.app = app
     
-    def _get_lock(self, websocket: WebSocket) -> Lock:
-        """Get or create a lock for a specific websocket connection"""
-        ws_id = id(websocket)
-        if ws_id not in self.locks:
-            self.locks[ws_id] = Lock()
-        return self.locks[ws_id]
+    def _get_lock(self, websocket) -> Lock:
+        """Get or create a lock for a run.
+
+        A background run is driven through a RunSink (which carries a
+        ``thread_id``), so key the lock by thread there — this serializes turns
+        for the same thread regardless of which connection drove them. For a raw
+        websocket (legacy / direct calls) fall back to per-connection keying.
+        """
+        thread_id = getattr(websocket, "thread_id", None)
+        key = ("thread", str(thread_id)) if thread_id is not None else id(websocket)
+        if key not in self.locks:
+            self.locks[key] = Lock()
+        return self.locks[key]
+
+    def _run_manager(self):
+        """The shared app-level RunManager (lazily created)."""
+        rm = getattr(self.app.state, "run_manager", None)
+        if rm is None:
+            from app.websocket.run_manager import RunManager
+            rm = RunManager()
+            self.app.state.run_manager = rm
+        return rm
+
+    async def start_chat_run(self, message: dict, websocket: WebSocket):
+        """Start a chat turn as a background run, decoupled from the live socket.
+
+        The run is owned by the per-thread RunManager, not the connection, so it
+        survives a disconnect; the socket is attached as a live subscriber. A new
+        message for the same thread supersedes (cancels) the prior run.
+        """
+        thread_id = str(message.get("thread_id"))
+
+        async def factory(sink):
+            await self.handle_request(message, sink)
+
+        await self._run_manager().start(thread_id, factory, websocket)
+
+    async def start_resume_run(self, response_message: dict, websocket: WebSocket, kind: str):
+        """Resume after an approval/question answer as a background run."""
+        thread_id = str(response_message.get("thread_id"))
+
+        if kind == "approval":
+            async def factory(sink):
+                await self.handle_approval_response(response_message, sink)
+        else:
+            async def factory(sink):
+                await self.handle_question_response(response_message, sink)
+
+        await self._run_manager().start(thread_id, factory, websocket)
 
     def _is_websocket_open(self, websocket: WebSocket) -> bool:
         """Check if the WebSocket connection is still open"""
@@ -518,22 +561,13 @@ class RequestHandler:
 
                 async for chunk in app.astream(stream_input, config=config, stream_mode=["updates", "messages"], subgraphs=True):
 
-                    # If the WS died mid-stream (e.g., uvicorn keepalive ping
-                    # timeout), stop here. Continuing would let the graph keep
-                    # advancing through tool nodes and writing checkpoints with
-                    # no observer, producing orphan ToolMessages that corrupt
-                    # the thread.
-                    if not self._is_websocket_open(websocket):
-                        logger.warning(
-                            f"WS closed mid-stream for thread {incoming_message.get('thread_id')}; "
-                            f"aborting astream consumer."
-                        )
-                        if mothership is not None:
-                            asyncio.create_task(mothership.report_disconnect(
-                                thread_id=str(incoming_message.get("thread_id", "")),
-                                reason="ws_closed_mid_stream",
-                            ))
-                        break
+                    # Layer 2: this loop runs inside a background run (RunManager)
+                    # writing to a RunSink, NOT bound to the live socket. We do
+                    # NOT abort when the browser drops — the run is the observer
+                    # that drives the graph to completion (so no orphan
+                    # ToolMessages) and every chunk is logged for replay when the
+                    # client reconnects. `websocket` here is the sink, whose
+                    # client_state is always CONNECTED. See run_manager.py.
 
                     # NOTE: In LangGraph 0.5, they introduced this "subgraphs" parameter, that changes the datashape if you set it to True.
                     # if subgraph=True, it returns a tuple with 3 elements, instead of 2 elements.

--- a/app/websocket/run_manager.py
+++ b/app/websocket/run_manager.py
@@ -1,0 +1,245 @@
+"""Background LangGraph runs + reconnect replay (Layer 2).
+
+See docs/dev/websocket_background_runs.md for the full design. In short:
+
+- A chat turn (or a resume after approval/question) runs as a **background task
+  keyed by thread_id**, owned by the app-level :class:`RunManager` — NOT by the
+  WebSocket connection that started it. So when the browser drops, the build
+  keeps running.
+- Every message the run would have sent to the socket is written to a per-thread
+  :class:`ThreadOutputLog` (assigning a monotonic ``seq``) and *also* forwarded
+  to the currently-attached live socket, if any. The socket is a subscriber, not
+  the run's lifeline.
+- On reconnect the client sends ``{type:"attach", thread_id, last_seq}``; the
+  handler replays ``log.since(last_seq)`` then live-tails. The client dedupes by
+  ``seq`` so replay/live-tail overlap is harmless.
+
+The run writes through :class:`RunSink`, which deliberately mimics a Starlette
+WebSocket (``send_json`` + ``client_state``) so the existing streaming code in
+RequestHandler needs no per-send-site changes: ``_is_websocket_open(sink)`` is
+always True (the run never gates on a live socket), and ``sink.send_json(...)``
+logs + forwards.
+
+This is process-local (in-memory). It is NOT durable across a process restart —
+a client that reconnects after a restart gets ``no_active_run`` and falls back to
+loading thread history from the checkpointer. Durable (Redis/Postgres) replay is
+a later step; see the design doc.
+"""
+import asyncio
+from asyncio import CancelledError
+from collections import deque, OrderedDict
+import logging
+
+from starlette.websockets import WebSocketState
+
+logger = logging.getLogger(__name__)
+
+
+class ThreadOutputLog:
+    """Bounded, sequence-numbered log of the messages a run emitted for a thread.
+
+    ``seq`` is monotonic across turns for the lifetime of the handle, so a client
+    can carry a single ``last_seq`` across reconnects and even across turns.
+    """
+
+    def __init__(self, maxlen: int = 2000):
+        self._entries = deque(maxlen=maxlen)  # each entry is the stored msg dict (carries "seq")
+        self._seq = 0
+        # Run lifecycle as seen by subscribers: running -> done | error | cancelled.
+        self.status = "running"
+
+    def append(self, msg: dict) -> dict:
+        """Assign the next seq, store a copy carrying it, and return that copy."""
+        self._seq += 1
+        stored = {**msg, "seq": self._seq}
+        self._entries.append(stored)
+        return stored
+
+    @property
+    def last_seq(self) -> int:
+        return self._seq
+
+    @property
+    def min_seq(self) -> int:
+        """Lowest seq still retained (0 if empty). Below this, entries were evicted."""
+        return self._entries[0]["seq"] if self._entries else 0
+
+    def since(self, last_seq: int) -> list:
+        """Every retained entry with seq > last_seq, in order."""
+        return [e for e in self._entries if e["seq"] > last_seq]
+
+    def has_gap(self, last_seq: int) -> bool:
+        """True if the client is missing entries that have already been evicted.
+
+        The client wants everything after ``last_seq``. If the oldest entry we
+        still hold is newer than ``last_seq + 1``, the messages in between are
+        gone and replay would be incomplete — the client must reload from the
+        checkpointer instead.
+        """
+        if not self._entries:
+            return False
+        return self.min_seq > last_seq + 1
+
+
+class RunHandle:
+    """One thread's run: its task, its output log, and the live socket (if any)."""
+
+    def __init__(self, thread_id: str, log: ThreadOutputLog):
+        self.thread_id = thread_id
+        self.log = log
+        self.task = None          # asyncio.Task running the graph
+        self.attached_ws = None   # the currently-live subscriber socket, or None
+
+
+class RunSink:
+    """WebSocket-shaped sink: logs every send and forwards to the live socket.
+
+    Mimics enough of a Starlette WebSocket that RequestHandler's streaming code
+    works unchanged:
+    - ``client_state`` is always CONNECTED, so ``_is_websocket_open(sink)`` is
+      True and the run never skips a send or aborts mid-stream.
+    - ``send_json`` appends to the log (assigning a seq) then best-effort
+      forwards the stored copy to the attached socket. ``thread_id`` lets
+      RequestHandler key its per-thread lock off the sink.
+    """
+
+    def __init__(self, handle: RunHandle):
+        self._handle = handle
+        self.client_state = WebSocketState.CONNECTED
+        self.thread_id = handle.thread_id
+
+    async def send_json(self, msg: dict) -> None:
+        stored = self._handle.log.append(msg)
+        ws = self._handle.attached_ws
+        if ws is None:
+            return
+        try:
+            if getattr(ws, "client_state", None) == WebSocketState.CONNECTED:
+                await ws.send_json(stored)
+        except Exception as e:
+            # The live socket died mid-send; the run continues and the message is
+            # safe in the log for replay on the next attach.
+            logger.debug(f"RunSink forward failed (run continues): {e}")
+
+    async def send_text(self, text: str) -> None:
+        await self.send_json({"type": "text", "content": text})
+
+
+class RunManager:
+    """App-level registry of background runs, one per thread_id.
+
+    Shared across every WebSocket connection (lives on ``app.state``) so a
+    reconnect — which creates a fresh handler — can still find and attach to a
+    run started by the previous connection.
+    """
+
+    def __init__(self, log_maxlen: int = 2000, max_threads: int = 512):
+        self._runs: "OrderedDict[str, RunHandle]" = OrderedDict()
+        self._start_locks: dict = {}
+        self._log_maxlen = log_maxlen
+        self._max_threads = max_threads
+
+    def get(self, thread_id) -> RunHandle:
+        return self._runs.get(str(thread_id))
+
+    def _lock_for(self, thread_id: str) -> asyncio.Lock:
+        if thread_id not in self._start_locks:
+            self._start_locks[thread_id] = asyncio.Lock()
+        return self._start_locks[thread_id]
+
+    async def start(self, thread_id, run_factory, websocket=None) -> RunHandle:
+        """Start a background run for ``thread_id``, superseding any active one.
+
+        ``run_factory`` is ``async (sink) -> None`` — typically a closure over a
+        RequestHandler streaming method. A run already active for this thread is
+        cancelled first (a genuinely new message supersedes the old turn). The
+        output log is REUSED across turns so ``seq`` stays monotonic and a client
+        can attach with a single ``last_seq``.
+        """
+        thread_id = str(thread_id)
+        async with self._lock_for(thread_id):
+            existing = self._runs.get(thread_id)
+            if existing and existing.task and not existing.task.done():
+                existing.task.cancel()
+                try:
+                    await existing.task
+                except (CancelledError, Exception):
+                    pass
+
+            log = existing.log if existing else ThreadOutputLog(maxlen=self._log_maxlen)
+            log.status = "running"
+            handle = existing or RunHandle(thread_id, log)
+            handle.log = log
+            handle.attached_ws = websocket
+
+            sink = RunSink(handle)
+            handle.task = asyncio.create_task(self._wrap(handle, run_factory, sink))
+
+            self._runs[thread_id] = handle
+            self._runs.move_to_end(thread_id)
+            self._evict_finished_if_needed()
+            return handle
+
+    async def _wrap(self, handle: RunHandle, run_factory, sink: RunSink) -> None:
+        try:
+            await run_factory(sink)
+            handle.log.status = "done"
+        except CancelledError:
+            handle.log.status = "cancelled"
+            raise
+        except Exception:
+            handle.log.status = "error"
+            logger.exception(f"Background run failed for thread {handle.thread_id}")
+            # Swallow: the error message was already streamed to the sink by the
+            # run body's own except handler. Re-raising would only produce an
+            # unretrieved-task-exception warning.
+
+    def attach(self, thread_id, websocket) -> RunHandle:
+        """Mark ``websocket`` as the live subscriber for the thread's run.
+
+        Returns the RunHandle (so the caller can replay ``log.since(...)``), or
+        None if there is no run for this thread (client should reload history).
+        """
+        handle = self._runs.get(str(thread_id))
+        if handle is not None:
+            handle.attached_ws = websocket
+            self._runs.move_to_end(str(thread_id))
+        return handle
+
+    def detach(self, thread_id, websocket) -> None:
+        """Clear the live socket on disconnect WITHOUT cancelling the run."""
+        handle = self._runs.get(str(thread_id))
+        if handle is not None and handle.attached_ws is websocket:
+            handle.attached_ws = None
+
+    async def cancel(self, thread_id) -> bool:
+        """Explicitly cancel a thread's run (user pressed stop)."""
+        handle = self._runs.get(str(thread_id))
+        if handle is None or handle.task is None or handle.task.done():
+            return False
+        handle.task.cancel()
+        try:
+            await handle.task
+        except (CancelledError, Exception):
+            pass
+        return True
+
+    def active_tasks(self) -> list:
+        """All not-yet-finished run tasks (used for graceful shutdown / tests)."""
+        return [h.task for h in self._runs.values() if h.task and not h.task.done()]
+
+    def _evict_finished_if_needed(self) -> None:
+        """Bound memory: drop oldest FINISHED runs once we exceed max_threads.
+
+        Never evicts a still-running run. Replaces the design's TTL with a
+        simpler LRU bound (a reconnect to an evicted finished run gets
+        ``no_active_run`` and reloads history — same fallback as a gap).
+        """
+        while len(self._runs) > self._max_threads:
+            for tid, handle in list(self._runs.items()):
+                if handle.task is None or handle.task.done():
+                    del self._runs[tid]
+                    self._start_locks.pop(tid, None)
+                    break
+            else:
+                break  # nothing finished to evict; let it grow rather than kill a live run

--- a/app/websocket/web_socket_connection_manager.py
+++ b/app/websocket/web_socket_connection_manager.py
@@ -3,6 +3,9 @@ from starlette.websockets import WebSocketState
 import asyncio
 import logging
 from typing import Union
+
+from app.websocket.message_deduplicator import MessageDeduplicator
+
 logger = logging.getLogger(__name__)
 
 class WebSocketConnectionManager:
@@ -11,6 +14,10 @@ class WebSocketConnectionManager:
         self.active_connections: list[WebSocket] = []
         self.active_tasks: set = set()
         self._connection_ids: set = set()  # Track unique connections
+        # Shared across every connection so a reconnect (which creates a fresh
+        # handler) still recognizes a re-sent message registered by the previous
+        # connection. See message_deduplicator.py for the invariant.
+        self.deduplicator = MessageDeduplicator()
 
     def _is_websocket_open(self, websocket: WebSocket) -> bool:
         """Check if the WebSocket connection is still open"""

--- a/app/websocket/web_socket_handler.py
+++ b/app/websocket/web_socket_handler.py
@@ -33,6 +33,11 @@ class WebSocketHandler:
         self.authenticated = not WS_AUTH_REQUIRED  # Auto-auth if auth not required
         self.auth_user = None
 
+        # Threads this connection has driven/subscribed to. Background runs are
+        # owned by the app-level RunManager, not this connection — on disconnect
+        # we DETACH from these (so the run keeps going), we do not cancel them.
+        self._attached_threads: set = set()
+
     def _is_websocket_open(self, websocket: WebSocket) -> bool:
         """Check if the WebSocket connection is still open"""
         return websocket.client_state == WebSocketState.CONNECTED
@@ -95,10 +100,56 @@ class WebSocketHandler:
 
         return False
 
+    async def _handle_attach(self, json_data: dict) -> None:
+        """Resume a background run after (re)connect: replay missed output, then live-tail.
+
+        The client sends ``{type:"attach", thread_id, last_seq}`` with the
+        highest seq it has already rendered. We mark this socket as the run's
+        live subscriber and replay everything after ``last_seq``. If the missed
+        window was evicted (gap) or there's no run for the thread (finished long
+        ago / process restarted), we tell the client to reload thread history.
+        The client dedupes by seq, so any overlap between this replay and the
+        live tail is harmless.
+        """
+        thread_id = str(json_data.get("thread_id"))
+        try:
+            last_seq = int(json_data.get("last_seq") or 0)
+        except (TypeError, ValueError):
+            last_seq = 0
+
+        self._attached_threads.add(thread_id)
+        run_manager = self.request_handler._run_manager()
+        handle = run_manager.attach(thread_id, self.websocket)
+
+        if handle is None:
+            await self.manager.send_personal_message({
+                "type": "no_active_run",
+                "thread_id": thread_id,
+            }, self.websocket)
+            return
+
+        log = handle.log
+        if log.has_gap(last_seq):
+            # Missed messages were evicted — client must reload from checkpoint.
+            await self.manager.send_personal_message({
+                "type": "replay_gap",
+                "thread_id": thread_id,
+                "min_seq": log.min_seq,
+            }, self.websocket)
+        else:
+            for entry in log.since(last_seq):
+                await self.manager.send_personal_message(entry, self.websocket)
+
+        await self.manager.send_personal_message({
+            "type": "attached",
+            "thread_id": thread_id,
+            "status": log.status,
+            "last_seq": log.last_seq,
+        }, self.websocket)
+
     async def handle_websocket(self):
         logger.info(f"New WebSocket connection attempt from {self.websocket.client}")
         await self.manager.connect(self.websocket)
-        current_task = None
 
         # Track if we've sent an auth warning (only send once)
         auth_warning_sent = False
@@ -135,33 +186,47 @@ class WebSocketHandler:
                             break
                         continue
 
-                    # Handle cancel (always allowed)
+                    # Handle cancel (always allowed) — stop the background run(s)
+                    # for the target thread (explicit user "stop").
                     if isinstance(json_data, dict) and json_data.get("type") == "cancel":
                         logger.info("CANCEL RECV")
-                        if current_task and not current_task.done():
-                            current_task.cancel()
-                            # Only send if WebSocket is still open
-                            if self._is_websocket_open(self.websocket):
-                                await self.manager.send_personal_message({
-                                    "type": "system_message",
-                                    "content": "Previous task has been cancelled"
-                                }, self.websocket)
+                        run_manager = self.request_handler._run_manager()
+                        target = json_data.get("thread_id")
+                        targets = [str(target)] if target else list(self._attached_threads)
+                        cancelled_any = False
+                        for tid in targets:
+                            if await run_manager.cancel(tid):
+                                cancelled_any = True
+                        if cancelled_any and self._is_websocket_open(self.websocket):
+                            await self.manager.send_personal_message({
+                                "type": "system_message",
+                                "content": "Previous task has been cancelled"
+                            }, self.websocket)
+                        continue
+
+                    # Handle attach — a (re)connecting client resuming a background
+                    # run. Replays missed output then live-tails. See run_manager.py.
+                    if isinstance(json_data, dict) and json_data.get("type") == "attach":
+                        logger.info("ATTACH RECV")
+                        await self._handle_attach(json_data)
                         continue
 
                     # Handle approval response (user approved/rejected a HITL tool call)
                     if isinstance(json_data, dict) and json_data.get("type") == "approval_response":
                         logger.info("APPROVAL_RESPONSE RECV")
-                        current_task = asyncio.create_task(
-                            self.request_handler.handle_approval_response(json_data, self.websocket)
-                        )
+                        tid = json_data.get("thread_id")
+                        if tid:
+                            self._attached_threads.add(str(tid))
+                        await self.request_handler.start_resume_run(json_data, self.websocket, "approval")
                         continue
 
                     # Handle question response (user answered a plan mode question)
                     if isinstance(json_data, dict) and json_data.get("type") == "question_response":
                         logger.info("QUESTION_RESPONSE RECV")
-                        current_task = asyncio.create_task(
-                            self.request_handler.handle_question_response(json_data, self.websocket)
-                        )
+                        tid = json_data.get("thread_id")
+                        if tid:
+                            self._attached_threads.add(str(tid))
+                        await self.request_handler.start_resume_run(json_data, self.websocket, "question")
                         continue
 
                     # For all other messages, check authentication
@@ -183,23 +248,41 @@ class WebSocketHandler:
                                 logger.info(f"Unauthenticated WebSocket from {self.websocket.client} (auth not required)")
                                 auth_warning_sent = True
 
-                    # Cancel any in-flight task so the new message interrupts the agent.
-                    # Thread state corruption from mid-tool cancellation is repaired on the
-                    # next run by _repair_thread_state_if_needed in RequestHandler.
-                    if current_task and not current_task.done():
-                        logger.info("Cancelling previous task")
-                        current_task.cancel()
-                        try:
-                            await current_task
-                        except asyncio.CancelledError:
-                            logger.info("Previous task was cancelled successfully")
+                    # Idempotency guard (Layer 1 seatbelt): a dropped socket can
+                    # make the browser re-send a message it already delivered
+                    # (see resend-on-reconnect in frontend/chat/index.js). Without
+                    # this guard the re-send would cancel the in-flight run and
+                    # restart the agent from scratch. Recognize the duplicate by
+                    # (thread_id, client_message_id), ACK it, and ignore it.
+                    # Clients that don't send client_message_id (Rails gem, older
+                    # browsers) are always treated as new.
+                    client_message_id = json_data.get("client_message_id")
+                    thread_id = json_data.get("thread_id")
+                    is_new_message = self.manager.deduplicator.register(thread_id, client_message_id)
+                    if client_message_id and self._is_websocket_open(self.websocket):
+                        await self.manager.send_personal_message({
+                            "type": "ack",
+                            "client_message_id": client_message_id,
+                            "status": "accepted" if is_new_message else "duplicate",
+                        }, self.websocket)
+                    if not is_new_message:
+                        logger.info(
+                            f"Ignoring duplicate message {client_message_id} on thread "
+                            f"{thread_id} (idempotency guard); leaving in-flight run intact."
+                        )
+                        continue
 
                     message = ChatMessage(**json_data)
+                    if thread_id:
+                        self._attached_threads.add(str(thread_id))
 
                     logger.info(f"Received message: {message}")
-                    current_task = asyncio.create_task(
-                        self.request_handler.handle_request(message, self.websocket)
-                    )
+                    # Start the turn as a background run owned by the per-thread
+                    # RunManager (decoupled from this socket, which is attached as
+                    # a live subscriber). A new message supersedes any in-flight
+                    # run for the thread; that cancellation + thread-state repair
+                    # is handled inside RunManager / _repair_thread_state_if_needed.
+                    await self.request_handler.start_chat_run(message, self.websocket)
                 except WebSocketDisconnect as e:
                     if e.code == 1000:
                         logger.info(f"WebSocket connection closed gracefully by client: {e.reason}")
@@ -226,13 +309,13 @@ class WebSocketHandler:
                     "content": f"Error 253: {str(e)}"
                 }, self.websocket)
         finally:
-            if current_task and not current_task.done():
-                current_task.cancel()
-                try:
-                    logger.info("Cancelling current task")
-                    await current_task
-                except asyncio.CancelledError:
-                    logger.info("Current task was cancelled successfully")
-                    pass
+            # Detach from any background runs this connection subscribed to — but
+            # DO NOT cancel them. A dropped browser must not kill an in-progress
+            # build; the run keeps going and the client replays it on reconnect
+            # via `attach`. Explicit cancellation only happens on a `cancel`
+            # message or when a new message supersedes the run.
+            run_manager = self.request_handler._run_manager()
+            for tid in self._attached_threads:
+                run_manager.detach(tid, self.websocket)
             self.manager.disconnect(self.websocket)
             self.request_handler.cleanup_connection(self.websocket)

--- a/docs/dev/websocket_background_runs.md
+++ b/docs/dev/websocket_background_runs.md
@@ -1,0 +1,238 @@
+# Design: Background LangGraph runs + reconnect replay (Layer 2)
+
+**Status:** Implemented (v1, in-memory). See "As-built" at the bottom.
+**Author:** investigation for the 0.5.3a websocket bug
+**Depends on / follows:** Layer 1 idempotency seatbelt (shipped — see below)
+
+## Background: the two layers
+
+A user reported (via a ChatGPT incident transcript) that a long build — "upload
+spreadsheet → build an app" — kept restarting from scratch ("Let me start by
+reading…"), with the same bootstrap prompt appearing repeatedly in the
+transcript. Investigation traced this to a WebSocket reconnect re-firing the
+same message with no server-side idempotency, against a stream that is
+abandoned the moment the socket dies.
+
+We split the fix into two layers:
+
+- **Layer 1 — idempotency seatbelt (SHIPPED).** Stops the duplicate/restart
+  loop. Small, in-memory, no lifecycle change. Details at the bottom of this
+  doc.
+- **Layer 2 — background runs + replay (THIS DOC).** Decouples the agent run
+  from the live socket so a build keeps running when the browser drops, and a
+  reconnecting client replays what it missed. This is the real fix for "let it
+  keep running in the background."
+
+## Problem (Layer 2)
+
+Today the LangGraph `astream` consumer lives *inside* `RequestHandler.handle_request`,
+which is the per-socket asyncio task. Two consequences:
+
+1. **The run is bound to the socket.** `request_handler.py` breaks out of the
+   `astream` loop the instant `_is_websocket_open(websocket)` is false
+   (`request_handler.py` ~L526). The comment there is honest about why: with no
+   observer, continuing would let the graph advance through tool nodes and write
+   checkpoints that produce orphan ToolMessages. So the *abort-on-disconnect is a
+   workaround for the absence of a background observer* — not a feature we want.
+
+2. **A reconnect cannot resume an in-progress turn.** The LangGraph Postgres
+   checkpointer persists thread *state* (keyed by `thread_id`), so history
+   survives, but the interrupted assistant turn is neither finished nor
+   re-streamed. The only recovery is `_repair_thread_state_if_needed` on the
+   *next* user message — repair, not resume.
+
+What we want:
+
+> A run, once started, runs to completion regardless of the browser. The live
+> socket is a *subscriber* to the run's output, not its lifeline. On (re)connect
+> a client attaches to the running (or finished) run and replays anything it
+> missed.
+
+## Design
+
+### 1. Decouple the run from the socket
+
+Move the `astream` consumer out of `handle_request`'s socket-bound task into a
+**background run task** keyed by `thread_id`. The task:
+
+- drives the graph to completion (or to a HITL interrupt), regardless of socket
+  state — so the `_is_websocket_open` *abort* at `request_handler.py` ~L526 is
+  removed; the background task is now the observer that prevents orphan
+  ToolMessages.
+- writes every chunk it would have sent to the socket into a **per-thread output
+  buffer** (below) instead of (or in addition to) the live socket.
+
+A **run registry** maps `thread_id → RunHandle { task, last_seq, status }`.
+Starting a turn:
+
+- if no run is active for the thread → create one.
+- if a run is already active for the thread → this is the duplicate/resend case;
+  do **not** start a second run (Layer 1 already guards this by
+  `client_message_id`; the registry is the structural backstop).
+
+### 2. Per-thread output buffer with sequence numbers
+
+Each emitted chunk gets a monotonically increasing `seq` (per thread). The
+buffer is the "queue" the reconnecting client pulls from:
+
+```
+ThreadOutputLog(thread_id):
+    append(chunk) -> seq          # assigns next seq, stores (seq, chunk)
+    since(seq) -> list[(seq, chunk)]   # everything after the client's last seq
+    last_seq -> int
+```
+
+Two viable backings:
+
+- **In-memory ring buffer (start here).** Bounded (e.g. last N chunks or last
+  few MB per thread). Lost on process restart — acceptable for v1 because the
+  LangGraph checkpointer still holds the authoritative final state; a client
+  that reconnects after a restart falls back to "reload thread from checkpoint."
+- **Durable log (Redis stream / Postgres table).** Survives restarts and lets
+  multiple processes serve the same thread. Heavier; do this only if we need
+  cross-process or restart-durable replay. Redis Streams (`XADD`/`XRANGE`) map
+  almost 1:1 onto `append`/`since`.
+
+The live socket subscribes to the log: on each `append`, if a socket is attached
+for that thread, push the chunk immediately.
+
+### 3. Attach + replay on (re)connect
+
+Replace the frontend resend-on-reconnect with **attach + replay**:
+
+1. Client tracks the highest `seq` it has received for the active thread.
+2. On (re)connect, after auth, client sends
+   `{ type: "attach", thread_id, last_seq }`.
+3. Server: `log.since(last_seq)` → send the missed chunks in order, then
+   live-tail. If the run already finished, the client gets the tail and an
+   `end`. If the thread isn't in the registry (e.g. after a restart), server
+   tells the client to reload from the checkpointer.
+
+This removes the need to re-submit the user message at all — which is exactly
+what Layer 1's "don't resend an ACKed message" anticipates.
+
+### 4. Lifecycle / cleanup
+
+- A finished run stays in the registry + buffer for a short TTL so a slow
+  reconnect can still replay, then is GC'd.
+- Cancel semantics unchanged: an explicit `cancel` (or a genuinely new user
+  message that supersedes the turn) cancels the background task.
+- The existing `_repair_thread_state_if_needed` stays as a belt-and-suspenders
+  for any state that still ends up dangling.
+
+## Why this is tractable here
+
+- **State is already durable.** `AsyncPostgresSaver` keyed by `thread_id`
+  already persists conversation state across disconnects (`main.py` ~L180-215).
+  Layer 2 adds *run liveness* + *output replay*, not state persistence.
+- **It removes a hack rather than adding one.** The abort-on-disconnect exists
+  *because* there is no background observer. Adding the observer lets us delete
+  the abort.
+
+## Risks / open questions
+
+- **Backpressure:** a fast graph + slow/absent socket must not let the buffer
+  grow unbounded → bound the ring buffer and drop-oldest with a replay-gap
+  signal that tells the client to reload from checkpoint.
+- **Single-writer assumption:** one background task per thread. If two browser
+  tabs share a `thread_id`, both attach as subscribers to the same run — fine;
+  but two *new turns* racing on one thread must serialize (the existing per-socket
+  lock becomes a per-thread lock).
+- **Process restart:** in-memory buffer is lost; the client falls back to
+  checkpoint reload. Durable log removes this caveat at the cost of infra.
+- **Mothership reporting** (`report_message`) already happens inside the stream
+  loop; moving the loop to a background task keeps that intact and actually makes
+  it more reliable (no longer aborted mid-stream).
+
+## Phasing recommendation
+
+1. Run registry + background task + in-memory ring buffer + attach/replay
+   protocol; remove the `_is_websocket_open` abort.
+2. Frontend: replace resend-on-reconnect with attach + `last_seq` replay.
+3. (Optional, later) swap the in-memory buffer for a Redis stream for
+   restart-durable / multi-process replay.
+
+---
+
+## Appendix: Layer 1 idempotency seatbelt (shipped)
+
+The invariant: **a user message may be retried, but it may not be processed
+twice.** Implemented as:
+
+- `app/websocket/message_deduplicator.py` — `MessageDeduplicator`, an
+  LRU-bounded registry of seen `(thread_id, client_message_id)` pairs, held on
+  the app-level `WebSocketConnectionManager` so it survives reconnects (which
+  create a fresh handler).
+- `web_socket_handler.py` — before cancelling the in-flight task for a new chat
+  message, it registers `(thread_id, client_message_id)`. A duplicate is ACKed
+  with `status: "duplicate"` and **ignored** (the in-flight run is left intact);
+  a new message is ACKed with `status: "accepted"` and processed. Clients that
+  send no `client_message_id` (Rails gem, older browsers) are always treated as
+  new and are unaffected.
+- Frontend (`index.js`, `WebSocketManager.js`) — generates a
+  `client_message_id` per message (stable across resends), tracks server ACKs,
+  and only resends a message the server never ACKed. The backend guard is the
+  real protection; the frontend gate avoids the needless round-trip.
+
+Tests: `app/tests/test_message_deduplicator.py` and
+`TestWebSocketIdempotency` in `app/tests/test_websocket.py`.
+
+Layer 1 stops the duplicate/restart loop but does **not** resume a run whose
+socket dropped mid-stream — that run is still abandoned until the next message.
+Resuming it is the job of Layer 2 above.
+
+---
+
+## As-built (Layer 2 v1)
+
+Shipped implementation, in-memory:
+
+- `app/websocket/run_manager.py`
+  - `ThreadOutputLog` — bounded, seq-numbered log per thread; `since(last_seq)`
+    + `has_gap(last_seq)` for replay.
+  - `RunSink` — quacks like a Starlette WebSocket (`send_json` + `client_state`
+    always CONNECTED). This is the trick that kept the change small: RequestHandler's
+    three streaming methods (`handle_request`, `handle_approval_response`,
+    `handle_question_response`) pass the sink where they used to pass the socket,
+    so every `await websocket.send_json(...)` / `_is_websocket_open(...)` site
+    works unchanged — sends now log + best-effort-forward, and the run never
+    aborts on a dead socket. The mid-stream abort in `handle_request` was removed.
+  - `RunHandle` — a thread's run: task, log, and the currently-attached socket.
+  - `RunManager` — app-level registry (`app.state.run_manager`, created in
+    `main.py`). `start()` supersedes (cancels) any active run for the thread and
+    reuses the log so `seq` stays monotonic across turns; `attach`/`detach`/
+    `cancel`; LRU-bounds finished runs (never evicts a live one).
+- `web_socket_handler.py`
+  - Chat / approval / question messages start a background run via
+    `RequestHandler.start_chat_run` / `start_resume_run` (owned by RunManager,
+    not the connection).
+  - New `attach` message → `_handle_attach`: replays `log.since(last_seq)` then
+    live-tails; sends `no_active_run` / `replay_gap` when replay isn't possible.
+  - `cancel` cancels the thread's run; disconnect (`finally`) DETACHES the
+    socket from its threads — it does **not** cancel the runs.
+- Frontend
+  - `index.js`: on reconnect, if a run is in progress, sends
+    `{type:"attach", thread_id, last_seq}` instead of re-sending the user
+    message. `cancel`/stop carry `thread_id`. `websocketReplayUnavailable`
+    (gap / no_active_run) stops the spinner.
+  - `MessageHandler.js`: dedupes by per-thread `seq` (replay/live overlap is
+    harmless), exposes `getLastSeq(threadId)`, and handles the `attached` /
+    `no_active_run` / `replay_gap` control frames.
+  - `WebSocketManager.js`: `attach` is non-queueable (connection-specific).
+
+Tests: `app/tests/test_run_manager.py` (log/sink/manager: background-continues,
+replay, supersede, cancel, detach, eviction) and `TestWebSocketLayer2Attach` in
+`app/tests/test_websocket.py` (handler attach/replay/gap/no-run wiring).
+
+### Known v1 limitations (follow-ups)
+
+- **In-memory only.** A process restart loses the registry + logs; a reconnect
+  then gets `no_active_run` and the client falls back to thread history. Durable
+  replay (Redis stream / Postgres) is the phase-3 follow-up above.
+- **No live re-attach after a full page reload.** Reconnect-attach only fires
+  while the tab still believes a run is in progress (`isAgentRunning`). After a
+  hard reload that flag is gone, so the still-running build completes invisibly
+  and its result shows on the next thread load — it is not live-streamed. A
+  durable "is this thread running?" probe on load would close this.
+- **`replay_gap` / `no_active_run` just stop the spinner** rather than
+  auto-reloading thread history. Good enough for v1; auto-reload is a polish item.

--- a/docs/dev_logs/0.5.3
+++ b/docs/dev_logs/0.5.3
@@ -7,3 +7,9 @@
 - [x] In AskUserQuestion, add a toggle for the AI to give the user a ui option for it to let the user request UI examples.
 - [x] Improve prompts to avoid emojis and use font awesome icons instead.
 - [x] Improve system prompts iteration speed
+
+0.5.3a:
+- [x] Fix websocket bug - needs to be invariant & not resend the same message.
+- [x] Add noise for the ticket mode proactive yes/no thing.
+- [x] Fix recurring 400 "tool_calls must be followed by tool messages": orphaned-tool-call repair was wired into rails_agent only. Extracted the repair into a shared app/agents/leonardo/agent_factory.py (build_leonardo_agent wraps create_agent to prepend the repair middleware for all 9 create_agent agents; pure repair_orphaned_tool_calls_in_messages() called before .invoke() in the 2 raw-StateGraph agents) + a parametrized backstop test so a new agent can't forget the wiring. (SI#112)
+- [x] Add end-user feedback reporting to the mothership: per-message 👍/👎 next to the copy button, plus a "How is Leo doing this session?" banner that auto-appears once per thread after ~10 messages (Good/Bad + dismiss). New MothershipClient.submit_feedback() + POST /api/feedback forward to /api/leonardo/submit_feedback (best-effort, never blocks chat); lands as source:"end_user" InstanceMessageAnnotation rows.


### PR DESCRIPTION
- [x] Fix websocket bug - needs to be invariant & not resend the same message.
- [x] Add noise for the ticket mode proactive yes/no thing.
- [x] Fix recurring 400 "tool_calls must be followed by tool messages": orphaned-tool-call repair was wired into rails_agent only. Extracted the repair into a shared app/agents/leonardo/agent_factory.py (build_leonardo_agent wraps create_agent to prepend the repair middleware for all 9 create_agent agents; pure repair_orphaned_tool_calls_in_messages() called before .invoke() in the 2 raw-StateGraph agents) + a parametrized backstop test so a new agent can't forget the wiring. (SI#112)
- [x] Add end-user feedback reporting to the mothership: per-message 👍/👎 next to the copy button, plus a "How is Leo doing this session?" banner that auto-appears once per thread after ~10 messages (Good/Bad + dismiss). New MothershipClient.submit_feedback() + POST /api/feedback forward to /api/leonardo/submit_feedback (best-effort, never blocks chat); lands as source:"end_user" InstanceMessageAnnotation rows.