### PR TITLE
Add "Sign in with your LlamaPress.ai account" CTA to the login page

### DIFF
--- a/app/login.html
+++ b/app/login.html
@@ -104,6 +104,38 @@
             border: 1px solid rgba(239, 68, 68, 0.25);
             color: #ef4444;
         }
+        /* Unified Login CTA — "Sign in with your LlamaPress.ai account". Only
+           rendered on mothership-managed instances (see app/routers/ui.py). */
+        .sso-cta {
+            display: block;
+            width: 100%;
+            padding: 12px;
+            margin-bottom: 20px;
+            background: linear-gradient(135deg, #8b5cf6 0%, #a78bfa 100%);
+            color: white;
+            border-radius: 8px;
+            text-align: center;
+            text-decoration: none;
+            font-size: 1rem;
+            font-weight: 500;
+            box-sizing: border-box;
+            transition: opacity 0.2s;
+        }
+        .sso-cta:hover { opacity: 0.9; }
+        .sso-divider {
+            display: flex;
+            align-items: center;
+            text-align: center;
+            color: rgba(255, 255, 255, 0.35);
+            font-size: 0.85rem;
+            margin-bottom: 20px;
+        }
+        .sso-divider::before, .sso-divider::after {
+            content: '';
+            flex: 1;
+            border-bottom: 1px solid rgba(139, 92, 246, 0.2);
+        }
+        .sso-divider span { padding: 0 12px; }
     </style>
 </head>
 <body>
@@ -113,6 +145,7 @@
             <h2>Leonardo</h2>
         </div>
         <div class="card">
+            <!--SSO_CTA-->
             <form id="loginForm" autocomplete="on">
                 <label for="username">Username</label>
                 <input type="text" id="username" name="username" autocomplete="username" required autofocus>

--- a/app/routers/ui.py
+++ b/app/routers/ui.py
@@ -3,6 +3,7 @@
 import json
 import logging
 import os
+from html import escape
 from pathlib import Path
 
 from fastapi import APIRouter, Request, Depends, HTTPException, Form
@@ -27,6 +28,7 @@ from app.services.magic_link_service import (
     MagicLinkSecretMissing,
     verify_magic_link_token,
 )
+from app.services.mothership_client import MothershipClient
 
 # Role-based default visible agents
 DEFAULT_VISIBLE_AGENTS_USER = ["feedback"]
@@ -128,6 +130,34 @@ router = APIRouter()
 
 # Frontend directory path
 frontend_dir = Path(__file__).parent.parent / "frontend"
+
+# Placeholder in login.html where the Unified Login CTA is injected server-side.
+_SSO_CTA_PLACEHOLDER = "<!--SSO_CTA-->"
+
+
+def _render_sso_login_cta() -> str:
+    """Build the "Sign in with your LlamaPress.ai account" CTA for the login page.
+
+    Unified Login's discoverable entry point: a link that top-navigates to the
+    mothership's ``/sso/leo/{instance_name}`` SSO endpoint (which mints a grant
+    and bounces back to ``/auth/consume``). ``target="_top"`` is REQUIRED — the
+    login page can render inside the chat's app-preview iframe and LlamaPress.ai
+    won't load framed, so the click must break out to the top window.
+
+    Returns "" on self-hosted instances (no mothership configured) so those users
+    see the unchanged stock username/password form — never a broken button.
+    """
+    mothership = MothershipClient()
+    base = mothership.mothership_url
+    name = mothership.instance_name
+    if not base or not name:
+        return ""
+    sso_url = f"{base.rstrip('/')}/sso/leo/{name}"
+    return (
+        f'<a class="sso-cta" href="{escape(sso_url, quote=True)}" target="_top">'
+        "Sign in with your LlamaPress.ai account</a>"
+        '<div class="sso-divider"><span>or</span></div>'
+    )
 
 
 @router.get("/")
@@ -357,7 +387,11 @@ async def login_get(
         if not has_any_users():
             return RedirectResponse(url="/register", status_code=302)
         with open("login.html") as f:
-            return HTMLResponse(content=f.read())
+            html = f.read()
+        # Inject the Unified Login CTA on mothership-managed instances; on
+        # self-hosted boxes the placeholder is replaced with "" (stock form).
+        html = html.replace(_SSO_CTA_PLACEHOLDER, _render_sso_login_cta())
+        return HTMLResponse(content=html)
 
     try:
         username = verify_magic_link_token(token)

--- a/app/tests/test_auth_session.py
+++ b/app/tests/test_auth_session.py
@@ -11,7 +11,7 @@ import time
 
 import pytest
 from fastapi.testclient import TestClient
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from app.models import User
 from app.services.token_service import (
@@ -434,6 +434,44 @@ class TestLoginForm:
         assert resp.status_code == 200
         assert "text/html" in resp.headers.get("content-type", "")
         assert "loginForm" in resp.text
+
+    _CARD_HTML = (
+        "<div class='card'><!--SSO_CTA-->"
+        "<form id='loginForm'></form></div>"
+    )
+
+    def test_login_form_shows_sso_cta_on_managed_instance(self, client_with_user):
+        """On a mothership-managed instance the login page surfaces the
+        'Sign in with your LlamaPress.ai account' CTA, top-navigating to the
+        mothership /sso/leo/<instance> endpoint (target=_top for the iframe)."""
+        fake_ms = MagicMock()
+        fake_ms.mothership_url = "https://llamapress.ai/"
+        fake_ms.instance_name = "my-box"
+        with patch("app.routers.ui.has_any_users", return_value=True), \
+             patch("app.routers.ui.MothershipClient", return_value=fake_ms), \
+             patch("builtins.open", create=True) as mock_open:
+            mock_open.return_value.__enter__.return_value.read.return_value = self._CARD_HTML
+            resp = client_with_user.get("/login", follow_redirects=False)
+        assert resp.status_code == 200
+        assert "Sign in with your LlamaPress.ai account" in resp.text
+        assert 'href="https://llamapress.ai/sso/leo/my-box"' in resp.text
+        assert 'target="_top"' in resp.text
+
+    def test_login_form_hides_sso_cta_when_self_hosted(self, client_with_user):
+        """Self-hosted (no mothership config) → the placeholder collapses to
+        nothing; the user sees only the stock username/password form."""
+        fake_ms = MagicMock()
+        fake_ms.mothership_url = None
+        fake_ms.instance_name = None
+        with patch("app.routers.ui.has_any_users", return_value=True), \
+             patch("app.routers.ui.MothershipClient", return_value=fake_ms), \
+             patch("builtins.open", create=True) as mock_open:
+            mock_open.return_value.__enter__.return_value.read.return_value = self._CARD_HTML
+            resp = client_with_user.get("/login", follow_redirects=False)
+        assert resp.status_code == 200
+        assert "loginForm" in resp.text
+        assert "sso/leo" not in resp.text
+        assert "<!--SSO_CTA-->" not in resp.text
 
     def test_get_login_no_users_redirects_to_register(self, client_with_user):
         with patch("app.routers.ui.has_any_users", return_value=False):


### PR DESCRIPTION
## What

Unified Login — the discoverable **"Sign in with your LlamaPress.ai account"** CTA on the FastAPI login page (`GET /login`), so users don't need to know the SSO URL.

- `app/login.html` — a `<!--SSO_CTA-->` placeholder above the username/password form + styles for the CTA button/divider.
- `app/routers/ui.py` — `_render_sso_login_cta()` builds a `target="_top"` link to the mothership `/sso/leo/<instance>` endpoint from `MothershipClient` config; `login_get` injects it into the placeholder, or collapses it to `""` on self-hosted boxes.
- `app/tests/test_auth_session.py` — 2 tests (CTA renders with URL + `target="_top"` when managed; hidden with no placeholder leak when self-hosted).

`target="_top"` is required — the login page can render inside the chat's app-preview iframe, and LlamaPress.ai won't load framed, so the click must break out to the top window.

## Behavior

Purely additive: on a self-hosted instance (no mothership config) the placeholder collapses to nothing and the stock username/password form is unchanged. Inert until `unified_login_mode` is on.

## Verified

`pytest app/tests/test_auth_session.py` → **34 passed** (incl. the 2 new). Paired with the `llama_bot_rails` gem (Rails-side CTA) and Leonardo overlay PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)