### PR TITLE
Fix silent delegate_task hangs with bounded async delegation

### DIFF
--- a/app/agents/leonardo/delegation.py
+++ b/app/agents/leonardo/delegation.py
@@ -1,0 +1,73 @@
+"""Shared runtime for bounded, observable nested-agent delegation."""
+
+import asyncio
+import contextlib
+import logging
+import time
+from collections.abc import Callable
+from typing import Any
+
+
+logger = logging.getLogger(__name__)
+
+DELEGATION_TIMEOUT_SECONDS = 240
+DELEGATION_HEARTBEAT_SECONDS = 15
+
+
+class DelegationTimedOut(TimeoutError):
+    """Raised after the whole nested-agent delegation exceeds its deadline."""
+
+
+async def run_delegation(
+    sub_agent,
+    input_data: dict[str, Any],
+    *,
+    config: dict[str, Any] | None = None,
+    stream_writer: Callable[[dict[str, Any]], None] | None = None,
+    timeout_seconds: float = DELEGATION_TIMEOUT_SECONDS,
+    heartbeat_seconds: float = DELEGATION_HEARTBEAT_SECONDS,
+    label: str = "Sub-agent",
+):
+    """Run a nested agent with a whole-run deadline and progress heartbeats.
+
+    ``ainvoke`` is intentional: cancelling an executor-wrapped synchronous invoke
+    returns control to the caller but leaves the blocked worker (and HTTP request)
+    alive. Async cancellation reaches the provider client instead.
+    """
+    started_at = time.monotonic()
+
+    def emit(phase: str, message: str) -> None:
+        if stream_writer is None:
+            return
+        stream_writer({
+            "type": "delegation_progress",
+            "phase": phase,
+            "elapsed_seconds": round(time.monotonic() - started_at),
+            "message": message,
+        })
+
+    async def heartbeat() -> None:
+        while True:
+            await asyncio.sleep(heartbeat_seconds)
+            elapsed = round(time.monotonic() - started_at)
+            emit("working", f"{label} is still working… ({elapsed}s)")
+
+    emit("started", f"{label} started")
+    heartbeat_task = asyncio.create_task(heartbeat())
+    try:
+        async with asyncio.timeout(timeout_seconds):
+            result = await sub_agent.ainvoke(input_data, config=config)
+        emit("completed", f"{label} completed")
+        return result
+    except TimeoutError as exc:
+        elapsed = f"{timeout_seconds:g}"
+        emit("timed_out", f"{label} timed out after {elapsed}s")
+        logger.warning("%s timed out after %ss", label, elapsed)
+        raise DelegationTimedOut(f"timed out after {elapsed}s") from exc
+    except Exception:
+        emit("failed", f"{label} failed")
+        raise
+    finally:
+        heartbeat_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await heartbeat_task

--- a/app/agents/leonardo/llm_factory.py
+++ b/app/agents/leonardo/llm_factory.py
@@ -126,6 +126,10 @@ def get_llm(model_name: str):
     - DeepSeek: reasoning_content preserved via ChatDeepSeekWithReasoning
 
     Unknown model names fall back to the project default (DeepSeek v4 Flash).
+
+    Provider SDK retries are disabled here because they are opaque and multiply
+    the 180-second request timeout. Middleware-based agents own classified,
+    warning-logged retries; direct callers fail into the normal recovery path.
     """
     if model_name == "fake-llm" and os.getenv("LLAMABOT_ENABLE_FAKE_LLM", "").lower() == "true":
         return FakeTestChatModel()
@@ -148,11 +152,13 @@ def get_llm(model_name: str):
         return ChatDeepSeekWithReasoning(
             model="deepseek-v4-flash",
             timeout=180,
+            max_retries=0,
         )
     if model_name == "deepseek-v4-pro":
         return ChatDeepSeekWithReasoning(
             model="deepseek-v4-pro",
             timeout=180,
+            max_retries=0,
         )
     if model_name == "gpt-5-codex":
         return ChatOpenAI(
@@ -160,6 +166,7 @@ def get_llm(model_name: str):
             use_responses_api=True,
             reasoning={"effort": "low", "summary": "auto"},
             output_version="responses/v1",
+            max_retries=0,
         )
     if model_name == "gpt-5-mini":
         return ChatOpenAI(
@@ -167,6 +174,7 @@ def get_llm(model_name: str):
             use_responses_api=True,
             reasoning={"effort": "low", "summary": "auto"},
             output_version="responses/v1",
+            max_retries=0,
         )
     if model_name == "gpt-5-nano":
         return ChatOpenAI(
@@ -174,6 +182,7 @@ def get_llm(model_name: str):
             use_responses_api=True,
             reasoning={"effort": "low", "summary": "auto"},
             output_version="responses/v1",
+            max_retries=0,
         )
     if model_name == "gpt-5.4-nano":
         return ChatOpenAI(
@@ -181,34 +190,40 @@ def get_llm(model_name: str):
             use_responses_api=True,
             reasoning={"effort": "low", "summary": "auto"},
             output_version="responses/v1",
+            max_retries=0,
         )
     if model_name == "claude-4.5-sonnet":
         return ChatAnthropic(
             model="claude-sonnet-4-5-20250929",
             max_tokens=16384,
             thinking={"type": "enabled", "budget_tokens": 5000},
+            max_retries=0,
         )
     if model_name == "claude-4.5-haiku":
         return ChatAnthropic(
             model="claude-haiku-4-5",
             max_tokens=16384,
             thinking={"type": "enabled", "budget_tokens": 3000},
+            max_retries=0,
         )
     if model_name == "gemini-3-flash":
         return ChatGoogleGenerativeAI(
             model="gemini-3-flash-preview",
             include_thoughts=True,
+            retries=0,
         )
     if model_name == "gemini-3-pro":
         return ChatGoogleGenerativeAI(
             model="gemini-3.1-pro-preview",
             include_thoughts=True,
+            retries=0,
         )
     if model_name == "gemini-3.1-flash-lite":
         return ChatGoogleGenerativeAI(
             model="gemini-3.1-flash-lite",
             thinking_level="high",
             include_thoughts=True,
+            retries=0,
         )
     if model_name == "qwen3.7-plus":
         # Alibaba Cloud Model Studio's Qwen3.7 Plus, via the dedicated
@@ -227,11 +242,13 @@ def get_llm(model_name: str):
             api_key=os.getenv("ALIBABA_API_KEY"),
             enable_thinking=True,
             thinking_budget=8192,
+            max_retries=0,
         )
 
     return ChatDeepSeekWithReasoning(
         model="deepseek-v4-flash",
         timeout=180,
+        max_retries=0,
     )
 
 

--- a/app/agents/leonardo/rails_agent/sub_agents.py
+++ b/app/agents/leonardo/rails_agent/sub_agents.py
@@ -36,6 +36,11 @@ from app.agents.leonardo.rails_agent.tools import (
 )
 # Shared LLM factory - single source of truth for model selection
 from app.agents.leonardo.llm_factory import get_llm
+from app.agents.leonardo.delegation import (
+    DELEGATION_TIMEOUT_SECONDS,
+    DelegationTimedOut,
+    run_delegation,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -238,7 +243,7 @@ def create_sub_agent(llm_model: str = None):
 # =============================================================================
 
 @tool("delegate_task")
-def delegate_task(
+async def delegate_task(
     task_description: str,
     runtime: ToolRuntime,
 ) -> Command:
@@ -281,9 +286,13 @@ def delegate_task(
         sub_agent = create_sub_agent(llm_model=llm_model)
 
         # Invoke with the task - sub-agent starts with fresh context
-        result = sub_agent.invoke({
-            "messages": [{"role": "user", "content": task_description}]
-        })
+        result = await run_delegation(
+            sub_agent,
+            {"messages": [{"role": "user", "content": task_description}]},
+            config=runtime.config,
+            stream_writer=runtime.stream_writer,
+            label="Implementation sub-agent",
+        )
 
         # Extract the final response from the sub-agent
         final_message = result["messages"][-1].content if result["messages"] else "No response from sub-agent"
@@ -299,6 +308,21 @@ def delegate_task(
             ]
         })
 
+    except DelegationTimedOut:
+        logger.warning("Sub-agent delegation timed out")
+        return Command(update={
+            "messages": [
+                ToolMessage(
+                    content=(
+                        "[DELEGATED TASK FAILED]\n\n"
+                        f"Timed out after {DELEGATION_TIMEOUT_SECONDS}s — you may retry "
+                        "delegate_task once."
+                    ),
+                    tool_call_id=tool_call_id
+                )
+            ],
+            "failed_tool_calls_count": 1
+        })
     except Exception as e:
         logger.error(f"Sub-agent failed: {str(e)}")
         return Command(update={
@@ -365,7 +389,7 @@ def create_research_sub_agent(llm_model: str = None):
 # =============================================================================
 
 @tool("delegate_research")
-def delegate_research(
+async def delegate_research(
     task_description: str,
     runtime: ToolRuntime,
 ) -> Command:
@@ -432,9 +456,13 @@ def delegate_research(
         sub_agent = create_research_sub_agent(llm_model=llm_model)
 
         # Invoke with fresh context - sub-agent only sees the task description
-        result = sub_agent.invoke({
-            "messages": [{"role": "user", "content": task_description}]
-        })
+        result = await run_delegation(
+            sub_agent,
+            {"messages": [{"role": "user", "content": task_description}]},
+            config=runtime.config,
+            stream_writer=runtime.stream_writer,
+            label="Research sub-agent",
+        )
 
         # Extract the final response from the sub-agent
         final_message = result["messages"][-1].content if result["messages"] else "No response from research sub-agent"
@@ -450,6 +478,21 @@ def delegate_research(
             ]
         })
 
+    except DelegationTimedOut:
+        logger.warning("Research sub-agent delegation timed out")
+        return Command(update={
+            "messages": [
+                ToolMessage(
+                    content=(
+                        "[RESEARCH FAILED]\n\n"
+                        f"Timed out after {DELEGATION_TIMEOUT_SECONDS}s — you may retry "
+                        "delegate_research once."
+                    ),
+                    tool_call_id=tool_call_id
+                )
+            ],
+            "failed_tool_calls_count": 1
+        })
     except Exception as e:
         logger.error(f"Research sub-agent failed: {str(e)}")
         return Command(update={

--- a/app/agents/leonardo/rails_ticket_mode_agent/sub_agents.py
+++ b/app/agents/leonardo/rails_ticket_mode_agent/sub_agents.py
@@ -28,6 +28,11 @@ from app.agents.leonardo.rails_agent.tools import (
 )
 # Shared LLM factory - single source of truth for model selection
 from app.agents.leonardo.llm_factory import get_llm
+from app.agents.leonardo.delegation import (
+    DELEGATION_TIMEOUT_SECONDS,
+    DelegationTimedOut,
+    run_delegation,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -186,7 +191,7 @@ def create_sub_agent(llm_model: str = None):
 # =============================================================================
 
 @tool("delegate_task")
-def delegate_task(
+async def delegate_task(
     task_description: str,
     runtime: ToolRuntime,
 ) -> Command:
@@ -240,9 +245,13 @@ def delegate_task(
         sub_agent = create_sub_agent(llm_model=llm_model)
 
         # Invoke with the task - sub-agent starts with fresh context
-        result = sub_agent.invoke({
-            "messages": [{"role": "user", "content": task_description}]
-        })
+        result = await run_delegation(
+            sub_agent,
+            {"messages": [{"role": "user", "content": task_description}]},
+            config=runtime.config,
+            stream_writer=runtime.stream_writer,
+            label="Ticket research sub-agent",
+        )
 
         # Extract the final response from the sub-agent
         final_message = result["messages"][-1].content if result["messages"] else "No response from sub-agent"
@@ -258,6 +267,21 @@ def delegate_task(
             ]
         })
 
+    except DelegationTimedOut:
+        logger.warning("Ticket Mode sub-agent delegation timed out")
+        return Command(update={
+            "messages": [
+                ToolMessage(
+                    content=(
+                        "[DELEGATED TASK FAILED]\n\n"
+                        f"Timed out after {DELEGATION_TIMEOUT_SECONDS}s — you may retry "
+                        "delegate_task once."
+                    ),
+                    tool_call_id=tool_call_id
+                )
+            ],
+            "failed_tool_calls_count": 1
+        })
     except Exception as e:
         logger.error(f"Ticket Mode sub-agent failed: {str(e)}")
         return Command(update={

--- a/app/agents/leonardo/rails_user_feedback_agent/sub_agents.py
+++ b/app/agents/leonardo/rails_user_feedback_agent/sub_agents.py
@@ -29,6 +29,11 @@ from app.agents.leonardo.rails_agent.tools import (
 )
 # Shared LLM factory - single source of truth for model selection
 from app.agents.leonardo.llm_factory import get_llm
+from app.agents.leonardo.delegation import (
+    DELEGATION_TIMEOUT_SECONDS,
+    DelegationTimedOut,
+    run_delegation,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -159,7 +164,7 @@ def create_sub_agent(llm_model: str = None):
 # =============================================================================
 
 @tool("delegate_task")
-def delegate_task(
+async def delegate_task(
     task_description: str,
     runtime: ToolRuntime,
 ) -> Command:
@@ -208,9 +213,13 @@ def delegate_task(
         sub_agent = create_sub_agent(llm_model=llm_model)
 
         # Invoke with the task - sub-agent starts with fresh context
-        result = sub_agent.invoke({
-            "messages": [{"role": "user", "content": task_description}]
-        })
+        result = await run_delegation(
+            sub_agent,
+            {"messages": [{"role": "user", "content": task_description}]},
+            config=runtime.config,
+            stream_writer=runtime.stream_writer,
+            label="User research sub-agent",
+        )
 
         # Extract the final response from the sub-agent
         final_message = result["messages"][-1].content if result["messages"] else "No response from sub-agent"
@@ -226,6 +235,21 @@ def delegate_task(
             ]
         })
 
+    except DelegationTimedOut:
+        logger.warning("User Mode sub-agent delegation timed out")
+        return Command(update={
+            "messages": [
+                ToolMessage(
+                    content=(
+                        "[DELEGATED RESEARCH FAILED]\n\n"
+                        f"Timed out after {DELEGATION_TIMEOUT_SECONDS}s — you may retry "
+                        "delegate_task once."
+                    ),
+                    tool_call_id=tool_call_id
+                )
+            ],
+            "failed_tool_calls_count": 1
+        })
     except Exception as e:
         logger.error(f"User Mode sub-agent failed: {str(e)}")
         return Command(update={

--- a/app/frontend/chat/index.js
+++ b/app/frontend/chat/index.js
@@ -111,6 +111,8 @@ class ChatApp {
     // Agent running state (for stop button)
     this.isAgentRunning = false;
     this.cancelPressCount = 0;
+    this.lastInboundAt = null;
+    this.STALL_HINT_THRESHOLD_MS = 90000;
 
     // Last payload we sent (carries its client_message_id). Kept so the backend
     // idempotency guard has a stable key; resume-on-reconnect no longer re-sends
@@ -273,6 +275,14 @@ class ChatApp {
     window.addEventListener('websocketReplayUnavailable', () => {
       this.hideThinkingIndicator();
       this.setAgentRunning(false);
+    });
+
+    // Any inbound frame proves the run is alive. Delegation heartbeats arrive
+    // through this same path, so the generic stall affordance works for both
+    // nested agents and future long-running operations.
+    window.addEventListener('websocketActivity', () => {
+      this.lastInboundAt = Date.now();
+      this.clearStallHint();
     });
 
     // Listen for agent task completion to stop duration timer and show elapsed time
@@ -1930,11 +1940,38 @@ class ChatApp {
   startDurationTimerDisplay() {
     // Start the timer in app state
     this.appState.startTaskTimer();
+    this.lastInboundAt = Date.now();
+    this.clearStallHint();
 
     // Update every second - the timer text is injected into the thinking area
     this.appState.taskTimerInterval = setInterval(() => {
       this.updateTimerInThinkingArea();
+      this.updateStallHint();
     }, 1000);
+  }
+
+  handleDelegationProgress(data) {
+    if (!this.elements.thinkingArea) return;
+    const thinkingDiv = this.elements.thinkingArea.querySelector('.typing-indicator');
+    if (thinkingDiv && data.message) {
+      this.loadingVerbs?.stopCycling();
+      thinkingDiv.textContent = `🦙 ${data.message}`;
+    }
+  }
+
+  updateStallHint() {
+    if (!this.isAgentRunning || !this.lastInboundAt || !this.elements.thinkingArea) return;
+    if (Date.now() - this.lastInboundAt < this.STALL_HINT_THRESHOLD_MS) return;
+    if (this.elements.thinkingArea.querySelector('.stall-hint')) return;
+
+    const hint = document.createElement('div');
+    hint.className = 'stall-hint';
+    hint.textContent = "Taking longer than usual — you can cancel and say ‘continue’ to retry.";
+    this.elements.thinkingArea.appendChild(hint);
+  }
+
+  clearStallHint() {
+    this.elements.thinkingArea?.querySelector('.stall-hint')?.remove();
   }
 
   /**
@@ -1975,6 +2012,8 @@ class ChatApp {
   stopDurationTimerDisplay() {
     // Stop the timer in app state
     this.appState.stopTaskTimer();
+    this.lastInboundAt = null;
+    this.clearStallHint();
 
     // Remove timer from thinking area if it exists
     if (this.elements.thinkingArea) {

--- a/app/frontend/chat/websocket/MessageHandler.js
+++ b/app/frontend/chat/websocket/MessageHandler.js
@@ -157,6 +157,9 @@ export class MessageHandler {
       return;
     }
 
+    // Only activity for the visible thread resets its silent-stall timer.
+    window.dispatchEvent(new CustomEvent('websocketActivity', { detail: data }));
+
     // Update token indicator if token usage data is present
     if (data.token_usage && this.tokenIndicator) {
       this.tokenIndicator.update(data.token_usage);
@@ -176,6 +179,8 @@ export class MessageHandler {
       this.handleSuggestModeSwitch(data);
     } else if (data.type === 'implement_ticket') {
       this.handleImplementTicket(data);
+    } else if (data.type === 'delegation_progress') {
+      window.chatApp?.handleDelegationProgress(data);
     } else {
       this.handleGenericMessage(data);
     }

--- a/app/frontend/style.css
+++ b/app/frontend/style.css
@@ -4489,6 +4489,14 @@ button.brand-logo-thumb:hover .brand-logo-zoom {
     letter-spacing: 0.3px;
 }
 
+.stall-hint {
+    flex-basis: 100%;
+    margin-top: 4px;
+    color: #a3a3a3;
+    font-size: 0.72rem;
+    line-height: 1.3;
+}
+
 /* ============================================
    SUB-AGENT BADGE ON TOOL CALLS
    Visual indicator for sub-agent tool calls

--- a/app/tests/test_delegate_runtime.py
+++ b/app/tests/test_delegate_runtime.py
@@ -1,0 +1,82 @@
+"""Regression coverage for cancellable, observable sub-agent delegation."""
+
+import asyncio
+
+import pytest
+
+from app.agents.leonardo.delegation import DelegationTimedOut, run_delegation
+
+
+class _BlockingAgent:
+    def __init__(self):
+        self.cancelled = False
+
+    async def ainvoke(self, input_data, config=None):
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            self.cancelled = True
+            raise
+
+
+class _SuccessfulAgent:
+    async def ainvoke(self, input_data, config=None):
+        return {"messages": ["done"]}
+
+
+@pytest.mark.asyncio
+async def test_delegation_timeout_cancels_nested_agent_and_emits_terminal_progress():
+    agent = _BlockingAgent()
+    events = []
+
+    with pytest.raises(DelegationTimedOut, match="timed out after 0.02s"):
+        await run_delegation(
+            agent,
+            {"messages": [{"role": "user", "content": "research"}]},
+            timeout_seconds=0.02,
+            heartbeat_seconds=0.005,
+            stream_writer=events.append,
+            label="Research sub-agent",
+        )
+
+    assert agent.cancelled is True
+    assert events[0]["phase"] == "started"
+    assert any(event["phase"] == "working" for event in events)
+    assert events[-1]["phase"] == "timed_out"
+    assert all(event["type"] == "delegation_progress" for event in events)
+
+
+@pytest.mark.asyncio
+async def test_delegation_success_preserves_result_and_emits_completed():
+    events = []
+
+    result = await run_delegation(
+        _SuccessfulAgent(),
+        {"messages": [{"role": "user", "content": "research"}]},
+        timeout_seconds=1,
+        heartbeat_seconds=0.01,
+        stream_writer=events.append,
+        label="Research sub-agent",
+        config={"metadata": {"thread_id": "thread-1"}},
+    )
+
+    assert result == {"messages": ["done"]}
+    assert [event["phase"] for event in events] == ["started", "completed"]
+
+
+@pytest.mark.asyncio
+async def test_delegation_failure_emits_failed_and_reraises():
+    class _FailingAgent:
+        async def ainvoke(self, input_data, config=None):
+            raise RuntimeError("provider exploded")
+
+    events = []
+    with pytest.raises(RuntimeError, match="provider exploded"):
+        await run_delegation(
+            _FailingAgent(),
+            {"messages": []},
+            timeout_seconds=1,
+            stream_writer=events.append,
+        )
+
+    assert events[-1]["phase"] == "failed"

--- a/app/tests/test_delegate_tools.py
+++ b/app/tests/test_delegate_tools.py
@@ -1,0 +1,43 @@
+from types import SimpleNamespace
+
+import pytest
+
+from app.agents.leonardo.delegation import DelegationTimedOut
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("module_name", "failure_marker"),
+    [
+        ("app.agents.leonardo.rails_agent.sub_agents", "[DELEGATED TASK FAILED]"),
+        ("app.agents.leonardo.rails_ticket_mode_agent.sub_agents", "[DELEGATED TASK FAILED]"),
+        ("app.agents.leonardo.rails_user_feedback_agent.sub_agents", "[DELEGATED RESEARCH FAILED]"),
+    ],
+)
+async def test_delegate_task_timeout_returns_recoverable_tool_message(
+    monkeypatch, module_name, failure_marker
+):
+    module = __import__(module_name, fromlist=["sub_agents"])
+
+    async def time_out(*args, **kwargs):
+        raise DelegationTimedOut("timed out after 240s")
+
+    monkeypatch.setattr(module, "create_sub_agent", lambda **_: object())
+    monkeypatch.setattr(module, "run_delegation", time_out)
+    runtime = SimpleNamespace(
+        tool_call_id="call-1",
+        state={"llm_model": "deepseek-v4-flash"},
+        config={"configurable": {"thread_id": "thread-1"}},
+        stream_writer=lambda _: None,
+    )
+
+    command = await module.delegate_task.coroutine(
+        task_description="research the issue", runtime=runtime
+    )
+
+    assert command.update["failed_tool_calls_count"] == 1
+    message = command.update["messages"][0]
+    assert failure_marker in message.content
+    assert "Timed out after 240s" in message.content
+    assert "retry" in message.content
+    assert message.tool_call_id == "call-1"

--- a/app/tests/test_delegation_progress_stream.py
+++ b/app/tests/test_delegation_progress_stream.py
@@ -1,0 +1,42 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from starlette.websockets import WebSocketState
+
+from app.websocket.request_handler import RequestHandler
+
+
+@pytest.mark.asyncio
+async def test_custom_delegation_progress_is_forwarded_to_websocket():
+    handler = RequestHandler(MagicMock())
+    websocket = MagicMock()
+    websocket.client_state = WebSocketState.CONNECTED
+    websocket.send_json = AsyncMock()
+    payload = {
+        "type": "delegation_progress",
+        "phase": "working",
+        "elapsed_seconds": 15,
+        "message": "Research sub-agent is still working… (15s)",
+    }
+
+    handled = await handler._forward_custom_stream_chunk(
+        (("tools:delegate_task",), "custom", payload), websocket
+    )
+
+    assert handled is True
+    websocket.send_json.assert_awaited_once_with(payload)
+
+
+@pytest.mark.asyncio
+async def test_unknown_custom_event_is_not_exposed_to_browser():
+    handler = RequestHandler(MagicMock())
+    websocket = MagicMock()
+    websocket.client_state = WebSocketState.CONNECTED
+    websocket.send_json = AsyncMock()
+
+    handled = await handler._forward_custom_stream_chunk(
+        ((), "custom", {"type": "internal_secret_event"}), websocket
+    )
+
+    assert handled is True
+    websocket.send_json.assert_not_awaited()

--- a/app/tests/test_llm_factory_retry_ownership.py
+++ b/app/tests/test_llm_factory_retry_ownership.py
@@ -1,0 +1,73 @@
+"""Provider SDKs must not silently multiply application-owned retries."""
+
+import pytest
+import logging
+
+from app.agents.leonardo import llm_factory
+from app.agents.leonardo import model_policy
+
+
+@pytest.mark.parametrize(
+    ("model_name", "constructor_name", "retry_key"),
+    [
+        ("deepseek-v4-flash", "ChatDeepSeekWithReasoning", "max_retries"),
+        ("gpt-5-mini", "ChatOpenAI", "max_retries"),
+        ("claude-4.5-haiku", "ChatAnthropic", "max_retries"),
+        ("gemini-3-flash", "ChatGoogleGenerativeAI", "retries"),
+        ("qwen3.7-plus", "ChatQwen", "max_retries"),
+    ],
+)
+def test_get_llm_disables_hidden_provider_retries(
+    monkeypatch, model_name, constructor_name, retry_key
+):
+    captured = {}
+
+    def fake_constructor(**kwargs):
+        captured.update(kwargs)
+        return object()
+
+    monkeypatch.setattr(model_policy, "is_model_enabled", lambda _: True)
+    monkeypatch.setattr(llm_factory, constructor_name, fake_constructor)
+
+    llm_factory.get_llm(model_name)
+
+    assert captured[retry_key] == 0
+
+
+@pytest.mark.asyncio
+async def test_application_retry_is_warning_logged(monkeypatch, caplog):
+    from app.agents.leonardo.rails_agent import middleware
+
+    class Model:
+        def bind_tools(self, *args, **kwargs):
+            return self
+
+    class Request:
+        state = {"llm_model": "deepseek-v4-flash"}
+
+        def override(self, **kwargs):
+            return self
+
+    calls = 0
+
+    async def handler(_request):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise TimeoutError("provider stalled")
+        return "ok"
+
+    monkeypatch.setattr(middleware, "get_llm", lambda _: Model())
+    monkeypatch.setattr(middleware.asyncio, "sleep", lambda _: _completed_sleep())
+    with caplog.at_level(logging.WARNING):
+        result = await middleware.DynamicModelMiddleware().awrap_model_call(
+            Request(), handler
+        )
+
+    assert result == "ok"
+    assert "Transient model error" in caplog.text
+    assert "retrying" in caplog.text
+
+
+async def _completed_sleep():
+    return None

--- a/app/websocket/request_handler.py
+++ b/app/websocket/request_handler.py
@@ -179,6 +179,26 @@ class RequestHandler:
         """Check if the WebSocket connection is still open"""
         return websocket.client_state == WebSocketState.CONNECTED
 
+    async def _forward_custom_stream_chunk(self, chunk, websocket: WebSocket) -> bool:
+        """Forward supported LangGraph custom events to the browser.
+
+        Returns True when ``chunk`` was a custom stream item, even if its payload
+        was intentionally ignored. This keeps custom events out of message/update
+        handling while limiting the browser protocol to known event types.
+        """
+        is_custom = isinstance(chunk, tuple) and len(chunk) == 3 and chunk[1] == "custom"
+        if not is_custom:
+            return False
+
+        payload = chunk[2]
+        if (
+            isinstance(payload, dict)
+            and payload.get("type") == "delegation_progress"
+            and self._is_websocket_open(websocket)
+        ):
+            await websocket.send_json(payload)
+        return True
+
     # Interrupt types raised by "ask the user" tools whose interrupt() expects a plain
     # text answer (which the tool wraps into a ToolMessage). A normal chat message sent
     # while one of these is pending should resume the interrupt with that text — NOT be
@@ -611,7 +631,7 @@ class RequestHandler:
                     await self._repair_thread_state_if_needed(app, config)
                     stream_input = state
 
-                async for chunk in app.astream(stream_input, config=config, stream_mode=["updates", "messages"], subgraphs=True):
+                async for chunk in app.astream(stream_input, config=config, stream_mode=["updates", "messages", "custom"], subgraphs=True):
 
                     # Layer 2: this loop runs inside a background run (RunManager)
                     # writing to a RunSink, NOT bound to the live socket. We do
@@ -624,6 +644,9 @@ class RequestHandler:
                     # NOTE: In LangGraph 0.5, they introduced this "subgraphs" parameter, that changes the datashape if you set it to True.
                     # if subgraph=True, it returns a tuple with 3 elements, instead of 2 elements.
                     # the first element is the subgraph name, the second element is the streaming data type ["updates", "messages", "values"], and the third element is the actual metadata.
+
+                    if await self._forward_custom_stream_chunk(chunk, websocket):
+                        continue
 
                     is_this_chunk_an_llm_message = isinstance(chunk, tuple) and len(chunk) == 3 and chunk[1] == 'messages'
                     is_this_chunk_an_update_stream_type = isinstance(chunk, tuple) and len(chunk) == 3 and chunk[1] == 'updates'
@@ -919,7 +942,10 @@ class RequestHandler:
                 hitl_response = {"decisions": decisions}
 
                 # Resume the graph
-                async for chunk in app.astream(Command(resume=hitl_response), config=config, stream_mode=["updates", "messages"], subgraphs=True):
+                async for chunk in app.astream(Command(resume=hitl_response), config=config, stream_mode=["updates", "messages", "custom"], subgraphs=True):
+                    if await self._forward_custom_stream_chunk(chunk, websocket):
+                        continue
+
                     is_this_chunk_an_llm_message = isinstance(chunk, tuple) and len(chunk) == 3 and chunk[1] == 'messages'
                     is_this_chunk_an_update_stream_type = isinstance(chunk, tuple) and len(chunk) == 3 and chunk[1] == 'updates'
 
@@ -1128,7 +1154,10 @@ class RequestHandler:
                 # Resume the graph — interrupt() returns this answer string
                 answer = response_message.get("answer", "")
 
-                async for chunk in app.astream(Command(resume=answer), config=config, stream_mode=["updates", "messages"], subgraphs=True):
+                async for chunk in app.astream(Command(resume=answer), config=config, stream_mode=["updates", "messages", "custom"], subgraphs=True):
+                    if await self._forward_custom_stream_chunk(chunk, websocket):
+                        continue
+
                     is_this_chunk_an_llm_message = isinstance(chunk, tuple) and len(chunk) == 3 and chunk[1] == 'messages'
                     is_this_chunk_an_update_stream_type = isinstance(chunk, tuple) and len(chunk) == 3 and chunk[1] == 'updates'
 

--- a/docs/dev_logs/0.6.0
+++ b/docs/dev_logs/0.6.0
@@ -4,3 +4,4 @@
 0.6.0b: 
 - [x] Fix UI/UX issues with our chat tab, so our background runs route properly and the user is less confused. (Ticket -> Engineer mode in particular was rough & broken).
 - [x] Auto change to implement when it goes from ticket -> engineer mode.
+- [x] Bound delegated sub-agent runs to 240s, disable hidden provider retries, stream progress heartbeats, and warn users after 90s of silence.


### PR DESCRIPTION
## Summary
- replace blocking nested-agent invokes with cancellable async delegation capped at 240 seconds across all delegation tools
- disable hidden provider SDK retries while retaining warning-logged application retries
- stream 15-second delegation progress heartbeats and show a 90-second no-activity hint in chat

## Regression coverage
- timeout cancels the nested call and returns a recoverable failed ToolMessage
- successful and exceptional delegation paths retain their existing contracts
- every configured provider disables hidden SDK retries
- custom progress frames are allowlisted and forwarded through the thread-scoped WebSocket stream

## Verification
- failing-first: test_delegate_runtime initially failed because the shared bounded runtime did not exist
- focused agent/WebSocket/retry suite: 66 passed
- complete app/tests suite: 527 passed, 1 skipped
- Python compileall: passed
- ES-module syntax checks: passed
- Playwright smoke: 4 passed, 1 skipped
- targeted browser check: heartbeat text, 90-second hint, and activity reset passed

The existing mock-LLM Ticket Mode test remains red independently: its ping prompt is intercepted by Ticket Mode's deterministic pong before fake-llm runs.

## Rollout
Release through the gated LlamaBot tag workflow, then roll the image to both the fleet and instant pool. During a forced provider stall, expect warning logs, visible 15-second progress, and a recoverable timeout by 240 seconds.

Tracks SupportIncident #131.