### PR TITLE
0.6.0d:

### DIFF
--- a/app/agents/leonardo/llm_factory.py
+++ b/app/agents/leonardo/llm_factory.py
@@ -160,6 +160,59 @@ def get_llm(model_name: str):
             timeout=180,
             max_retries=0,
         )
+    if model_name == "deepseek-v4-flash-gmi":
+        # DeepSeek V4 Flash served by GMI Cloud instead of DeepSeek's own API.
+        # Deliberately a SEPARATE model entry from `deepseek-v4-flash` (which
+        # keeps pointing at api.deepseek.com) so the provider is an explicit
+        # user choice, not a hidden swap.
+        #
+        # GMI is OpenAI-compatible and returns DeepSeek's reasoning_content
+        # (streamed in deltas too), so the same ChatDeepSeekWithReasoning client
+        # works — only the endpoint, key and model id differ. GMI is also more
+        # lenient than DeepSeek direct: it accepts assistant messages with no
+        # reasoning_content, so DeepSeekReasoningMiddleware (which gates on the
+        # exact name "deepseek-v4-flash" and therefore does NOT fire here) is
+        # not needed for this path.
+        return ChatDeepSeekWithReasoning(
+            model=os.getenv("GMI_DEEPSEEK_MODEL", "deepseek-ai/DeepSeek-V4-Flash"),
+            api_base=os.getenv("GMI_BASE_URL", "https://api.gmi-serving.com/v1"),
+            api_key=os.getenv("GMI_DEEPSEEK_API_KEY"),
+            timeout=180,
+            max_retries=0,
+        )
+    if model_name == "deepseek-v4-flash-fireworks":
+        # DeepSeek V4 Flash served by Fireworks AI. Like the GMI entry, a
+        # SEPARATE model from `deepseek-v4-flash` so the provider is an explicit
+        # choice rather than a hidden swap.
+        #
+        # Chosen over DeepSeek direct for data-retention reasons (US-hosted open
+        # weights, so no Chinese data jurisdiction) and over GMI on prompt-cache
+        # behavior: measured ~90% token-weighted prefix-cache hit rate (27/30
+        # calls, misses are all-or-nothing) vs ~20% on GMI's shared fleet. Prompt
+        # caching is per-replica, so a provider's routing — not the model —
+        # decides the hit rate.
+        #
+        # Fireworks is OpenAI-compatible, separates reasoning_content (streamed
+        # in deltas), reports cache hits via usage.prompt_tokens_details, and
+        # accepts assistant messages without reasoning_content — so, as with GMI,
+        # DeepSeekReasoningMiddleware (gated on the exact name
+        # "deepseek-v4-flash") does not need to fire for this path.
+        #
+        # NOTE: stay on chat completions. Fireworks' *Response* API defaults to
+        # store=True with 30-day retention, which would defeat the retention
+        # rationale above.
+        return ChatDeepSeekWithReasoning(
+            model=os.getenv(
+                "FIREWORKS_DEEPSEEK_MODEL",
+                "accounts/fireworks/models/deepseek-v4-flash",
+            ),
+            api_base=os.getenv(
+                "FIREWORKS_BASE_URL", "https://api.fireworks.ai/inference/v1"
+            ),
+            api_key=os.getenv("FIREWORKS_DEEPSEEK_API_KEY"),
+            timeout=180,
+            max_retries=0,
+        )
     if model_name == "gpt-5-codex":
         return ChatOpenAI(
             model="gpt-5-codex",

--- a/app/agents/leonardo/model_capabilities.py
+++ b/app/agents/leonardo/model_capabilities.py
@@ -33,6 +33,11 @@ MODEL_CAPABILITIES = {
     # DeepSeek - primarily text focused
     'deepseek-v4-flash': {'images': False, 'video': False, 'pdf': False},
     'deepseek-v4-pro': {'images': False, 'video': False, 'pdf': False},
+    # Same model as deepseek-v4-flash, served by GMI Cloud rather than
+    # DeepSeek's own API — same (text-only) capabilities.
+    'deepseek-v4-flash-gmi': {'images': False, 'video': False, 'pdf': False},
+    # Same model again, served by Fireworks AI — same (text-only) capabilities.
+    'deepseek-v4-flash-fireworks': {'images': False, 'video': False, 'pdf': False},
 
     # Qwen3.7 Plus (Alibaba) - multimodal agent model: images and video; PDFs
     # are ingested as page-images, not natively, so we leave pdf off.

--- a/app/agents/leonardo/model_policy.py
+++ b/app/agents/leonardo/model_policy.py
@@ -90,6 +90,8 @@ _FAIL_OPEN_MODELS = frozenset({"deepseek-v4-flash", "gpt-5-nano"})
 _KNOWN_MODELS = [
     "deepseek-v4-flash",
     "deepseek-v4-pro",
+    "deepseek-v4-flash-gmi",
+    "deepseek-v4-flash-fireworks",
     "claude-4.5-sonnet",
     "claude-4.5-haiku",
     "gpt-5-codex",

--- a/app/agents/leonardo/rails_agent/middleware.py
+++ b/app/agents/leonardo/rails_agent/middleware.py
@@ -16,7 +16,13 @@ import time
 
 from app.agents.leonardo.rails_agent.state import RailsAgentState
 from app.agents.leonardo.llm_factory import get_llm
-from app.agents.leonardo.resilience import is_transient_error
+from app.agents.leonardo.resilience import (
+    is_transient_error,
+    _MODEL_RETRY_MAX_ATTEMPTS,
+    _MODEL_RETRY_BASE_DELAY,
+    _MODEL_RETRY_MAX_DELAY,
+    _model_retry_delay,
+)
 from app.agents.leonardo.model_capabilities import (
     get_model_capabilities,
     get_file_category,
@@ -382,14 +388,11 @@ class DeepSeekReasoningMiddleware(AgentMiddleware):
 # chat model intact. Deterministic errors (bad kwargs, 400s) are NOT retried —
 # is_transient_error returns False — so they fall straight through to the
 # fallback/floor rungs instead of failing identically N times.
-_MODEL_RETRY_MAX_ATTEMPTS = 5          # initial call + up to 4 retries
-_MODEL_RETRY_BASE_DELAY = 0.5          # seconds
-_MODEL_RETRY_MAX_DELAY = 8.0           # seconds
-
-
-def _model_retry_delay(attempt: int) -> float:
-    """Exponential backoff (capped) for the Nth failed attempt (1-based)."""
-    return min(_MODEL_RETRY_BASE_DELAY * (2 ** (attempt - 1)), _MODEL_RETRY_MAX_DELAY)
+#
+# The retry constants + _model_retry_delay live in resilience.py (single source
+# of truth); raw StateGraph nodes reuse them via invoke_with_transient_retry.
+# They're imported into this module's namespace above, so references below (and
+# tests reaching mw._MODEL_RETRY_MAX_ATTEMPTS) resolve unchanged.
 
 
 class DynamicModelMiddleware(AgentMiddleware):

--- a/app/agents/leonardo/rails_agent/state.py
+++ b/app/agents/leonardo/rails_agent/state.py
@@ -27,4 +27,8 @@ class RailsAgentState(AgentState):
     debug_info: NotRequired[dict[str, Any]]
     agent_mode: NotRequired[str]
     llm_model: NotRequired[str]
+    # NOTE: deliberately NO `api_token` here. The built-in agents don't call the
+    # user-scoped Rails API, and declaring the field would persist a bearer credential
+    # into every checkpoint for nothing. Custom agents that DO use it subclass
+    # LlamaPressAPIState (app/lib/llamapress_api.py), which declares it.
     failed_tool_calls_count: Annotated[NotRequired[int], operator.add]

--- a/app/agents/leonardo/rails_ai_builder_agent/nodes.py
+++ b/app/agents/leonardo/rails_ai_builder_agent/nodes.py
@@ -32,6 +32,7 @@ from app.agents.leonardo.rails_ai_builder_agent.prompts import RAILS_AI_BUILDER_
 from app.agents.leonardo.project_context import build_system_prompt_with_project_context, brand_context_section
 from app.agents.leonardo.llm_factory import get_llm
 from app.agents.leonardo.agent_factory import repair_orphaned_tool_calls_in_messages
+from app.agents.leonardo.resilience import invoke_with_transient_retry
 
 import logging
 logger = logging.getLogger(__name__)
@@ -110,11 +111,18 @@ def leonardo_ai_builder(state: RailsAgentState) -> Command[Literal["tools"]]:
    if failed_tool_calls_count >= 3:
       messages = messages + [HumanMessage(content="<NOTE_FROM_SYSTEM> The user has had too many failed tool calls. DO NOT DO ANY NEW TOOL CALLS. Tell the user it's failed, and you need to stop and ask the user to try again in a different way. </NOTE_FROM_SYSTEM>")]
       # Don't bind tools when we've failed too many times - we want a text response only
-      # Only pass cache_control for Anthropic models
+      # Only pass cache_control for Anthropic models. Raw node — no middleware — so
+      # wrap the direct invoke in the shared rung-1 transient-error retry.
       if llm_model.startswith("claude"):
-         response = llm.invoke(messages, cache_control={"type": "ephemeral"})
+         response = invoke_with_transient_retry(
+            lambda: llm.invoke(messages, cache_control={"type": "ephemeral"}),
+            label=f"rails_ai_builder_agent/{llm_model}",
+         )
       else:
-         response = llm.invoke(messages)
+         response = invoke_with_transient_retry(
+            lambda: llm.invoke(messages),
+            label=f"rails_ai_builder_agent/{llm_model}",
+         )
       # Reset counter by subtracting current count (since reducer uses operator.add)
       return {"messages": [response], "failed_tool_calls_count": -failed_tool_calls_count} # by adding a negative number, we subtract the current count and reset it to 0.
 
@@ -126,9 +134,15 @@ def leonardo_ai_builder(state: RailsAgentState) -> Command[Literal["tools"]]:
 
    # Only pass cache_control for Anthropic models
    if llm_model.startswith("claude"):
-      response = llm_with_tools.invoke(messages, cache_control={"type": "ephemeral"})
+      response = invoke_with_transient_retry(
+         lambda: llm_with_tools.invoke(messages, cache_control={"type": "ephemeral"}),
+         label=f"rails_ai_builder_agent/{llm_model}",
+      )
    else:
-      response = llm_with_tools.invoke(messages)
+      response = invoke_with_transient_retry(
+         lambda: llm_with_tools.invoke(messages),
+         label=f"rails_ai_builder_agent/{llm_model}",
+      )
    return {"messages": [response]}
 
 # Graph

--- a/app/agents/leonardo/rails_beginner_agent/nodes.py
+++ b/app/agents/leonardo/rails_beginner_agent/nodes.py
@@ -29,6 +29,7 @@ from app.agents.leonardo.rails_beginner_agent.prompts import BEGINNER_AGENT_PROM
 from app.agents.leonardo.project_context import build_beginner_system_prompt, brand_context_section
 from app.agents.leonardo.llm_factory import get_llm
 from app.agents.leonardo.agent_factory import repair_orphaned_tool_calls_in_messages
+from app.agents.leonardo.resilience import invoke_with_transient_retry
 
 import logging
 logger = logging.getLogger(__name__)
@@ -150,7 +151,13 @@ def leonardo_beginner(state: RailsAgentState, browser_inspect_on: bool = False) 
         messages = messages + [HumanMessage(
             content="<NOTE_FROM_SYSTEM> The user has had too many failed tool calls. DO NOT DO ANY NEW TOOL CALLS. Tell the user it's failed in friendly, beginner-appropriate language, and suggest they try again with a simpler request. </NOTE_FROM_SYSTEM>"
         )]
-        response = llm.invoke(messages)
+        # Raw node — no DynamicModelMiddleware, so wrap the direct invoke in the
+        # shared rung-1 retry (transient DeepSeek connection blips would otherwise
+        # kill the turn with no retry at all).
+        response = invoke_with_transient_retry(
+            lambda: llm.invoke(messages),
+            label=f"rails_beginner_agent/{llm_model}",
+        )
         return {"messages": [response], "failed_tool_calls_count": -failed_tool_calls_count}
 
     if llm_model.startswith("gemini"):
@@ -158,7 +165,10 @@ def leonardo_beginner(state: RailsAgentState, browser_inspect_on: bool = False) 
     else:
         llm_with_tools = llm.bind_tools(tools, parallel_tool_calls=False)
 
-    response = llm_with_tools.invoke(messages)
+    response = invoke_with_transient_retry(
+        lambda: llm_with_tools.invoke(messages),
+        label=f"rails_beginner_agent/{llm_model}",
+    )
     return {"messages": [response]}
 
 

--- a/app/agents/leonardo/rails_beginner_agent/prompts.py
+++ b/app/agents/leonardo/rails_beginner_agent/prompts.py
@@ -240,7 +240,19 @@ When you spot that confusion, gently reframe it. Don't make them feel silly. Try
 
 **Then give them the shareable link.** Use the existing `HOSTED_DOMAIN` lookup (see **Full URL / domain** below). The shareable URL is `https://rails-{HOSTED_DOMAIN}`. Don't guess — always check.
 
-**Phones:** It works on phones today as a website. Tell them: *"Open that link in your phone's browser. You can tap 'Add to Home Screen' and it'll feel just like an app."* Native App Store distribution is a different conversation — if they push for that, point them to **support@llamapress.ai**.
+**Phones ("how do I download this to my phone?"):** Their app is already installable — it's a Progressive Web App (the manifest is wired up in `app/views/pwa/manifest.json.erb` and linked from the layout). When someone asks how to download, install, or put the app on their phone, don't just explain — **build them an install page**:
+
+1. **Create an install-instructions page at `/install`** (skip if it already exists):
+   - Route: `get "install", to: "pages#install"` — create a simple `PagesController#install` with a view if there isn't one.
+   - The page walks them through installing, one section per device (Daisy UI cards/steps + Font Awesome icons, plain 7th-grade English):
+     - **iPhone / iPad:** open this site in **Safari** → tap the **Share** button → **Add to Home Screen** → **Add**. (Only works from Safari.)
+     - **Android:** open this site in **Chrome** → tap the **menu (three dots)** → **Add to Home screen** / **Install app** → confirm.
+     - **Computer (Windows / Mac):** open this site in **Chrome or Edge** → click the **install icon** in the address bar (or browser menu → "Install…") → confirm.
+2. **Add a small "Install" button** on the page they're currently looking at that links to `/install` (e.g. a Daisy UI button with `fa-solid fa-mobile-screen-button`).
+3. **Give them the direct link for their phone:** `https://rails-{HOSTED_DOMAIN}/install` (look up `HOSTED_DOMAIN` — never guess). Tell them: *"Open this link on your phone and follow the steps — your app will get its own icon on your home screen."*
+4. **Polish the manifest:** update `name` and `description` in `app/views/pwa/manifest.json.erb` to match their app, and set `theme_color`/`background_color` to match its look (the defaults are placeholder red).
+
+Installing this way gives them a real app icon that opens **just their app** — full screen, no browser bars, no chat/editor interface. Native App Store distribution is a different conversation — if they push for that, point them to **support@llamapress.ai**.
 
 **"Can I download the code?":** That's a separate thing from running the app. The app is already running for them — they don't need the code to use it. If they want a copy of the code itself, that's the GitHub sync flow → email **support@llamapress.ai**.
 
@@ -258,7 +270,7 @@ When you spot that confusion, gently reframe it. Don't make them feel silly. Try
 | "build me X" / "add Y" / any description of an app idea | **BUILD IT NOW.** Make a TODO list → build → show them what to click. Don't ask clarifying questions — pick defaults and go. |
 | "it's broken" / "this doesn't work" | Calmly investigate. Explain the problem in plain words. Fix it. |
 | User sends a file / attachment / "I have a spreadsheet" | See **EXCEL & FILE IMPORTS** below. Pull the file, inspect it, and start building immediately. |
-| "how do I download this?" / "can I install this on my phone?" / "where's the app file?" / anything that suggests they think the app needs to be downloaded | Reframe gently: their app is **already live** on the right side of the screen, shareable via URL. See **EXPLAINING THAT THE APP IS ALREADY LIVE** above. |
+| "how do I download this?" / "can I install this on my phone?" / "where's the app file?" / anything that suggests they think the app needs to be downloaded | Reframe gently: their app is **already live** on the right side of the screen, shareable via URL. If they want it **on their phone**, build the `/install` page + Install button — see **Phones** under **EXPLAINING THAT THE APP IS ALREADY LIVE** above. |
 | "how much does this cost?" / "what are the paid plans?" / any pricing question | Share `https://llamapress.ai/pricing`. Don't quote prices. |
 | User says "stop asking questions" / "just build it" | You messed up. Immediately start building with whatever you know. Apologize briefly and get to work. |
 
@@ -750,7 +762,7 @@ When you call `suggest_plan_mode`, the user will see a button to switch. After s
 - If I just finished work, did I end with the **handoff block** and avoid telling them to refresh?
 - **Are my 3 next-step options specific to THIS app** — naming its real data/screens/actions — instead of generic filler like "make it better" or "anything else?"
 - If I built something new, is it on the page they're on, or is there a clear link?
-- If they sounded confused about needing to download/install the app, did I reframe it as **already live** with their URL?
+- If they sounded confused about needing to download/install the app, did I reframe it as **already live** with their URL? If they wanted it on their phone, did I build the `/install` page and add the Install button?
 - If pricing came up, did I include `https://llamapress.ai/pricing`?
 - Did I update LEONARDO.md if anything meaningful changed?
 - Did I learn anything worth saving with `save_memory`?

--- a/app/agents/leonardo/rails_plain_chat_mode/nodes.py
+++ b/app/agents/leonardo/rails_plain_chat_mode/nodes.py
@@ -1,0 +1,67 @@
+"""Plain chat mode: an LLM and nothing else.
+
+Deliberately the simplest graph in the repo — one node, no tools, no ToolNode, no
+conditional edges. It cannot read, write, or run anything; it can only talk. That
+is the whole point: it's the mode granted to the `user` role (see
+app/permissions.py DEFAULT_ROLE_MODES), so its capability ceiling IS the
+permission boundary. Adding a tool here silently widens what that role can do.
+
+Reuses RailsAgentState so the fields the frontend already sends (llm_model,
+debug_info, ...) pass through unchanged, and so thread state stays compatible if
+a user switches modes mid-thread.
+"""
+import logging
+
+from dotenv import load_dotenv
+from langgraph.graph import END, START, StateGraph
+
+from app.agents.leonardo.llm_factory import get_llm
+from app.agents.leonardo.rails_agent.state import RailsAgentState
+from app.agents.leonardo.project_context import brand_context_section
+
+load_dotenv()
+
+logger = logging.getLogger(__name__)
+
+PLAIN_CHAT_PROMPT = """You are a helpful assistant inside LlamaPress.
+
+You are in plain chat mode: you can talk with the user, answer questions, explain
+things, and help them think. You have no tools — you cannot read or edit files,
+run commands, browse the web, or change their app.
+
+If the user asks you to DO something to their app, say plainly that you can't in
+this mode, and tell them to switch modes using the mode selector to get an agent
+that can. Don't guess at file contents or pretend to have made a change."""
+
+
+def get_sys_msg():
+    # Rebuilt per turn so a brand-guide edit lands without a restart (same
+    # reasoning as the other raw-graph agents' get_sys_msg).
+    return {
+        "role": "system",
+        "content": [
+            {
+                "type": "text",
+                "text": PLAIN_CHAT_PROMPT + brand_context_section(),
+                "cache_control": {"type": "ephemeral"},
+            },
+        ],
+    }
+
+
+def plain_chat(state: RailsAgentState):
+    llm_model = state.get("llm_model") or "deepseek-v4-flash"
+    logger.info(f"Using LLM model: {llm_model}")
+
+    # No .bind_tools() — see the module docstring before adding any.
+    llm = get_llm(llm_model)
+
+    return {"messages": [llm.invoke([get_sys_msg()] + state["messages"])]}
+
+
+def build_workflow(checkpointer=None):
+    builder = StateGraph(RailsAgentState)
+    builder.add_node("plain_chat", plain_chat)
+    builder.add_edge(START, "plain_chat")
+    builder.add_edge("plain_chat", END)
+    return builder.compile(checkpointer=checkpointer)

--- a/app/agents/leonardo/rails_ticket_mode_agent/prompts.py
+++ b/app/agents/leonardo/rails_ticket_mode_agent/prompts.py
@@ -8,6 +8,18 @@ You are **Leonardo Ticket Mode** - a specialized agent for converting non-techni
 - NO emoji spam or bullet point menus
 - ONE question at a time when gathering information
 
+**DRAFT, DON'T INTERROGATE.** Your default move on ANY vague input is to fill in the
+observation template with your best-guess defaults and ask the user to correct it — NOT to
+hand back a list of options and wait. A wrong draft the user edits in 5 seconds beats a
+menu that costs them a round-trip. Never respond with "which of these would you like?"
+when you could have picked and shown them.
+
+**NEVER ASK THE SAME QUESTION TWICE.** If you already asked for something and the user
+answered vaguely, deflected, or said "just do it" / "skip this" / "ship it" — that is a
+GO. Pick sensible defaults, mark them as assumptions in the observation, and move forward.
+Re-asking a question the user has already declined to answer is the single worst failure
+mode in Ticket Mode. If you catch yourself about to repeat a question, draft instead.
+
 ---
 
 ## User-Uploaded Files
@@ -343,6 +355,44 @@ When user provides partial info, YOU complete the template and ask them to verif
 - **Only include Business Rules the user explicitly stated** - with source citations
 - If no Business Rules stated, write: "Business Rules: (None stated - will identify existing rules during research)"
 - Ask: "Does this look right? If so, I'll delegate the technical research."
+
+**UI SCOPE IS YOURS TO DEFAULT — DON'T ASK, PICK.**
+
+When the user asks for something whose *shape* is unspecified ("make this a landing page",
+"add a dashboard", "clean up this form"), the specific UI content is a **minor UI default**,
+NOT a business rule. You own it. Pick the conventional answer, put it in the observation
+marked as an assumption, and let the user edit it.
+
+| User says | ❌ BAD (menu) | ✅ GOOD (draft with defaults) |
+|-----------|--------------|------------------------------|
+| "Make this a landing page" | "Which sections? Features, pricing, testimonials, FAQ...?" | Draft with hero + features + how-it-works + CTA + footer, marked ASSUMED |
+| "Add a dashboard" | "What metrics do you want?" | Draft with the obvious metrics for this domain, marked ASSUMED |
+| "Clean up this form" | "What's wrong with it?" | Draft with the visible issues you found in the quick context check |
+
+**The test:** Could a competent designer pick a reasonable default without asking? If yes → pick it.
+Only ask when the answer is a **domain/business rule** you cannot source (pricing amounts,
+who can see what, how a value is calculated) — those are the conservative categories and
+they still require a source or UNKNOWN.
+
+**Mark assumed scope explicitly** so the user knows what to push back on:
+```
+**Desired Behavior:** Home page is a full landing page with hero, features, how-it-works, and a closing CTA.
+
+*(ASSUMED — I picked standard landing page sections. Tell me what to add/cut and I'll adjust.)*
+```
+
+**HANDLING "JUST DO IT" / EXPLICIT GO-AHEAD:**
+
+When the user says "do it", "ship it", "skip all this", "great", "looks good", or otherwise
+signals go — that is confirmation. Immediately:
+1. If you have a drafted observation → call `delegate_task` for research. Do not re-confirm.
+2. If you have NOT drafted one yet → draft it with defaults AND delegate in the same turn.
+   Say "Going with these defaults — correcting anything is easy, starting research now."
+
+An explicit go-ahead OVERRIDES your desire for more detail. Missing detail goes in
+**Unresolved Questions** with a recommended default, or **Non-Goals** — it does not block
+the ticket. The user can always correct the draft; they cannot get time back from a
+question loop.
 
 **CRITICAL: Before delegating research, ensure you have confirmed:**
 - URL (auto-filled)
@@ -1489,7 +1539,9 @@ If user asks for code changes: "I can't make code changes in Ticket Mode. Once t
 1. Greet briefly
 2. Check if view_path is available - if so, acknowledge the URL they're on
 3. Explain Ticket Mode's purpose (1 sentence)
-4. Ask them to fill out the remaining template fields
+4. **If they described ANYTHING at all → draft the filled observation with your defaults and
+   ask them to confirm/correct.** Do NOT ask them to fill fields in. Do NOT offer a menu of
+   options. Only ask an open "what's the issue?" when they've given you literally nothing.
 5. Remind them to SELECT the specific UI element they're observing
 
 **Example first response (WITH view_path available):**
@@ -1619,6 +1671,47 @@ Got it! Here's the ticket outline:
 Does this capture what you want? Any specific content that must be in the PDF?
 ```
 
+### Example: User asks for something with unspecified UI shape
+
+User: "As a user, I want to make this page into more of a landing page."
+
+**BAD response (this is the #1 observed failure — do NOT do this):**
+```
+To turn this into more of a landing page, I need a bit more detail from you:
+What elements would you like to add? Common landing page sections include:
+- Hero section
+- Feature highlights
+- Testimonials
+- Pricing tiers
+And what's the overall vibe? Professional SaaS, playful, minimalist?
+```
+Why it's bad: it's a bullet menu, it asks two questions, and it makes the user do the
+design work. "Which landing page sections" is a minor UI default — you pick it.
+
+**GOOD response:**
+```
+Got it. Here's the ticket outline:
+
+**URL:** /
+**User Story:** As a visitor, I want a full landing page so I understand what the product offers before signing up.
+**Current Behavior:** Home page is a minimal hero with logo, tagline, and sign-in/sign-up buttons only.
+**Desired Behavior:** Home page is a full landing page with a polished hero, a features section, a how-it-works section, and a closing sign-up CTA.
+
+*(ASSUMED — I picked standard landing page sections. Tell me what to add or cut.)*
+
+**Verification Criteria (UI/UX):**
+- [ ] Given I visit the home page, When it loads, Then I see a polished hero with a clear value proposition and sign-up CTA
+- [ ] Given I scroll down, When I view the page, Then I see a features section, a how-it-works section, and a closing CTA
+
+**Business Rules:**
+(None stated - will identify during research)
+
+Look right? I'll delegate the research.
+```
+
+**If the user then says "just do it" / "ship it" / "great":** that's a GO. Delegate research
+immediately. Do NOT re-ask which sections — you already defaulted them and they didn't object.
+
 ### Example: User describes multiple issues at once
 
 User: "The rate is wrong and also the delete button doesn't work and the page is slow"
@@ -1639,9 +1732,10 @@ I'll create a ticket for whichever you pick first, then we can do the others.
 
 1. **Always auto-fill the template** with whatever you can infer
 2. **Never run queries or debug** — that's what the research sub-agent is for AFTER confirmation
-3. **Ask ONE clarifying question** if something critical is missing
-4. **Keep responses to 3-4 sentences** plus the template
-5. **Frame everything as outcome, not technical investigation** — "Desired Behavior" is what the user wants to see, not what code needs to change
+3. **Ask AT MOST ONE clarifying question, and only if it's a domain/business rule you can't source.** UI shape, sections, layout, and vibe are yours to default — never ask about those.
+4. **Never ask the same question twice.** A vague answer, a deflection, or "just do it" = GO with defaults.
+5. **Keep responses to 3-4 sentences** plus the template
+6. **Frame everything as outcome, not technical investigation** — "Desired Behavior" is what the user wants to see, not what code needs to change
 
 ---
 
@@ -1682,7 +1776,7 @@ The sub-agent will complete the task and report back with a summary of findings.
 2. **VC = restatements only** - VC may only be direct, UI-observable restatements of Desired Behavior. If adding a new requirement axis (sorting, defaults, permissions, validation, editability), ask first.
 3. **NEVER invent Business Rules** - Domain logic MUST have explicit source (user quote, screenshot, requirement doc, code observation)
 4. **Source: UNKNOWN triggers clarifying question** - Ask ONE question (with recommended default). Only use ASSUMPTION if blocked.
-5. **ALWAYS auto-fill what you can** - Be helpful, not bureaucratic. Restate Desired Behavior as VC and ask user to confirm.
+5. **ALWAYS auto-fill what you can** - Be helpful, not bureaucratic. Restate Desired Behavior as VC and ask user to confirm. **Draft, don't interrogate:** UI shape/sections/layout are minor UI defaults you PICK (marked ASSUMED), never a menu you hand back. Never ask the same question twice — "just do it" / "ship it" / a vague answer is a GO. See "UI SCOPE IS YOURS TO DEFAULT" and "HANDLING 'JUST DO IT'".
 6. **NEVER write code** - Research and tickets only
 7. **ALWAYS call write_final_ticket() to persist ticket** - You MUST call `write_final_ticket()` with all required fields (title, description, ticket_type) and verify success BEFORE announcing "Ticket created." Generating content in your response is NOT persisting it.
 8. **ALWAYS use delegate_task for research** - Keep your context clean by delegating technical research to a sub-agent

--- a/app/agents/leonardo/resilience.py
+++ b/app/agents/leonardo/resilience.py
@@ -19,6 +19,7 @@ can never break graph compilation (fleet-wide compile guard).
 """
 
 import logging
+import time
 
 logger = logging.getLogger(__name__)
 
@@ -45,6 +46,12 @@ def transient_exception_types() -> tuple[type, ...]:
             httpx.ReadTimeout,
             httpx.RemoteProtocolError,
             httpx.PoolTimeout,
+            # Mid-stream socket read/write failures (mapped from httpcore.Read/
+            # WriteError). ReadError has an empty str(e); it kills a turn when the
+            # peer drops the connection while we're streaming the response. Same
+            # transient family as the timeouts above — a retry genuinely helps.
+            httpx.ReadError,
+            httpx.WriteError,
         ]
     except Exception:  # pragma: no cover - httpx is always present today
         pass
@@ -121,3 +128,52 @@ def is_transient_error(exc: BaseException) -> bool:
     if code is not None:
         return code in _TRANSIENT_STATUS
     return False
+
+
+# =============================================================================
+# Rung 1 retry mechanics (shared by every call path, not just the middleware)
+# =============================================================================
+#
+# The retry *policy* (how many attempts, how long to back off) lives here next to
+# the transient/deterministic classifier so there is exactly one source of truth.
+# DynamicModelMiddleware.wrap_model_call runs its own inline loop over the handler
+# (it also does model selection); raw StateGraph nodes that call the model
+# directly — and therefore never touch the middleware — use invoke_with_transient
+# _retry below. Both share these constants so their behavior can't drift apart.
+_MODEL_RETRY_MAX_ATTEMPTS = 5          # initial call + up to 4 retries
+_MODEL_RETRY_BASE_DELAY = 0.5          # seconds
+_MODEL_RETRY_MAX_DELAY = 8.0           # seconds
+
+
+def _model_retry_delay(attempt: int) -> float:
+    """Exponential backoff (capped) for the Nth failed attempt (1-based)."""
+    return min(_MODEL_RETRY_BASE_DELAY * (2 ** (attempt - 1)), _MODEL_RETRY_MAX_DELAY)
+
+
+def invoke_with_transient_retry(fn, *, label: str = "model call"):
+    """Call ``fn()`` with rung-1 transient-error retry semantics, returning its result.
+
+    For raw StateGraph nodes (e.g. rails_beginner_agent, rails_ai_builder_agent)
+    that invoke the model directly and thus never run through
+    ``DynamicModelMiddleware.wrap_model_call`` — the only other place this ladder
+    lives. Re-calls ``fn`` up to ``_MODEL_RETRY_MAX_ATTEMPTS`` times with capped
+    exponential backoff while ``is_transient_error`` is true; a deterministic
+    error (bad kwarg -> TypeError, 400) or a persistent transient one re-raises so
+    it can flow on to the fallback/floor rungs instead of retrying identically.
+
+    ``fn`` is a zero-arg thunk so the caller keeps full control of how the model is
+    invoked (bind_tools, cache_control kwargs, message list, etc.).
+    """
+    attempt = 0
+    while True:
+        try:
+            return fn()
+        except Exception as e:
+            attempt += 1
+            if attempt >= _MODEL_RETRY_MAX_ATTEMPTS or not is_transient_error(e):
+                raise
+            logger.warning(
+                "Transient error on %s (attempt %d/%d): %r; retrying",
+                label, attempt, _MODEL_RETRY_MAX_ATTEMPTS - 1, e,
+            )
+            time.sleep(_model_retry_delay(attempt))

--- a/app/frontend/chat.html
+++ b/app/frontend/chat.html
@@ -217,16 +217,17 @@
                     <select data-llamabot="agent-mode-select" class="custom-dropdown">
                         <option value="engineer" data-short-label="Engineer" data-original-label="Engineer Mode">Engineer</option>
                         <option value="ticket" data-short-label="Ticket">Ticket Mode</option>
-                        <option value="user" data-short-label="Database">Database Mode</option>
+                        <option value="database" data-short-label="Database">Database Mode</option>
                         <option value="ai_builder" data-short-label="AI Builder">AI Builder Mode</option>
                         <option value="testing" data-short-label="Test Builder">Test Builder Mode</option>
                         <option value="beginner" data-short-label="Beginner" selected>Beginner Mode</option>
                         <option value="pyxl" data-short-label="PyXL">PyXL (Excel → Rails)</option>
+                        <option value="chat" data-short-label="Chat">Chat (no tools)</option>
                     </select>
                 </div>
             </div>
             <input type="file" data-llamabot="file-input" class="hidden-file-input" accept=".pdf,.png,.jpg,.jpeg,.gif,.webp,.webm,.mp4,.xlsx,.xls,.csv,image/png,image/jpeg,image/gif,image/webp,video/webm,video/mp4,application/pdf,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.ms-excel,text/csv" multiple>
-            <input type="file" data-llamabot="upload-file-input" class="hidden-file-input" accept=".pdf,.docx,.png,.jpg,.jpeg,.gif,.webp,.svg,.xlsx,.xls,.xlsm,.xlsb,.xltx,.xltm,.csv,.pptx,.ppt,.pptm,.key,.odp,.mp4,.webm,.xml,.json,.txt,.md,.yaml,.yml,.html,.htm,.zip" multiple>
+            <input type="file" data-llamabot="upload-file-input" class="hidden-file-input" accept=".pdf,.docx,.png,.jpg,.jpeg,.gif,.webp,.svg,.ico,.xlsx,.xls,.xlsm,.xlsb,.xltx,.xltm,.csv,.pptx,.ppt,.pptm,.key,.odp,.mp4,.webm,.xml,.json,.txt,.md,.yaml,.yml,.html,.htm,.zip" multiple>
             <!-- Model selector (hidden by default, shown when model toggle clicked) -->
             <div class="model-selector-container hidden" data-llamabot="model-selector-container">
                 <div class="custom-dropdown-container">
@@ -240,6 +241,8 @@
                         <option value="gpt-5.4-nano" data-short-label="GPT-5.4 Nano">GPT-5.4 Nano</option>
                         <option value="deepseek-v4-flash" data-short-label="DeepSeek" selected>DeepSeek V4 Flash</option>
                         <option value="deepseek-v4-pro" data-short-label="DeepSeek Pro">DeepSeek V4 Pro</option>
+                        <option value="deepseek-v4-flash-gmi" data-short-label="DeepSeek GMI">DeepSeek V4 Flash (GMI)</option>
+                        <option value="deepseek-v4-flash-fireworks" data-short-label="DeepSeek FW">DeepSeek V4 Flash (Fireworks)</option>
                         <option value="qwen3.7-plus" data-short-label="Qwen">Qwen3.7 Plus</option>
                     </select>
                 </div>
@@ -744,8 +747,7 @@
 
     <!-- Role-based mode and tab restriction -->
     <script>
-        // Filter agent modes based on user's visible_agents setting
-        // Also handle legacy 'user' role restriction and hide engineer-only tabs
+        // Filter agent modes to the user's granted set, and hide engineer-only tabs.
         // Wait for LlamaBot to initialize before modifying the dropdown
         window.addEventListener('llamabot:ready', function() {
             const userRole = window.LLAMABOT_USER_ROLE || 'engineer';
@@ -771,18 +773,11 @@
                     modeSelect.appendChild(opt);
                 });
 
-                // If user role is 'user' and no visible_agents configured (legacy behavior)
-                if (userRole === 'user' && !visibleAgents) {
-                    // Restrict agent mode dropdown to only feedback
-                    Array.from(modeSelect.options).forEach(option => {
-                        if (option.value !== 'feedback') {
-                            option.remove();
-                        }
-                    });
-                    modeSelect.value = 'feedback';
-                }
-                // If visible_agents is configured, filter dropdown to those agents only
-                else if (visibleAgents && Array.isArray(visibleAgents)) {
+                // Filter the dropdown to the modes this user is granted. The backend
+                // always injects LLAMABOT_VISIBLE_AGENTS (app/permissions.py resolves
+                // role grant ∩ per-user preference), so this is presentation only —
+                // the WebSocket rejects an ungranted agent_name regardless.
+                if (visibleAgents && Array.isArray(visibleAgents)) {
                     Array.from(modeSelect.options).forEach(option => {
                         if (!visibleAgents.includes(option.value)) {
                             option.remove();

--- a/app/frontend/chat/config.js
+++ b/app/frontend/chat/config.js
@@ -24,14 +24,19 @@ export const DEFAULT_CONFIG = {
   },
 
   // Agent mode mappings
+  // Mode key -> agent_name (the langgraph graph that actually runs).
+  // Mirrored server-side by MODE_AGENTS in app/permissions.py, which gates these
+  // on the WebSocket — app/tests/test_permissions.py parses THIS object and fails
+  // if the two drift. Change one, change the other.
   agentModes: {
     engineer: 'rails_agent',
     ai_builder: 'rails_ai_builder_agent',
     testing: 'rails_testing_agent',
     ticket: 'rails_ticket_mode_agent',
-    user: 'rails_user_mode_agent',
+    database: 'rails_user_mode_agent',
     beginner: 'rails_beginner_agent',
     pyxl: 'pyxl_agent',
+    chat: 'rails_plain_chat_mode',
     plan: 'rails_plan_mode_agent',
     engineer_plan: 'rails_engineer_plan_mode_agent',
     ticket_plan: 'rails_ticket_plan_mode_agent'

--- a/app/frontend/chat/index.js
+++ b/app/frontend/chat/index.js
@@ -96,6 +96,8 @@ class ChatApp {
     this.modelCapabilities = new Map([
       ['deepseek-v4-flash', { images: false }],
       ['deepseek-v4-pro', { images: false }],
+      ['deepseek-v4-flash-gmi', { images: false }],
+      ['deepseek-v4-flash-fireworks', { images: false }],
       // Qwen3.7 Plus is image-capable — seed it so an image upload while it's
       // selected is NOT spuriously auto-switched to Gemini before the async
       // /api/available-models fetch resolves (the unknown-model default is
@@ -1321,7 +1323,68 @@ class ChatApp {
   /**
    * Send message via WebSocket
    */
-  sendMessage(debugInfo = null) {
+  /**
+   * Fetch (and cache) the per-user Rails API token.
+   *
+   * Why this exists: the chat UI and the Rails app are on DIFFERENT ORIGINS, so this
+   * page can't read Rails' session cookie. Rails mints a short-lived token for
+   * whoever the cookie says you are, and we pass it to the agent, which presents it
+   * back to Rails — so the agent acts as YOU, with your permissions.
+   *
+   * Rails is the only thing that can mint one (it holds the signing key). That's the
+   * point: LlamaBot can't forge a token for someone else.
+   *
+   * Returns null when the user isn't signed into the Rails app. That's a normal
+   * state, not an error — agents needing the token report it themselves.
+   */
+  async getRailsApiToken() {
+    // Reuse while valid. Refresh a minute early so a token can't expire in flight
+    // on a long agent turn.
+    const now = Date.now();
+    if (this._railsApiToken && now < this._railsApiTokenExpiresAt - 60_000) {
+      return this._railsApiToken;
+    }
+    // Coalesce concurrent callers onto one request.
+    if (this._railsApiTokenPromise) return this._railsApiTokenPromise;
+
+    this._railsApiTokenPromise = (async () => {
+      try {
+        const resp = await fetch(`${getRailsUrl()}/llama_bot/agent/token`, {
+          // Sends the Rails session cookie. Both hosts sit under the same site, so
+          // the cookie rides along; Rails must allow this origin + credentials (see
+          // AgentTokenController#set_cors_headers) or the browser blocks the read.
+          credentials: 'include',
+          headers: { 'Accept': 'application/json' }
+        });
+        if (!resp.ok) {
+          // 401 = not signed into Rails. Expected; don't spam the console.
+          if (resp.status !== 401) {
+            console.warn(`[llamabot] token fetch failed: HTTP ${resp.status}`);
+          }
+          this._railsApiToken = null;
+          return null;
+        }
+        const data = await resp.json();
+        this._railsApiToken = data.api_token || null;
+        this._railsApiTokenExpiresAt = Date.now() + ((data.expires_in || 1800) * 1000);
+        return this._railsApiToken;
+      } catch (e) {
+        // Network/CORS failure. Never block sending a message over this.
+        console.warn('[llamabot] token fetch error:', e.message);
+        this._railsApiToken = null;
+        return null;
+      } finally {
+        this._railsApiTokenPromise = null;
+      }
+    })();
+
+    return this._railsApiTokenPromise;
+  }
+
+  // async only for the token fetch below — every caller is fire-and-forget (never
+  // awaits, never uses the return), and all the synchronous UI work still happens
+  // before the first await.
+  async sendMessage(debugInfo = null) {
     const input = this.elements.messageInput;
     if (!input) return;
 
@@ -1546,7 +1609,15 @@ class ChatApp {
         engineer: 'rails_engineer_plan_mode_agent',
         ticket: 'rails_ticket_plan_mode_agent',
       };
-      agentName = planAgentByMode[agentMode] || 'rails_plan_mode_agent';
+      // Modes with no plan variant at all — they keep their own agent when Plan is
+      // toggled. `chat` MUST stay here: the generic plan agent has tools, so falling
+      // back to it would hand a chat-only user (the `user` role) a tool-using agent.
+      // MODE_AGENTS in app/permissions.py grants chat exactly one graph and the
+      // WebSocket enforces it, so a fallback here would just be denied anyway.
+      const NO_PLAN_VARIANT = ['chat'];
+      if (!NO_PLAN_VARIANT.includes(agentMode)) {
+        agentName = planAgentByMode[agentMode] || 'rails_plan_mode_agent';
+      }
     }
 
     // Send message. The client_message_id is the idempotency key: it stays
@@ -1556,6 +1627,12 @@ class ChatApp {
     const clientMessageId = (window.crypto && window.crypto.randomUUID)
       ? window.crypto.randomUUID()
       : `cmid-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    // Per-user Rails token, so agents can call the app's API AS this user. Fetched
+    // fresh-ish from Rails (see getRailsApiToken); null when they aren't signed into
+    // the Rails app, in which case agents that need it say so rather than acting
+    // unauthenticated. Awaited here so the very first message carries it.
+    const apiToken = await this.getRailsApiToken();
+
     const messageData = {
       message: message,
       thread_id: threadId,
@@ -1568,6 +1645,7 @@ class ChatApp {
       attachments: attachments.filter(a => a.type !== 'uploaded_file'),
       ask_before_edits: executionMode === 'ask'
     };
+    if (apiToken) messageData.api_token = apiToken;
 
     this.webSocketManager.send(messageData);
     this.lastSentMessageData = messageData;

--- a/app/frontend/chat/ui/BrandGuide.js
+++ b/app/frontend/chat/ui/BrandGuide.js
@@ -46,7 +46,7 @@ export class BrandGuide {
     // Hidden input for uploading logo images.
     this.logoInput = document.createElement('input');
     this.logoInput.type = 'file';
-    this.logoInput.accept = 'image/png,image/jpeg,image/gif,image/webp,image/svg+xml,.png,.jpg,.jpeg,.gif,.webp,.svg';
+    this.logoInput.accept = 'image/png,image/jpeg,image/gif,image/webp,image/svg+xml,image/x-icon,image/vnd.microsoft.icon,.png,.jpg,.jpeg,.gif,.webp,.svg,.ico';
     this.logoInput.style.display = 'none';
     this.logoInput.addEventListener('change', (e) => this.onLogoChosen(e));
     this.panel.appendChild(this.logoInput);

--- a/app/frontend/chat/ui/PromptManager.js
+++ b/app/frontend/chat/ui/PromptManager.js
@@ -4,17 +4,22 @@
  * Manages the prompt library panel in the chat interface.
  * Allows users to browse, search, select, and quick-edit prompts to attach to messages.
  *
- * NOTE: This panel used to have a second "Skills" tab (DB-backed prompt-blobs
- * multi-selected and concatenated into every message). Skills are now Agent
- * Skills on the filesystem (.leonardo/skills/<slug>/SKILL.md, the SKILL.md open
- * standard) that the model loads on demand via the use_skill tool — so the
- * legacy Skills tab was removed and this manager is prompts-only.
+ * Two tabs:
+ *   - Prompts: DB-backed prompt library; selecting one attaches it as a badge
+ *     that gets prepended to the next message.
+ *   - Skills: filesystem Agent Skills (.leonardo/skills/<slug>/SKILL.md, the
+ *     SKILL.md open standard) read from /api/skills. These are NOT attached —
+ *     clicking one drops "/<slug> " into the input, same as picking it from the
+ *     slash-command dropdown (see SlashCommandManager.evokeSkill). The agent
+ *     recognizes the leading token and calls use_skill for that slug.
  */
 
 export class PromptManager {
   constructor() {
     this.isOpen = false;
+    this.activeTab = 'skills';
     this.prompts = [];
+    this.skills = [];
     this.groups = [];
     this.selectedPrompt = null;
     this.selectedBadge = null;
@@ -71,16 +76,17 @@ export class PromptManager {
     this.panel.innerHTML = `
       <div class="prompt-panel-header">
         <div class="prompt-panel-tabs">
-          <span class="prompt-panel-title">Prompts</span>
+          <button class="prompt-panel-tab active" data-tab="skills">Skills</button>
+          <button class="prompt-panel-tab" data-tab="prompts">Prompts</button>
         </div>
-        <button class="prompt-panel-add" title="Add new prompt">
+        <button class="prompt-panel-add" title="Add new prompt" style="display: none;">
           <i class="fa-solid fa-plus"></i>
         </button>
         <button class="prompt-panel-close" title="Close">&times;</button>
       </div>
       <div class="prompt-panel-search">
-        <input type="text" placeholder="Search prompts..." class="prompt-search-input">
-        <select class="prompt-group-select">
+        <input type="text" placeholder="Search skills..." class="prompt-search-input">
+        <select class="prompt-group-select" style="display: none;">
           <option value="">All Groups</option>
         </select>
       </div>
@@ -96,6 +102,14 @@ export class PromptManager {
     } else {
       this.inputArea.insertBefore(this.panel, this.inputArea.firstChild);
     }
+
+    // Tab switching
+    this.panel.querySelectorAll('.prompt-panel-tab').forEach(tab => {
+      tab.addEventListener('click', (e) => {
+        e.stopPropagation();
+        this.switchTab(tab.dataset.tab);
+      });
+    });
 
     // Add button
     this.panel.querySelector('.prompt-panel-add').addEventListener('click', (e) => {
@@ -113,6 +127,11 @@ export class PromptManager {
     let searchTimeout;
     searchInput.addEventListener('input', () => {
       clearTimeout(searchTimeout);
+      // Skills are filtered client-side (small list, already fetched), so no debounce needed there.
+      if (this.activeTab === 'skills') {
+        this.renderSkills();
+        return;
+      }
       searchTimeout = setTimeout(() => this.loadPrompts(), 300);
     });
 
@@ -336,14 +355,120 @@ export class PromptManager {
     this.panel.classList.add('open');
     this.button.classList.add('active');
 
-    await this.loadGroups();
-    await this.loadPrompts();
+    if (this.activeTab === 'skills') {
+      await this.loadSkills();
+    } else {
+      await this.loadGroups();
+      await this.loadPrompts();
+    }
 
     // Focus search input
     const searchInput = this.panel.querySelector('.prompt-search-input');
     if (searchInput) {
       searchInput.focus();
     }
+  }
+
+  /**
+   * Switch between the Prompts and Skills tabs. The group filter and the "add"
+   * button are prompts-only (skills are authored by the agent, not this panel).
+   */
+  async switchTab(tab) {
+    if (!tab || tab === this.activeTab) return;
+    this.activeTab = tab;
+
+    this.panel.querySelectorAll('.prompt-panel-tab').forEach(t => {
+      t.classList.toggle('active', t.dataset.tab === tab);
+    });
+
+    const isSkills = tab === 'skills';
+    this.panel.querySelector('.prompt-group-select').style.display = isSkills ? 'none' : '';
+    this.panel.querySelector('.prompt-panel-add').style.display = isSkills ? 'none' : '';
+
+    const searchInput = this.panel.querySelector('.prompt-search-input');
+    searchInput.value = '';
+    searchInput.placeholder = isSkills ? 'Search skills...' : 'Search prompts...';
+
+    if (isSkills) {
+      await this.loadSkills();
+    } else {
+      await this.loadGroups();
+      await this.loadPrompts();
+    }
+  }
+
+  /**
+   * Load installed Agent Skills from the filesystem-backed skills API.
+   */
+  async loadSkills() {
+    const list = this.panel.querySelector('.prompt-panel-list');
+    list.innerHTML = '<div class="prompt-empty">Loading...</div>';
+    try {
+      const response = await fetch('/api/skills');
+      this.skills = response.ok ? await response.json() : [];
+      this.renderSkills();
+    } catch (error) {
+      console.error('Failed to load skills:', error);
+      list.innerHTML = '<div class="prompt-error">Failed to load skills</div>';
+    }
+  }
+
+  /**
+   * Render the skills list (filtered by the search box).
+   */
+  renderSkills() {
+    const list = this.panel.querySelector('.prompt-panel-list');
+    const query = this.panel.querySelector('.prompt-search-input').value.trim().toLowerCase();
+
+    const filtered = query
+      ? this.skills.filter(s =>
+          (s.slug || '').toLowerCase().includes(query) ||
+          (s.name || '').toLowerCase().includes(query) ||
+          (s.description || '').toLowerCase().includes(query))
+      : this.skills;
+
+    if (filtered.length === 0) {
+      list.innerHTML = `
+        <div class="prompt-empty">
+          <p>${this.skills.length === 0
+            ? 'No skills installed yet — ask me to create one.'
+            : 'No skills match your search'}</p>
+        </div>
+      `;
+      return;
+    }
+
+    list.innerHTML = filtered.map(s => `
+      <div class="skill-item" data-slug="${this.escapeHtml(s.slug)}">
+        <div class="skill-item-header">
+          <span class="skill-item-checkbox"><i class="fa-solid fa-bolt"></i></span>
+          <span class="skill-item-name">${this.escapeHtml(s.name || s.slug)}</span>
+          <span class="skill-item-group">/${this.escapeHtml(s.slug)}</span>
+        </div>
+        ${s.description ? '<div class="skill-item-preview">' + this.escapeHtml(s.description) + '</div>' : ''}
+      </div>
+    `).join('');
+
+    list.querySelectorAll('.skill-item').forEach(item => {
+      item.addEventListener('click', () => this.insertSkillToken(item.dataset.slug));
+    });
+  }
+
+  /**
+   * Drop "/<slug> " into the message input so the user can add their own request
+   * after it. Mirrors SlashCommandManager.evokeSkill — nothing is sent here.
+   */
+  insertSkillToken(slug) {
+    if (!slug || !this.messageInput) return;
+
+    this.closePanel();
+    this.messageInput.value = `/${slug} `;
+    this.messageInput.focus();
+    const len = this.messageInput.value.length;
+    if (this.messageInput.setSelectionRange) {
+      this.messageInput.setSelectionRange(len, len);
+    }
+    this.messageInput.dispatchEvent(new Event('input', { bubbles: true }));
   }
 
   /**

--- a/app/frontend/style.css
+++ b/app/frontend/style.css
@@ -42,6 +42,10 @@ body {
     border-right: 1px solid var(--border-color);
     position: relative;
     transition: width 0.15s ease, min-width 0.15s ease;
+    /* Let header controls respond to the panel's own width (it's resized
+       independently of the viewport) via container queries. */
+    container-type: inline-size;
+    container-name: chat-panel;
 }
 
 /* Resize handle between chat and iframe sections */
@@ -337,6 +341,27 @@ body {
 
 .compose-thread-btn i {
     font-size: 12px;
+}
+
+/* When the chat panel is narrow, drop the "New" label so the button shrinks
+   to just the plus icon and stops crowding the Leo title. */
+@container chat-panel (max-width: 380px) {
+    .compose-thread-btn span {
+        display: none;
+    }
+    .compose-thread-btn {
+        padding: 0 8px;
+    }
+    /* Pull the header controls closer together instead of letting them run
+       into the Leo title. */
+    .chat-header {
+        gap: 0.3rem;
+        padding-left: 0.6rem;
+        padding-right: 0.6rem;
+    }
+    .chat-header .logo-container {
+        margin-right: 0;
+    }
 }
 
 /* Logo container with status dot overlay */

--- a/app/langgraph.json
+++ b/app/langgraph.json
@@ -13,6 +13,7 @@
       "rails_beginner_agent": "./agents/leonardo/rails_beginner_agent/nodes.py:build_workflow",
       "rails_plan_mode_agent": "./agents/leonardo/rails_plan_mode_agent/nodes.py:build_workflow",
       "rails_engineer_plan_mode_agent": "./agents/leonardo/rails_engineer_plan_mode_agent/nodes.py:build_workflow",
-      "pyxl_agent": "./agents/leonardo/pyxl_agent/nodes.py:build_workflow"
+      "pyxl_agent": "./agents/leonardo/pyxl_agent/nodes.py:build_workflow",
+      "rails_plain_chat_mode": "./agents/leonardo/rails_plain_chat_mode/nodes.py:build_workflow"
     }
   }

--- a/app/lib/llamapress_api.py
+++ b/app/lib/llamapress_api.py
@@ -1,0 +1,221 @@
+"""User-scoped Rails API access for CUSTOM agents — the "llamapress api" library.
+
+This module is a LIBRARY, not an agent. LlamaBot deliberately registers no agent and
+no chat mode that uses it: the reference implementation lives downstream in Leonardo
+(`langgraph/agents/leo/nodes.py`, registered via `langgraph.local.json`, mounted into
+the container as /app/app/user_agents). That end-to-end path — custom agent in the
+client repo, library from the platform — is the product story, so keep it that way.
+
+Custom agents need exactly two things:
+
+    from app.lib.llamapress_api import LlamaPressAPIState, rails_api_request
+
+    class MyState(LlamaPressAPIState):   # 1. api_token must be on your state schema
+        ...                              #    (LangGraph drops fields not in the schema,
+                                         #     which silently disables the tool)
+
+    tools = [rails_api_request]          # 2. give the agent the tool
+
+Why this exists: every other Rails-touching tool in this repo (`bash_command`,
+`rails_api_sh`) shells into the Rails container and gets unrestricted ActiveRecord.
+That's fine for `engineer`, but it means "let a low-privilege user ask Leo about
+their data" had no safe answer. This tool is that answer.
+
+The authorization is NOT implemented here. It is inherited, and that's the point:
+
+  1. Rails mints a signed, 30-min token carrying `user_id` (the gem's
+     `message_verifier(:llamabot_ws)`). LlamaBot cannot forge one. The browser
+     fetches it from `GET /llama_bot/agent/token` (Devise session required) and the
+     chat frontend puts it on the WebSocket frame as `api_token`, which the request
+     handler copies into state — but only for schemas that declare it.
+  2. The gem's AgentAuth verifies the signature, resolves the user, and signs them
+     in via warden — so `current_user` in the controller is genuinely that person.
+  3. `llama_bot_allow :index, :show` in the controller allowlists which actions a
+     token-authed request may reach AT ALL. Anything else is 403 before any policy
+     runs.
+  4. Pundit then narrows per-user as it always has.
+
+So `DELETE /api/users/1` fails twice over: `destroy` isn't allowlisted, and the
+token's user isn't an admin. Widening reach is a Rails-side act (`llama_bot_allow`),
+never a Python-side one. Do not add an escape hatch to this file.
+
+The guards below are about SSRF, not authorization: keep the request pointed at the
+Rails app so the token can't be posted to an attacker's host.
+
+Full writeup: docs/dev/user_api_mode.md.
+"""
+import logging
+import os
+
+import httpx
+from langchain.tools import ToolRuntime, tool
+from langgraph.prebuilt.chat_agent_executor import AgentState
+from typing_extensions import NotRequired
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["LlamaPressAPIState", "rails_api_request"]
+
+# The Rails service on the compose network (see Leonardo/docker-compose-dev.yml:
+# service `llamapress`, port 3000). Overridable for other deployments.
+RAILS_BASE_URL = os.getenv("RAILS_BASE_URL", "http://llamapress:3000").rstrip("/")
+
+ALLOWED_METHODS = frozenset({"GET", "POST", "PATCH", "PUT", "DELETE"})
+
+# Only the agent-facing API namespace is reachable. This is defense-in-depth, and it
+# is NOT redundant with the Rails-side gates — it patches a real hole:
+#
+# `llama_bot_allow` only constrains controllers that include LlamaBotRails::AgentAuth.
+# A controller that never opted in is gated by the app's OWN auth — and the Leonardo
+# skeleton ships with `before_action :authenticate_user!` commented out ("AUTHENTICATION
+# IS DISABLED BY DEFAULT FOR NEW PROJECTS", rails/app/controllers/application_controller.rb).
+# Verified against the dev box: `GET /users` with no token at all returns 500, i.e. it
+# routed into the controller — ungated. Without this prefix check, this tool
+# would reach every such route and the per-account scoping would be a fiction.
+#
+# `/api/` is where the agent-facing controllers live by convention (see
+# Leonardo/rails/config/routes.rb + Api::UsersController). Note this is a CONVENTION,
+# not a proof: a controller added under /api/ that forgets `include AgentAuth` is
+# ungated too, unless the app enables authentication. See docs/dev/user_api_mode.md.
+ALLOWED_PATH_PREFIX = "/api/"
+
+# Rails errors are verbose (full HTML error pages in dev). Cap what re-enters context.
+RESPONSE_MAX_CHARS = 8000
+
+REQUEST_TIMEOUT_SECONDS = 30
+
+RAILS_API_REQUEST_DESCRIPTION = """Make an HTTP request to the Rails app's JSON API, authenticated as the signed-in user.
+
+Use this to read and change data through the app's own API, exactly as the current
+user could in their browser. Their permissions apply automatically: if they aren't
+allowed to do something, the request comes back 403 and that answer is correct —
+report it plainly, don't try to work around it.
+
+Args:
+    method: GET, POST, PATCH, PUT, or DELETE.
+    path: App-relative path starting with "/", e.g. "/api/users" or "/api/users/42".
+          May include a query string: "/api/users?q=alice".
+    body: Optional dict, sent as a JSON request body (POST/PATCH/PUT).
+
+Returns:
+    The HTTP status line followed by the response body.
+
+Notes:
+    - Only allow-listed endpoints are reachable. A 403 saying an action "isn't
+      white-listed" means the app has not exposed it — that is a deliberate limit,
+      not a bug to route around. Tell the user what you tried and what came back.
+    - You cannot reach any host other than the Rails app.
+"""
+
+
+class LlamaPressAPIState(AgentState):
+    """Base state for custom agents that call the Rails API as the signed-in user.
+
+    Subclass this (or copy the field verbatim). The field name `api_token` is part of
+    the wire contract: the frontend puts it on the WebSocket frame under that key, and
+    the request handler copies frame keys into state only if the schema declares them.
+    Never put the token in a prompt or a log — it is a bearer credential for that user.
+    """
+
+    api_token: NotRequired[str]
+
+
+def _truncate(text: str, max_chars: int = RESPONSE_MAX_CHARS) -> str:
+    if len(text) <= max_chars:
+        return text
+    return text[:max_chars] + f"\n\n[truncated {len(text) - max_chars} more chars]"
+
+
+def _reject_path(path: str) -> str | None:
+    """Return an error string if `path` could leave the Rails app, else None.
+
+    The token is a bearer credential: any request we send carries it in a header, so
+    an attacker-influenced path that redirects the request to another origin would
+    hand it over. Cheapest defense is to refuse anything that isn't a plain
+    app-relative path.
+    """
+    if not path.startswith("/"):
+        return "path must start with '/' (it is app-relative, e.g. '/api/users')"
+    if path.startswith("//"):
+        # "//evil.com/x" is protocol-relative — urljoin/httpx would resolve it off-host.
+        return "path must not start with '//'"
+    if "://" in path:
+        return "path must not contain a scheme — only the Rails app is reachable"
+    if "\\" in path:
+        return "path must not contain backslashes"
+    if ".." in path:
+        # "/api/../users" normalizes out of the namespace at the server.
+        return "path must not contain '..'"
+    if not path.startswith(ALLOWED_PATH_PREFIX):
+        return (
+            f"only the app's API namespace is reachable — path must start with "
+            f"'{ALLOWED_PATH_PREFIX}' (got {path!r})"
+        )
+    return None
+
+
+@tool(description=RAILS_API_REQUEST_DESCRIPTION)
+def rails_api_request(
+    method: str,
+    path: str,
+    runtime: ToolRuntime,
+    body: dict | None = None,
+) -> str:
+    """HTTP against the Rails app as the signed-in user. See module docstring."""
+    token = (runtime.state or {}).get("api_token")
+    if not token:
+        # Reached when the chat frame carried no api_token — e.g. the user isn't
+        # signed into the Rails app, or the agent's state schema forgot to declare
+        # the field (subclass LlamaPressAPIState). Fail loudly: silently proceeding
+        # unauthenticated would look like a permissions bug rather than a wiring one.
+        return (
+            "No API token available for this session, so I can't make authenticated "
+            "requests to your app right now. This is a setup issue, not a permissions "
+            "one — tell the user to report it."
+        )
+
+    method = (method or "").strip().upper()
+    if method not in ALLOWED_METHODS:
+        return f"Unsupported method {method!r}. Use one of: {', '.join(sorted(ALLOWED_METHODS))}."
+
+    if path_error := _reject_path(path or ""):
+        return f"Invalid path: {path_error}"
+
+    url = f"{RAILS_BASE_URL}{path}"
+    # `LlamaBot` is the scheme the gem's AgentAuth looks for (AUTH_SCHEME).
+    headers = {
+        "Authorization": f"LlamaBot {token}",
+        "Accept": "application/json",
+    }
+
+    # Log the path but NEVER the token or the headers.
+    logger.info(f"[llamapress_api] {method} {path}")
+
+    try:
+        with httpx.Client(
+            timeout=REQUEST_TIMEOUT_SECONDS,
+            # Do not follow redirects: a redirect off-origin would replay the
+            # Authorization header at the new host.
+            follow_redirects=False,
+        ) as client:
+            response = client.request(
+                method,
+                url,
+                headers=headers,
+                json=body if body is not None else None,
+            )
+    except httpx.RequestError as e:
+        # Connection-level failure — the exception repr can't contain the token
+        # (it's in headers, not the URL), so this is safe to surface.
+        logger.warning(f"[llamapress_api] request failed: {e.__class__.__name__}")
+        return f"Could not reach the Rails app ({e.__class__.__name__}). It may be starting up or down."
+
+    if response.is_redirect:
+        # Almost always Devise bouncing an unauthenticated request to /login, which
+        # means the token didn't authenticate. Say so rather than following it.
+        return (
+            f"HTTP {response.status_code} (redirect to {response.headers.get('location', '?')})\n"
+            "The request wasn't authenticated — the token may have expired (they last 30 minutes)."
+        )
+
+    return f"HTTP {response.status_code}\n{_truncate(response.text)}"

--- a/app/main.py
+++ b/app/main.py
@@ -341,6 +341,12 @@ async def startup_event():
         except ImportError:
             logger.info("pyxl_agent not found, skipping")
 
+        try:
+            from app.agents.leonardo.rails_plain_chat_mode.nodes import build_workflow as build_plain_chat
+            app.state.compiled_graphs["rails_plain_chat_mode"] = build_plain_chat(checkpointer=checkpointer)
+        except ImportError:
+            logger.info("rails_plain_chat_mode not found, skipping")
+
         logger.info(f"Compiled {len(app.state.compiled_graphs)} LangGraph workflows: {list(app.state.compiled_graphs.keys())}")
     except Exception as e:
         logger.error(f"Error compiling LangGraph workflows: {e}", exc_info=True)

--- a/app/permissions.py
+++ b/app/permissions.py
@@ -1,0 +1,282 @@
+"""Role → agent-mode permissions. The single source of truth.
+
+One question — *may this role use this agent mode?* — asked in exactly two places:
+
+  * ``app/routers/ui.py``               builds the mode dropdown for the browser
+  * ``app/websocket/web_socket_handler.py``  rejects a frame naming a mode the
+    user was never granted
+
+Both call :func:`allowed_modes`. The dropdown is a *view* of the permission set,
+never a second copy of the rule — that's what kept them from drifting before
+(the dropdown filtered client-side while the socket accepted any ``agent_name``).
+
+Storage is one ``SiteSetting`` row (``role_agent_modes``) holding JSON::
+
+    {"user": ["feedback"], "engineer": ["ticket", "engineer", ...]}
+
+Absent, unparseable, or DB-unavailable → :data:`DEFAULT_ROLE_MODES`. A role the
+admin has never configured keeps its default; once configured, that list is
+authoritative. Admin edits it via ``PUT /api/role-modes``.
+
+Design rules, chosen deliberately:
+  * ``is_admin`` is a **superset** — always every mode. An admin editing the role
+    table can't lock themselves out of the UI they're editing with.
+  * ``User.visible_agents`` **narrows only**. It's a per-user view preference and
+    can never widen past the role's grant, so "what can this user do?" is always
+    one lookup: the role.
+  * An unknown/missing role gets ``user``'s modes — least privilege. (The column
+    has a server_default, so real rows always carry a value; this is for safety,
+    and it settles the old getattr(role, 'user') vs getattr(role, 'engineer')
+    disagreement between dependencies.py and ui.py in favour of the safe answer.)
+"""
+import json
+import logging
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+ROLE_MODES_SETTING_KEY = "role_agent_modes"
+
+# Built-in agent-mode dropdown keys baked into the image (chat.html <option>s +
+# config.js agentModes). Per-instance custom modes may NOT shadow these.
+# Superset of MODE_AGENTS: `plan` is an execution toggle, not a grantable mode,
+# but a custom mode still must not claim the key.
+BUILTIN_AGENT_MODE_KEYS = frozenset({
+    "engineer", "ai_builder", "testing", "ticket", "database",
+    "beginner", "pyxl", "plan", "chat",
+})
+
+# Mode key → EVERY graph that mode can route to.
+#
+# This map is the crux. The browser picks a mode key, but the wire carries an
+# `agent_name` (a langgraph graph name), and the translation lives in the
+# frontend — so the server cannot gate on the mode key it never receives. It
+# resolves the agent_name back through this map instead.
+#
+# One mode reaches two graphs because the Plan toggle swaps the agent:
+#   base agent   — app/frontend/chat/config.js  (DEFAULT_CONFIG.agentModes)
+#   plan variant — app/frontend/chat/index.js   (planAgentByMode, else the
+#                  generic rails_plan_mode_agent)
+#
+# Duplicating the frontend's map here is a drift risk, so it's pinned:
+# test_permissions.py::test_mode_agents_matches_frontend parses both JS files
+# and fails if they diverge. Change one, change the other.
+_GENERIC_PLAN_AGENT = "rails_plan_mode_agent"
+
+MODE_AGENTS: dict[str, frozenset[str]] = {
+    "engineer":   frozenset({"rails_agent", "rails_engineer_plan_mode_agent"}),
+    "ticket":     frozenset({"rails_ticket_mode_agent", "rails_ticket_plan_mode_agent"}),
+    "database":   frozenset({"rails_user_mode_agent", _GENERIC_PLAN_AGENT}),
+    "ai_builder": frozenset({"rails_ai_builder_agent", _GENERIC_PLAN_AGENT}),
+    "testing":    frozenset({"rails_testing_agent", _GENERIC_PLAN_AGENT}),
+    "beginner":   frozenset({"rails_beginner_agent", _GENERIC_PLAN_AGENT}),
+    "pyxl":       frozenset({"pyxl_agent", _GENERIC_PLAN_AGENT}),
+    # Plain LLM, no tools. Its capability ceiling is the `user` role's ceiling —
+    # see app/agents/leonardo/rails_plain_chat_mode/nodes.py. No plan variant:
+    # there's nothing to plan without tools.
+    "chat":       frozenset({"rails_plain_chat_mode"}),
+    # NOTE: user-scoped Rails API access is deliberately NOT a built-in mode.
+    # LlamaBot ships only the library (app/lib/llamapress_api.py); the working
+    # agent lives downstream (Leonardo langgraph/agents/leo, registered via the
+    # langgraph.local.json overlay + agent_modes.json).
+}
+
+# The fallback grant per role, used until an admin configures that role.
+# Order matters: it drives the dropdown order.
+DEFAULT_ROLE_MODES: dict[str, list[str]] = {
+    # Plain LLM only. `chat` has no tools by construction, so this role can't
+    # touch the user's app at all — that's the ceiling, enforced by the graph
+    # itself rather than by trusting the mode not to misbehave.
+    "user": ["chat"],
+    "engineer": [
+        "ticket", "engineer", "testing", "database",
+        "ai_builder", "beginner", "pyxl", "chat",
+    ],
+}
+
+# Role used when a user's role is missing or unrecognised (least privilege).
+FALLBACK_ROLE = "user"
+
+
+def known_modes(custom_modes: Optional[dict] = None) -> set[str]:
+    """Every GRANTABLE mode key on this instance (built-in ∪ per-instance custom).
+
+    Grantable means "appears in MODE_AGENTS", not "in BUILTIN_AGENT_MODE_KEYS" —
+    the latter also holds `plan`, which is an execution toggle rather than a
+    dropdown mode and maps to no graph of its own.
+    """
+    return set(MODE_AGENTS) | set(custom_modes or {})
+
+
+def custom_modes() -> dict[str, str]:
+    """Per-instance custom modes as {mode_key: agent_name}, validated against the registry.
+
+    For callers that don't already have the overlay loaded (the WebSocket gate).
+    ui.py passes its own dict instead — it loads the full mode objects anyway.
+    """
+    # Deferred: ui.py imports this module at module level, so importing it back
+    # at the top would be a cycle.
+    from app.routers.ui import load_custom_agent_modes
+    try:
+        from app.lib.langgraph_registry import load_graphs
+        return {
+            m["key"]: m["agent_name"]
+            for m in load_custom_agent_modes("agent_modes.json", load_graphs())
+        }
+    except Exception as e:
+        logger.warning(f"Could not load custom agent modes: {e}")
+        return {}
+
+
+def _load_configured(session) -> dict[str, list[str]]:
+    """Just what the admin explicitly configured. {} when unset/malformed/no DB.
+
+    Kept separate from the defaults because "has this role been configured?" is
+    load-bearing: it decides whether custom modes ride along (see allowed_modes).
+    """
+    from app.models import SiteSetting
+    try:
+        setting = session.get(SiteSetting, ROLE_MODES_SETTING_KEY)
+    except Exception as e:
+        # Matches db.py's degradation: no auth DB → defaults, don't hard-fail login.
+        logger.warning(f"Could not read '{ROLE_MODES_SETTING_KEY}', using defaults: {e}")
+        return {}
+    if not setting or not setting.value:
+        return {}
+
+    try:
+        parsed = json.loads(setting.value)
+    except json.JSONDecodeError as e:
+        logger.warning(f"Ignoring malformed '{ROLE_MODES_SETTING_KEY}' ({e}); using defaults")
+        return {}
+    if not isinstance(parsed, dict):
+        logger.warning(f"Ignoring '{ROLE_MODES_SETTING_KEY}': expected a JSON object")
+        return {}
+
+    return {
+        role: [m for m in modes if isinstance(m, str)]
+        for role, modes in parsed.items()
+        if isinstance(role, str) and isinstance(modes, list)
+    }
+
+
+def get_role_modes(session) -> dict[str, list[str]]:
+    """The effective role → modes map: admin config merged over the defaults.
+
+    Only roles the admin has explicitly configured override their default, so
+    adding a new role to DEFAULT_ROLE_MODES in code doesn't require a DB edit.
+    """
+    merged = {role: list(modes) for role, modes in DEFAULT_ROLE_MODES.items()}
+    merged.update(_load_configured(session))
+    return merged
+
+
+def allowed_modes(
+    session,
+    role: Optional[str],
+    is_admin: bool = False,
+    custom: Optional[dict] = None,
+) -> list[str]:
+    """Modes this (role, is_admin) may use. Ordered — the dropdown renders it as-is.
+
+    Takes primitives rather than a User because the WebSocket only has JWT
+    claims (``role``/``is_admin``), never a User row. See
+    :func:`app.services.token_service.create_ws_token`.
+    """
+    custom = custom or {}
+
+    if is_admin:
+        # Superset. Ordered: the engineer default first (canonical dropdown
+        # order), then anything else that exists, then custom.
+        ordered = list(DEFAULT_ROLE_MODES["engineer"])
+        ordered += [m for m in sorted(MODE_AGENTS) if m not in ordered]
+        return ordered + [m for m in custom if m not in ordered]
+
+    configured = _load_configured(session)
+    effective = {**DEFAULT_ROLE_MODES, **configured}
+    if role not in effective:
+        role = FALLBACK_ROLE
+
+    modes = list(effective.get(role, DEFAULT_ROLE_MODES[FALLBACK_ROLE]))
+
+    # Custom modes ride along with a role's *default* grant only (preserves the
+    # pre-existing "engineer sees new custom modes without an admin edit"
+    # behaviour). Once an admin configures the role explicitly, their list wins
+    # and custom keys must be opted in there — no surprise grants.
+    if role not in configured and role != FALLBACK_ROLE:
+        modes += [m for m in custom if m not in modes]
+
+    # Never grant a key that doesn't exist on this instance (stale config).
+    valid = known_modes(custom)
+    return [m for m in modes if m in valid]
+
+
+def allowed_agent_names(
+    session,
+    role: Optional[str],
+    is_admin: bool = False,
+    custom: Optional[dict] = None,
+) -> set[str]:
+    """Every graph this (role, is_admin) may run — the set the WebSocket gates on.
+
+    The wire carries an ``agent_name`` (a graph), never the mode key, so the grant
+    has to be expanded through MODE_AGENTS before it can be checked. One mode
+    yields up to two graphs (base + plan variant).
+    """
+    custom = custom or {}
+    names: set[str] = set()
+    for mode in allowed_modes(session, role, is_admin, custom):
+        names |= MODE_AGENTS.get(mode, frozenset())
+        if mode in custom:
+            names.add(custom[mode])
+    return names
+
+
+def visible_modes(
+    session,
+    user,
+    custom: Optional[dict] = None,
+) -> list[str]:
+    """Modes to show this user in the dropdown = their grant, narrowed by preference.
+
+    ``user.visible_agents`` (JSON array) can only *hide* granted modes; a key it
+    names that the role doesn't grant is dropped. A malformed or empty value
+    means "no preference" → the full grant.
+    """
+    granted = allowed_modes(
+        session,
+        getattr(user, "role", None),
+        getattr(user, "is_admin", False),
+        custom,
+    )
+
+    raw = getattr(user, "visible_agents", None)
+    if not raw:
+        return granted
+    try:
+        preferred = json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        return granted
+    if not isinstance(preferred, list) or not preferred:
+        return granted
+
+    narrowed = [m for m in granted if m in preferred]
+    # An empty intersection means the preference is stale (e.g. the role lost
+    # those modes). Fall back to the grant rather than a dead dropdown.
+    return narrowed or granted
+
+
+def can_run_agent(
+    session,
+    role: Optional[str],
+    is_admin: bool,
+    agent_name: str,
+    custom: Optional[dict] = None,
+) -> bool:
+    """Authorization check for one ``agent_name`` off the wire. The WebSocket's gate.
+
+    Takes the graph name, not the mode key, because that's what the client sends
+    — gating on the mode key would compare two different namespaces and deny
+    everyone.
+    """
+    return agent_name in allowed_agent_names(session, role, is_admin, custom)

--- a/app/routers/api.py
+++ b/app/routers/api.py
@@ -648,6 +648,8 @@ async def available_models():
         "gemini-3.1-flash-lite": ("GEMINI_API_KEY", "GOOGLE_API_KEY"),
         "deepseek-v4-flash": "DEEPSEEK_API_KEY",
         "deepseek-v4-pro": "DEEPSEEK_API_KEY",
+        "deepseek-v4-flash-gmi": "GMI_DEEPSEEK_API_KEY",
+        "deepseek-v4-flash-fireworks": "FIREWORKS_DEEPSEEK_API_KEY",
         "qwen3.7-plus": "ALIBABA_API_KEY",
     }
 
@@ -1174,6 +1176,82 @@ async def set_visible_agents(
 VALID_SITE_SETTINGS = {"show_token_wheel", "proactive_build_after_ticket", "enable_browser_inspect"}
 
 
+# ============== Role → agent-mode permissions (admin only) ==============
+# Deliberately NOT part of VALID_SITE_SETTINGS: that PUT is engineer-or-admin,
+# and an engineer editing role grants could widen another role's access. These
+# endpoints are admin_required, and they validate the payload — the resolver in
+# app/permissions.py trusts nothing, but a 400 here beats a silently-ignored key.
+
+
+@router.get("/api/role-modes", response_class=JSONResponse)
+async def api_get_role_modes(
+    admin: User = Depends(admin_required),
+    session: Session = Depends(get_db_session),
+):
+    """Current role → agent-mode grants, plus the catalog to render a picker from."""
+    from app.permissions import DEFAULT_ROLE_MODES, MODE_AGENTS, custom_modes, get_role_modes
+
+    custom = custom_modes()
+    return {
+        "role_modes": get_role_modes(session),
+        "defaults": DEFAULT_ROLE_MODES,
+        "all_modes": sorted(MODE_AGENTS) + sorted(custom),
+        "custom_modes": sorted(custom),
+    }
+
+
+@router.put("/api/role-modes", response_class=JSONResponse)
+async def api_set_role_modes(
+    request: Request,
+    admin: User = Depends(admin_required),
+    session: Session = Depends(get_db_session),
+):
+    """Replace the role → agent-mode grants (admin only).
+
+    Body: ``{"role_modes": {"user": ["feedback"], "engineer": [...]}}``.
+    Rejects unknown mode keys so a typo fails loudly at the edit rather than
+    quietly narrowing someone's access at the next login.
+    """
+    from datetime import datetime, timezone
+
+    from app.models import SiteSetting
+    from app.permissions import ROLE_MODES_SETTING_KEY, custom_modes, known_modes
+
+    body = await request.json()
+    role_modes = body.get("role_modes")
+    if not isinstance(role_modes, dict):
+        raise HTTPException(status_code=400, detail="role_modes must be an object")
+
+    valid = known_modes(custom_modes())
+    cleaned: dict[str, list[str]] = {}
+    for role, modes in role_modes.items():
+        if not isinstance(role, str) or not role.strip():
+            raise HTTPException(status_code=400, detail="Role names must be non-empty strings")
+        if not isinstance(modes, list) or not all(isinstance(m, str) for m in modes):
+            raise HTTPException(status_code=400, detail=f"Modes for '{role}' must be a list of strings")
+        unknown = sorted(set(modes) - valid)
+        if unknown:
+            raise HTTPException(status_code=400, detail=f"Unknown mode(s) for '{role}': {', '.join(unknown)}")
+        # De-dupe, preserve the admin's ordering (it drives the dropdown order).
+        cleaned[role] = list(dict.fromkeys(modes))
+
+    value = json.dumps(cleaned)
+    if len(value) > 1000:  # SiteSetting.value is max_length=1000
+        raise HTTPException(status_code=400, detail="Too many roles/modes to store")
+
+    setting = session.get(SiteSetting, ROLE_MODES_SETTING_KEY)
+    if setting:
+        setting.value = value
+        setting.updated_at = datetime.now(timezone.utc)
+    else:
+        setting = SiteSetting(key=ROLE_MODES_SETTING_KEY, value=value)
+        session.add(setting)
+    session.commit()
+
+    logger.info(f"Role modes set to {value} by {admin.username}")
+    return {"role_modes": cleaned}
+
+
 def get_site_setting(session: Session, key: str, default: str = "false") -> str:
     """Get a site setting value, returning default if not found.
 
@@ -1299,7 +1377,7 @@ async def api_delete_skill(
 # ============== File Upload to Assets ==============
 
 UPLOAD_ALLOWED_EXTENSIONS = {
-    '.png', '.jpg', '.jpeg', '.gif', '.webp', '.svg',
+    '.png', '.jpg', '.jpeg', '.gif', '.webp', '.svg', '.ico',
     # Spreadsheets — all Excel variants, incl. macro-enabled and binary
     '.xlsx', '.xls', '.xlsm', '.xlsb', '.xltx', '.xltm', '.csv',
     # Documents
@@ -1314,14 +1392,14 @@ UPLOAD_ALLOWED_EXTENSIONS = {
     '.zip',
 }
 
-IMAGE_EXTENSIONS = {'.png', '.jpg', '.jpeg', '.gif', '.webp', '.svg'}
+IMAGE_EXTENSIONS = {'.png', '.jpg', '.jpeg', '.gif', '.webp', '.svg', '.ico'}
 
 # Types a browser can safely render inline. Deliberately excludes SVG: an SVG can
 # embed <script>, so serving it inline is an XSS vector — it downloads instead.
 # Everything not listed here (Office docs, slideshows, etc.) also downloads; we do
 # not render those server-side (no LibreOffice/conversion — keeps the image small
 # and the surface area tiny). The OS opens them in the real app.
-INLINE_PREVIEW_EXTENSIONS = {'.png', '.jpg', '.jpeg', '.gif', '.webp', '.pdf'}
+INLINE_PREVIEW_EXTENSIONS = {'.png', '.jpg', '.jpeg', '.gif', '.webp', '.pdf', '.ico'}
 
 RAILS_ROOT = "/app/app/rails"
 IMAGES_DIR = f"{RAILS_ROOT}/app/assets/images"

--- a/app/routers/ui.py
+++ b/app/routers/ui.py
@@ -30,16 +30,10 @@ from app.services.magic_link_service import (
 )
 from app.services.mothership_client import MothershipClient
 
-# Role-based default visible agents
-DEFAULT_VISIBLE_AGENTS_USER = ["feedback"]
-DEFAULT_VISIBLE_AGENTS_ENGINEER = ["ticket", "engineer", "testing", "feedback", "user", "ai_builder", "beginner", "pyxl"]
-
-# Built-in agent-mode dropdown keys baked into the image (chat.html <option>s +
-# config.js agentModes). Per-instance custom modes may NOT shadow these.
-BUILTIN_AGENT_MODE_KEYS = frozenset({
-    "engineer", "ai_builder", "testing", "ticket", "user",
-    "beginner", "pyxl", "plan", "feedback",
-})
+# Role → agent-mode permissions live in app/permissions.py — the single source of
+# truth this router and the WebSocket gate both read. Re-exported here because
+# load_custom_agent_modes() validates against the built-in keys.
+from app.permissions import BUILTIN_AGENT_MODE_KEYS, visible_modes  # noqa: F401
 
 logger = logging.getLogger(__name__)
 
@@ -176,23 +170,6 @@ async def root(request: Request):
         if not user:
             return RedirectResponse(url="/login", status_code=302)
 
-        # Get visible agents for this user (role-based defaults)
-        visible_agents = None
-        visible_from_default = False
-        if user.visible_agents:
-            try:
-                visible_agents = json.loads(user.visible_agents)
-            except json.JSONDecodeError:
-                pass
-
-        # If no custom setting, use role-based defaults
-        if not visible_agents:
-            visible_from_default = True
-            if getattr(user, "role", "engineer") == "user":
-                visible_agents = list(DEFAULT_VISIBLE_AGENTS_USER)
-            else:
-                visible_agents = list(DEFAULT_VISIBLE_AGENTS_ENGINEER)
-
         # Load per-instance custom agent modes (optional overlay, no image change).
         # Validated against the registered graphs (platform base ∪ client overlay).
         graphs = {}
@@ -207,13 +184,14 @@ async def root(request: Request):
             logger.warning(f"Could not load custom agent modes: {e}")
             custom_agent_modes = []
 
-        # Surface custom modes for engineer-role default visibility. We only auto-add
-        # to a role-based default list — an explicit per-user visible_agents setting
-        # is respected as-is (the admin opts the custom key in deliberately).
-        if custom_agent_modes and visible_from_default and getattr(user, "role", "engineer") != "user":
-            for m in custom_agent_modes:
-                if m["key"] not in visible_agents:
-                    visible_agents.append(m["key"])
+        # The dropdown is a VIEW of the role's grant — same resolver the WebSocket
+        # gates on (app/permissions.py). Hiding a mode here is a convenience, not
+        # the control: web_socket_handler rejects an ungranted agent_name outright.
+        visible_agents = visible_modes(
+            session,
+            user,
+            custom={m["key"]: m["agent_name"] for m in custom_agent_modes},
+        )
 
         # Serve the chat.html file with user role and visible agents injected
         with open(frontend_dir / "chat.html") as f:
@@ -564,6 +542,43 @@ async def users_page(admin: User = Depends(admin_required)):
             color: var(--text-color);
             border: 1px solid var(--border-color);
         }
+        .card-hint {
+            margin: 0 0 16px;
+            font-size: 0.85rem;
+            color: rgba(255, 255, 255, 0.5);
+            line-height: 1.5;
+        }
+        .role-row {
+            display: flex;
+            gap: 16px;
+            align-items: baseline;
+            padding: 12px 0;
+            border-top: 1px solid var(--border-color);
+            flex-wrap: wrap;
+        }
+        .role-row:first-child { border-top: none; }
+        .role-name {
+            min-width: 90px;
+            font-weight: 600;
+            text-transform: capitalize;
+        }
+        .mode-grid {
+            display: flex;
+            gap: 8px 18px;
+            flex-wrap: wrap;
+            flex: 1;
+        }
+        .mode-check {
+            display: flex;
+            align-items: center;
+            gap: 6px;
+            font-size: 0.85rem;
+            cursor: pointer;
+            white-space: nowrap;
+        }
+        .mode-check input { cursor: pointer; }
+        #saveRoleModes { margin-top: 16px; }
+        #saveRoleModes:disabled { opacity: 0.5; cursor: default; }
     </style>
 </head>
 <body>
@@ -616,9 +631,81 @@ async def users_page(admin: User = Depends(admin_required)):
                 </tbody>
             </table>
         </div>
+
+        <div class="card">
+            <div class="card-header">Role Permissions</div>
+            <p class="card-hint">
+                Which agent modes each role may use. Enforced on the server — a mode
+                that's off here can't be reached, not just hidden. Admins always have
+                every mode.
+            </p>
+            <div id="roleModes">Loading...</div>
+            <button class="btn btn-primary" id="saveRoleModes" onclick="saveRoleModes()">Save Permissions</button>
+        </div>
     </div>
 
     <script>
+        let ALL_MODES = [];
+
+        async function loadRoleModes() {
+            const container = document.getElementById('roleModes');
+            try {
+                const response = await fetch('/api/role-modes');
+                if (!response.ok) throw new Error(`HTTP ${response.status}`);
+                const data = await response.json();
+                ALL_MODES = data.all_modes;
+
+                container.innerHTML = Object.keys(data.role_modes).sort().map(role => `
+                    <div class="role-row" data-role="${role}">
+                        <div class="role-name">${role}</div>
+                        <div class="mode-grid">
+                            ${ALL_MODES.map(mode => `
+                                <label class="mode-check">
+                                    <input type="checkbox" value="${mode}"
+                                        ${data.role_modes[role].includes(mode) ? 'checked' : ''}>
+                                    <span>${mode}${data.custom_modes.includes(mode) ? ' *' : ''}</span>
+                                </label>
+                            `).join('')}
+                        </div>
+                    </div>
+                `).join('');
+
+                if (data.custom_modes.length) {
+                    container.innerHTML += '<p class="card-hint">* custom mode from this instance (agent_modes.json)</p>';
+                }
+            } catch (error) {
+                container.textContent = 'Error loading role permissions: ' + error.message;
+            }
+        }
+
+        async function saveRoleModes() {
+            const btn = document.getElementById('saveRoleModes');
+            btn.disabled = true;
+            const role_modes = {};
+            document.querySelectorAll('#roleModes .role-row').forEach(row => {
+                // Read back in ALL_MODES order — that order drives the chat dropdown.
+                role_modes[row.dataset.role] = Array.from(
+                    row.querySelectorAll('input[type=checkbox]:checked')
+                ).map(cb => cb.value);
+            });
+
+            try {
+                const response = await fetch('/api/role-modes', {
+                    method: 'PUT',
+                    headers: {'Content-Type': 'application/json'},
+                    body: JSON.stringify({role_modes})
+                });
+                const data = await response.json();
+                if (!response.ok) throw new Error(data.detail || `HTTP ${response.status}`);
+                showMessage('Role permissions saved. Takes effect on the next message.', 'success');
+            } catch (error) {
+                showMessage('Error saving: ' + error.message, 'error');
+                loadRoleModes();  // resync the checkboxes with what's actually stored
+            } finally {
+                btn.disabled = false;
+            }
+        }
+
         async function loadUsers() {
             try {
                 const response = await fetch('/api/users');
@@ -743,6 +830,7 @@ async def users_page(admin: User = Depends(admin_required)):
         });
 
         loadUsers();
+        loadRoleModes();
     </script>
 </body>
 </html>
@@ -1774,16 +1862,10 @@ async def settings_page(
         }}
 
         function logout() {{
-            // Clear credentials by making a request that will fail, then redirect
-            fetch('/logout', {{
-                method: 'POST',
-                headers: {{
-                    'Authorization': 'Basic ' + btoa('logout:logout')
-                }}
-            }}).finally(() => {{
-                // Redirect to home which will prompt for new credentials
-                window.location.href = '/?logout=' + Date.now();
-            }});
+            // Plain navigation: the server clears the cookie and redirects to
+            // the sign-in form. Deliberately not a fetch — a 401 response to a
+            // fetch triggers the browser's native auth dialog.
+            window.location.href = '/logout';
         }}
     </script>
 </body>
@@ -1805,6 +1887,20 @@ async def logout():
         status_code=401,
         headers={"WWW-Authenticate": "Basic"},
     )
+    response.delete_cookie(key=SESSION_COOKIE_NAME, path="/")
+    return response
+
+
+@router.get("/logout")
+async def logout_get():
+    """Browser logout — clear the session cookie and land on the sign-in form.
+
+    Unlike POST /logout this sends no WWW-Authenticate challenge: a 401 on a
+    fetch()/navigation is what makes the browser throw up its native Basic Auth
+    dialog, which is exactly what we don't want when the user clicks Sign Out.
+    Scripted callers that want cached Basic creds evicted still use POST.
+    """
+    response = RedirectResponse(url="/login", status_code=303)
     response.delete_cookie(key=SESSION_COOKIE_NAME, path="/")
     return response
 
@@ -3485,6 +3581,8 @@ async def scheduled_jobs_page(user: User = Depends(engineer_or_admin_required)):
             'gpt-5-mini': 'GPT-5 Mini',
             'gpt-5-codex': 'GPT-5 Codex',
             'deepseek-v4-flash': 'DeepSeek V4 Flash',
+            'deepseek-v4-flash-gmi': 'DeepSeek V4 Flash (GMI)',
+            'deepseek-v4-flash-fireworks': 'DeepSeek V4 Flash (Fireworks)',
         };
 
         function prettyAgentLabel(name) {

--- a/app/tests/test_auth_session.py
+++ b/app/tests/test_auth_session.py
@@ -509,3 +509,25 @@ class TestLogout:
         # Cookie should be cleared in the response (Set-Cookie with Max-Age=0).
         set_cookie = resp.headers.get("set-cookie", "")
         assert SESSION_COOKIE_NAME in set_cookie
+
+    def test_logout_get_redirects_to_login_without_dialog(
+        self, client_with_user, test_user
+    ):
+        """The browser Sign Out path: clear the cookie and land on the form.
+
+        No WWW-Authenticate header, so the browser never shows its native
+        Basic Auth dialog.
+        """
+        client_with_user.post(
+            "/login",
+            json={"username": test_user.username, "password": "correct-password"},
+        )
+        assert SESSION_COOKIE_NAME in client_with_user.cookies
+
+        resp = client_with_user.get("/logout", follow_redirects=False)
+        assert resp.status_code == 303
+        assert resp.headers["location"] == "/login"
+        assert "www-authenticate" not in {k.lower() for k in resp.headers.keys()}
+        set_cookie = resp.headers.get("set-cookie", "")
+        assert SESSION_COOKIE_NAME in set_cookie
+        assert SESSION_COOKIE_NAME not in client_with_user.cookies

--- a/app/tests/test_beginner_agent_transient_retry.py
+++ b/app/tests/test_beginner_agent_transient_retry.py
@@ -1,0 +1,80 @@
+"""Gap 2: rails_beginner_agent is a raw StateGraph node (no middleware.py), so it
+invokes the model directly and — before this fix — had NO transient-error retry at
+all. 4 real turns died on a single `httpx.RemoteProtocolError` ("peer closed
+connection ... incomplete chunked read") that the resilience ladder should have
+eaten. This test drives the actual node and asserts a model that raises a
+transient error twice then succeeds produces a response, not a raise.
+
+We call `leonardo_beginner` directly rather than building the graph: build_workflow()
+clears the asyncio event loop (team CI memo), and the node is where the invoke lives.
+"""
+import httpx
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage
+
+import app.agents.leonardo.rails_beginner_agent.nodes as nb
+import app.agents.leonardo.resilience as res
+
+
+class _FlakyBoundModel:
+    """The object llm.bind_tools() returns: .invoke raises a transient error
+    `fail_times` times, then returns a plain AIMessage."""
+
+    def __init__(self, fail_times):
+        self.fail_times = fail_times
+        self.calls = 0
+
+    def invoke(self, messages, **kwargs):
+        self.calls += 1
+        if self.calls <= self.fail_times:
+            raise httpx.RemoteProtocolError(
+                "peer closed connection without sending complete message body "
+                "(incomplete chunked read)"
+            )
+        return AIMessage(content="all done!")
+
+
+class _FlakyModel:
+    """Stand-in for get_llm(...): bind_tools returns the same flaky bound model so
+    we can count invokes across the retry loop."""
+
+    def __init__(self, fail_times):
+        self.bound = _FlakyBoundModel(fail_times)
+
+    def bind_tools(self, *a, **k):
+        return self.bound
+
+    # the failure-limit branch invokes the bare model (no bind_tools)
+    def invoke(self, messages, **kwargs):
+        return self.bound.invoke(messages, **kwargs)
+
+
+@pytest.fixture(autouse=True)
+def _no_backoff(monkeypatch):
+    monkeypatch.setattr(res.time, "sleep", lambda *_: None)
+    # Isolate the retry behavior from prompt/brand/skill machinery.
+    monkeypatch.setattr(nb, "get_sys_msg", lambda: {"role": "system", "content": "sys"})
+    monkeypatch.setattr(nb, "repair_orphaned_tool_calls_in_messages", lambda m: m)
+
+
+def test_beginner_node_retries_transient_then_succeeds(monkeypatch):
+    flaky = _FlakyModel(fail_times=2)
+    monkeypatch.setattr(nb, "get_llm", lambda name: flaky)
+
+    state = {"messages": [HumanMessage(content="build me a page")]}
+    out = nb.leonardo_beginner(state)
+
+    assert out["messages"][0].content == "all done!"   # response, not a raise
+    assert flaky.bound.calls == 3                       # failed twice, succeeded on 3rd
+
+
+def test_beginner_node_gives_up_after_cap(monkeypatch):
+    """A persistently transient endpoint still re-raises after the cap so it can
+    reach the outer floor rung — it must not retry forever."""
+    flaky = _FlakyModel(fail_times=99)
+    monkeypatch.setattr(nb, "get_llm", lambda name: flaky)
+
+    state = {"messages": [HumanMessage(content="build me a page")]}
+    with pytest.raises(httpx.RemoteProtocolError):
+        nb.leonardo_beginner(state)
+    assert flaky.bound.calls == res._MODEL_RETRY_MAX_ATTEMPTS

--- a/app/tests/test_llamapress_api.py
+++ b/app/tests/test_llamapress_api.py
@@ -1,0 +1,260 @@
+"""The llamapress_api library (app/lib/llamapress_api.py) — user-scoped Rails HTTP.
+
+This is a LIBRARY for custom agents (the reference implementation lives downstream
+in Leonardo's langgraph/agents/leo, registered via the langgraph.local.json overlay).
+LlamaBot itself deliberately registers no agent and no chat mode that uses it.
+
+What actually enforces "this user can only touch their own stuff" lives in RAILS
+(the gem's signed token -> warden sign-in -> `llama_bot_allow` -> Pundit), and is
+covered by the gem's specs. There is deliberately no authorization logic in Python
+to test.
+
+So what's left here is the stuff that would silently DEFEAT that design from this
+side, and each test below maps to one such way:
+
+  * the token must actually reach the tool (a dropped state field = the tool is
+    dead, or worse, quietly unauthenticated)
+  * the token must never leave for a host that isn't Rails (it's a bearer
+    credential — an off-host request hands the user's account away)
+  * LlamaBot must NOT quietly re-grow a built-in mode around it (the boundary is
+    the product story: platform ships the library, the client repo ships the agent)
+"""
+import httpx
+import pytest
+
+from app.lib import llamapress_api
+from app.lib.llamapress_api import (
+    RAILS_BASE_URL,
+    LlamaPressAPIState,
+    rails_api_request,
+)
+
+
+class _Runtime:
+    """Stand-in for ToolRuntime — the tool only reads `.state`."""
+
+    def __init__(self, state):
+        self.state = state
+        self.tool_call_id = "test-call"
+
+
+def _invoke(method="GET", path="/api/users", body=None, token="signed-token"):
+    state = {"api_token": token} if token is not None else {}
+    return rails_api_request.func(
+        method=method, path=path, body=body, runtime=_Runtime(state)
+    )
+
+
+@pytest.fixture
+def captured(monkeypatch):
+    """Capture the outbound request instead of making one. Returns a dict that
+    fills in with the request the tool tried to send."""
+    seen = {}
+
+    class _FakeClient:
+        def __init__(self, **kwargs):
+            seen["client_kwargs"] = kwargs
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def request(self, method, url, headers=None, json=None):
+            seen.update(method=method, url=url, headers=headers, json=json)
+            return httpx.Response(
+                200,
+                text='[{"id":1,"email":"a@b.com"}]',
+                request=httpx.Request(method, url),
+            )
+
+    monkeypatch.setattr(llamapress_api.httpx, "Client", _FakeClient)
+    return seen
+
+
+# --- the token reaches Rails, correctly ------------------------------------
+
+def test_token_is_sent_as_the_gem_auth_scheme(captured):
+    """The gem's AgentAuth only recognises `Authorization: LlamaBot <token>`
+    (AUTH_SCHEME). Send `Bearer` and every request 401s."""
+    _invoke(token="signed-token")
+    assert captured["headers"]["Authorization"] == "LlamaBot signed-token"
+
+
+def test_request_goes_to_the_rails_app(captured):
+    _invoke(path="/api/users?q=alice")
+    assert captured["url"] == f"{RAILS_BASE_URL}/api/users?q=alice"
+
+
+def test_body_is_sent_as_json(captured):
+    _invoke(method="POST", path="/api/users", body={"email": "a@b.com"})
+    assert captured["json"] == {"email": "a@b.com"}
+    assert captured["method"] == "POST"
+
+
+def test_missing_token_does_not_send_an_unauthenticated_request(captured):
+    """Without a token the tool must NOT fall through to an anonymous request —
+    that would read as a permissions result when it's really a wiring failure."""
+    result = _invoke(token=None)
+    assert "url" not in captured, "made a request despite having no token"
+    assert "setup issue" in result
+
+
+# --- the token can't leak off-host (SSRF) ----------------------------------
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "//evil.com/steal",             # protocol-relative
+        "https://evil.com/steal",       # absolute
+        "http://evil.com/steal",
+        "api/users",                    # not app-relative
+        "/api\\evil",                   # backslash trick
+    ],
+)
+def test_paths_that_could_leave_the_rails_app_are_refused(captured, path):
+    result = _invoke(path=path)
+    assert "url" not in captured, f"path {path!r} produced an outbound request"
+    assert "Invalid path" in result
+
+
+# --- the path boundary ------------------------------------------------------
+#
+# Why this exists: `llama_bot_allow` only gates controllers that include
+# AgentAuth, and the Leonardo skeleton ships with the app's own
+# `authenticate_user!` commented out. Verified on the dev box: `GET /users` with
+# NO token returns 500 — it routed into the controller, ungated. So restricting
+# the tool to the agent-facing namespace is load-bearing, not decoration.
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/users",              # the ungated app route this check exists for
+        "/users/1",
+        "/",
+        "/admin/things",
+        "/llama_bot/agent",    # the engine's own routes
+        "/apifoo",             # prefix must be "/api/", not "/api"
+        "/api/../users",       # normalizes out of the namespace server-side
+    ],
+)
+def test_routes_outside_the_api_namespace_are_refused(captured, path):
+    result = _invoke(path=path)
+    assert "url" not in captured, f"path {path!r} produced an outbound request"
+    assert "Invalid path" in result
+
+
+def test_the_api_namespace_is_reachable(captured):
+    """The guard must not be so tight the tool is useless."""
+    _invoke(path="/api/users")
+    assert captured["url"].endswith("/api/users")
+
+
+def test_redirects_are_not_followed(captured):
+    """A redirect would replay the Authorization header at the new origin."""
+    _invoke()
+    assert captured["client_kwargs"]["follow_redirects"] is False
+
+
+def test_redirect_response_is_reported_not_chased(monkeypatch):
+    class _FakeClient:
+        def __init__(self, **kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def request(self, method, url, headers=None, json=None):
+            return httpx.Response(
+                302,
+                headers={"location": "/users/sign_in"},
+                request=httpx.Request(method, url),
+            )
+
+    monkeypatch.setattr(llamapress_api.httpx, "Client", _FakeClient)
+    result = _invoke()
+    assert "302" in result and "expired" in result
+
+
+def test_unsupported_method_is_refused(captured):
+    result = _invoke(method="TRACE")
+    assert "url" not in captured
+    assert "Unsupported method" in result
+
+
+def test_token_is_never_echoed_into_the_response(monkeypatch):
+    """Tool output re-enters the LLM context and the transcript. The token must
+    not ride along — a 403 body is shown to the user verbatim."""
+    class _FakeClient:
+        def __init__(self, **kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def request(self, method, url, headers=None, json=None):
+            return httpx.Response(403, text="forbidden", request=httpx.Request(method, url))
+
+    monkeypatch.setattr(llamapress_api.httpx, "Client", _FakeClient)
+    result = _invoke(token="super-secret-token")
+    assert "super-secret-token" not in result
+
+
+def test_a_403_is_surfaced_as_a_normal_result(monkeypatch):
+    """Pundit/allowlist denials are the expected path, not an exception."""
+    class _FakeClient:
+        def __init__(self, **kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def request(self, method, url, headers=None, json=None):
+            return httpx.Response(
+                403,
+                text='{"error":"Action \'destroy\' isn\'t white-listed for LlamaBot."}',
+                request=httpx.Request(method, url),
+            )
+
+    monkeypatch.setattr(llamapress_api.httpx, "Client", _FakeClient)
+    result = _invoke(method="DELETE", path="/api/users/1")
+    assert "HTTP 403" in result
+    assert "white-listed" in result
+
+
+# --- the wire contract ------------------------------------------------------
+
+def test_state_base_declares_api_token():
+    """LangGraph filters state to the schema, so an undeclared `api_token` is
+    dropped between the WS frame and the tool — the tool fails closed and looks
+    like a permissions bug. Custom agents subclass this to stay wired."""
+    assert "api_token" in LlamaPressAPIState.__annotations__
+
+
+# --- the platform/client boundary -------------------------------------------
+
+def test_llamabot_ships_no_builtin_agent_or_mode_for_this_library():
+    """The working agent lives in the CLIENT repo (Leonardo leo, via the
+    langgraph.local.json overlay). If LlamaBot re-grows a built-in `user_api`
+    mode or registers a graph around this tool, the separation this library
+    exists for is gone — do it deliberately or not at all."""
+    import json
+    from pathlib import Path
+
+    from app.permissions import BUILTIN_AGENT_MODE_KEYS, MODE_AGENTS
+
+    assert "user_api" not in BUILTIN_AGENT_MODE_KEYS
+    assert "user_api" not in MODE_AGENTS
+
+    base = json.loads((Path(__file__).parent.parent / "langgraph.json").read_text())
+    assert "user_api_agent" not in base["graphs"]

--- a/app/tests/test_llm_factory_retry_ownership.py
+++ b/app/tests/test_llm_factory_retry_ownership.py
@@ -11,6 +11,8 @@ from app.agents.leonardo import model_policy
     ("model_name", "constructor_name", "retry_key"),
     [
         ("deepseek-v4-flash", "ChatDeepSeekWithReasoning", "max_retries"),
+        ("deepseek-v4-flash-gmi", "ChatDeepSeekWithReasoning", "max_retries"),
+        ("deepseek-v4-flash-fireworks", "ChatDeepSeekWithReasoning", "max_retries"),
         ("gpt-5-mini", "ChatOpenAI", "max_retries"),
         ("claude-4.5-haiku", "ChatAnthropic", "max_retries"),
         ("gemini-3-flash", "ChatGoogleGenerativeAI", "retries"),
@@ -32,6 +34,77 @@ def test_get_llm_disables_hidden_provider_retries(
     llm_factory.get_llm(model_name)
 
     assert captured[retry_key] == 0
+
+
+def test_gmi_deepseek_routes_to_gmi_endpoint_and_key(monkeypatch):
+    """The GMI entry must stay a distinct provider path from DeepSeek direct.
+
+    Guards the whole point of the separate model name: it has to reach GMI's
+    endpoint with GMI's key and GMI's namespaced model id. A regression here
+    would silently bill/route to api.deepseek.com under a GMI-labelled option.
+    """
+    captured = {}
+
+    def fake_constructor(**kwargs):
+        captured.update(kwargs)
+        return object()
+
+    monkeypatch.setattr(model_policy, "is_model_enabled", lambda _: True)
+    monkeypatch.setattr(llm_factory, "ChatDeepSeekWithReasoning", fake_constructor)
+    monkeypatch.setenv("GMI_DEEPSEEK_API_KEY", "gmi-test-key")
+    monkeypatch.delenv("GMI_BASE_URL", raising=False)
+    monkeypatch.delenv("GMI_DEEPSEEK_MODEL", raising=False)
+
+    llm_factory.get_llm("deepseek-v4-flash-gmi")
+
+    assert captured["api_base"] == "https://api.gmi-serving.com/v1"
+    assert captured["api_key"] == "gmi-test-key"
+    assert captured["model"] == "deepseek-ai/DeepSeek-V4-Flash"
+
+
+def test_fireworks_deepseek_routes_to_fireworks_endpoint_and_key(monkeypatch):
+    """The Fireworks entry must stay a distinct provider path.
+
+    Fireworks was chosen for data-retention reasons (US-hosted) — a regression
+    that silently routed this to DeepSeek direct or GMI would break the very
+    guarantee the entry exists to provide, without any visible symptom.
+    """
+    captured = {}
+
+    def fake_constructor(**kwargs):
+        captured.update(kwargs)
+        return object()
+
+    monkeypatch.setattr(model_policy, "is_model_enabled", lambda _: True)
+    monkeypatch.setattr(llm_factory, "ChatDeepSeekWithReasoning", fake_constructor)
+    monkeypatch.setenv("FIREWORKS_DEEPSEEK_API_KEY", "fw-test-key")
+    monkeypatch.delenv("FIREWORKS_BASE_URL", raising=False)
+    monkeypatch.delenv("FIREWORKS_DEEPSEEK_MODEL", raising=False)
+
+    llm_factory.get_llm("deepseek-v4-flash-fireworks")
+
+    assert captured["api_base"] == "https://api.fireworks.ai/inference/v1"
+    assert captured["api_key"] == "fw-test-key"
+    assert captured["model"] == "accounts/fireworks/models/deepseek-v4-flash"
+
+
+def test_deepseek_direct_does_not_point_at_third_party(monkeypatch):
+    """The plain DeepSeek entry must keep using DeepSeek's own API."""
+    captured = {}
+
+    def fake_constructor(**kwargs):
+        captured.update(kwargs)
+        return object()
+
+    monkeypatch.setattr(model_policy, "is_model_enabled", lambda _: True)
+    monkeypatch.setattr(llm_factory, "ChatDeepSeekWithReasoning", fake_constructor)
+    monkeypatch.setenv("GMI_BASE_URL", "https://api.gmi-serving.com/v1")
+    monkeypatch.setenv("FIREWORKS_BASE_URL", "https://api.fireworks.ai/inference/v1")
+
+    llm_factory.get_llm("deepseek-v4-flash")
+
+    assert "api_base" not in captured
+    assert captured["model"] == "deepseek-v4-flash"
 
 
 @pytest.mark.asyncio

--- a/app/tests/test_orphaned_toolcall_repair_all_agents.py
+++ b/app/tests/test_orphaned_toolcall_repair_all_agents.py
@@ -172,6 +172,19 @@ def test_every_leonardo_agent_is_wired_for_repair(nodes_file):
     if not (uses_factory or uses_raw_create_agent or uses_stategraph):
         pytest.skip(f"{nodes_file.parent.name} does not construct an agent")
 
+    # An agent that binds NO tools cannot produce an orphaned tool call, so it has
+    # nothing to repair (SI#112 is specifically about AIMessage.tool_calls with no
+    # matching ToolMessage). Deliberately narrow: bind a tool by any of the usual
+    # routes and the backstop applies again — this exempts genuinely tool-less
+    # agents, not agents that merely wire tools in an unusual way.
+    #
+    # Scan CODE only: a comment saying "no bind_tools() here" must not read as
+    # binding tools.
+    code = "\n".join(line.split("#", 1)[0] for line in text.splitlines())
+    binds_tools = any(s in code for s in ("bind_tools(", "ToolNode(", "tools=", "tool_list"))
+    if not binds_tools:
+        pytest.skip(f"{nodes_file.parent.name} binds no tools — no orphans possible")
+
     # create_agent path: must go through the factory (which prepends repair).
     if uses_factory:
         return

--- a/app/tests/test_permissions.py
+++ b/app/tests/test_permissions.py
@@ -1,0 +1,324 @@
+"""Role → agent-mode permissions (app/permissions.py).
+
+The rule these lock down: the mode dropdown and the WebSocket gate are two views
+of ONE grant. Before this, the dropdown filtered client-side and the socket took
+any `agent_name` off the wire — so a `user`-role account could run any agent by
+editing one field in a frame. test_websocket_mode_enforcement.py covers the gate;
+this covers the resolver they both call.
+"""
+import json
+import re
+from pathlib import Path
+
+import pytest
+from sqlmodel import Session, SQLModel, create_engine
+
+from app.permissions import (
+    DEFAULT_ROLE_MODES,
+    MODE_AGENTS,
+    ROLE_MODES_SETTING_KEY,
+    allowed_agent_names,
+    allowed_modes,
+    can_run_agent,
+    get_role_modes,
+    visible_modes,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+FRONTEND = REPO_ROOT / "app" / "frontend" / "chat"
+
+
+@pytest.fixture
+def session():
+    """In-memory DB with the real SiteSetting table (no mocks — this is a schema test too)."""
+    import app.models  # noqa: F401  (registers the tables on SQLModel.metadata)
+
+    engine = create_engine("sqlite://")
+    SQLModel.metadata.create_all(engine)
+    with Session(engine) as s:
+        yield s
+
+
+def _configure(session, mapping):
+    """Write the admin's role→modes config, as PUT /api/role-modes does."""
+    from app.models import SiteSetting
+
+    session.add(SiteSetting(key=ROLE_MODES_SETTING_KEY, value=json.dumps(mapping)))
+    session.commit()
+
+
+class _User:
+    """Stand-in for the User row — the resolver only ever reads these three."""
+
+    def __init__(self, role=None, is_admin=False, visible_agents=None):
+        self.role = role
+        self.is_admin = is_admin
+        self.visible_agents = visible_agents
+
+
+# --- defaults / unconfigured instance -------------------------------------
+
+def test_unconfigured_roles_get_their_defaults(session):
+    assert allowed_modes(session, "user") == DEFAULT_ROLE_MODES["user"]
+    assert allowed_modes(session, "engineer") == DEFAULT_ROLE_MODES["engineer"]
+
+
+def test_user_role_cannot_use_engineer_modes_by_default(session):
+    assert can_run_agent(session, "user", False, "rails_plain_chat_mode") is True
+    assert can_run_agent(session, "user", False, "rails_agent") is False
+    assert can_run_agent(session, "user", False, "pyxl_agent") is False
+
+
+# --- the namespace the wire actually speaks -------------------------------
+# The client sends `agent_name` (a graph), never the mode key. Gating on mode
+# keys compared two different namespaces and denied everyone, admins included —
+# caught only by driving a real socket, so it's pinned here.
+
+def test_grant_is_checked_in_graph_space_not_mode_space(session):
+    """`engineer` is a mode key; `rails_agent` is what actually arrives."""
+    assert "engineer" in allowed_modes(session, "engineer")
+    assert can_run_agent(session, "engineer", False, "rails_agent") is True
+    # The mode key itself is NOT a graph and must never authorize a run.
+    assert can_run_agent(session, "engineer", False, "engineer") is False
+
+
+def test_admin_can_run_the_real_graph_names(session):
+    """The regression that locked admins out."""
+    for graph in ("rails_agent", "rails_beginner_agent", "pyxl_agent", "rails_plain_chat_mode"):
+        assert can_run_agent(session, "engineer", True, graph) is True
+
+
+def test_a_mode_grants_its_plan_variant_too(session):
+    """Toggling Plan swaps the graph; it must not trip the gate."""
+    assert can_run_agent(session, "engineer", False, "rails_engineer_plan_mode_agent") is True
+    assert can_run_agent(session, "engineer", False, "rails_plan_mode_agent") is True  # via beginner etc.
+
+
+def test_chat_mode_grants_no_tool_using_plan_agent(session):
+    """The escape hatch this closes: chat + Plan must not reach the generic plan agent.
+
+    rails_plan_mode_agent HAS tools. If `chat` granted it, the `user` role — whose
+    whole point is a no-tools ceiling — could toggle Plan and escape.
+    """
+    assert allowed_modes(session, "user") == ["chat"]
+    assert can_run_agent(session, "user", False, "rails_plain_chat_mode") is True
+    assert can_run_agent(session, "user", False, "rails_plan_mode_agent") is False
+
+
+def test_unknown_graph_is_denied(session):
+    assert can_run_agent(session, "engineer", False, "llamabot") is False
+    assert can_run_agent(session, "engineer", False, "totally_made_up") is False
+
+
+# --- parity with the frontend ---------------------------------------------
+# MODE_AGENTS duplicates a map that lives in JS. These parse the JS so the two
+# cannot drift silently.
+
+def _parse_agent_modes_js():
+    """Pull DEFAULT_CONFIG.agentModes out of config.js as {mode: agent_name}."""
+    src = (FRONTEND / "config.js").read_text()
+    block = re.search(r"agentModes:\s*\{(.*?)\}", src, re.S)
+    assert block, "could not find agentModes in config.js"
+    return dict(re.findall(r"(\w+):\s*'([^']+)'", block.group(1)))
+
+
+def _parse_plan_agents_js():
+    """Pull planAgentByMode out of index.js as {mode: plan_agent_name}."""
+    src = (FRONTEND / "index.js").read_text()
+    block = re.search(r"planAgentByMode\s*=\s*\{(.*?)\}", src, re.S)
+    assert block, "could not find planAgentByMode in index.js"
+    return dict(re.findall(r"(\w+):\s*'([^']+)'", block.group(1)))
+
+
+def test_mode_agents_covers_every_frontend_base_agent():
+    """Every mode the dropdown can select must be grantable server-side."""
+    js = _parse_agent_modes_js()
+    # These are agent_name aliases, not selectable dropdown modes.
+    aliases = {"plan", "engineer_plan", "ticket_plan"}
+    for mode, agent_name in js.items():
+        if mode in aliases:
+            continue
+        assert mode in MODE_AGENTS, f"config.js has mode '{mode}' with no MODE_AGENTS entry"
+        assert agent_name in MODE_AGENTS[mode], (
+            f"config.js maps {mode} -> {agent_name}, missing from MODE_AGENTS[{mode}]"
+        )
+
+
+def test_mode_agents_has_no_modes_the_frontend_cannot_select():
+    """A grantable mode with no dropdown entry is dead config (this is how `feedback` rotted)."""
+    js = _parse_agent_modes_js()
+    for mode in MODE_AGENTS:
+        assert mode in js, f"MODE_AGENTS has '{mode}' but config.js cannot select it"
+
+
+def test_mode_agents_covers_every_frontend_plan_variant():
+    for mode, plan_agent in _parse_plan_agents_js().items():
+        assert plan_agent in MODE_AGENTS[mode], (
+            f"index.js maps {mode} + Plan -> {plan_agent}, missing from MODE_AGENTS[{mode}]"
+        )
+
+
+def test_every_builtin_mode_resolves_to_a_registered_graph():
+    """A grantable mode pointing at an unregistered graph is a dead dropdown entry.
+
+    Reads app/langgraph.json directly rather than load_graphs(), which resolves
+    against the CWD. NOTE: the repo ALSO has a langgraph.json at its root with a
+    stale subset of graphs — the app never reads it (uvicorn's CWD is app/, so
+    app/langgraph.json shadows it). This asserts against the one that's live.
+    """
+    base = json.loads((REPO_ROOT / "app" / "langgraph.json").read_text())
+    registered = set(base["graphs"])
+
+    granted = {g for graphs in MODE_AGENTS.values() for g in graphs}
+    missing = sorted(granted - registered)
+    assert not missing, f"grantable modes map to unregistered graphs: {missing}"
+
+
+# --- admin-configured grants ----------------------------------------------
+
+def test_admin_config_overrides_the_default(session):
+    _configure(session, {"user": ["chat", "beginner"]})
+    assert allowed_modes(session, "user") == ["chat", "beginner"]
+    assert can_run_agent(session, "user", False, "rails_beginner_agent") is True
+
+
+def test_configuring_one_role_leaves_others_on_defaults(session):
+    _configure(session, {"user": ["beginner"]})
+    assert allowed_modes(session, "engineer") == DEFAULT_ROLE_MODES["engineer"]
+
+
+def test_config_can_revoke_a_mode_from_engineer(session):
+    _configure(session, {"engineer": ["ticket", "engineer"]})
+    assert can_run_agent(session, "engineer", False, "pyxl_agent") is False
+    assert can_run_agent(session, "engineer", False, "rails_ticket_mode_agent") is True
+
+
+def test_config_order_drives_dropdown_order(session):
+    _configure(session, {"user": ["pyxl", "chat", "beginner"]})
+    assert allowed_modes(session, "user") == ["pyxl", "chat", "beginner"]
+
+
+# --- admin is a superset ---------------------------------------------------
+
+def test_admin_gets_every_mode_regardless_of_role(session):
+    _configure(session, {"user": []})
+    granted = allowed_modes(session, "user", is_admin=True)
+    assert set(granted) == set(MODE_AGENTS)  # `plan` is a toggle, not a grantable mode
+
+
+def test_admin_cannot_lock_themselves_out(session):
+    """The point of the superset rule: an admin editing the role table keeps access."""
+    _configure(session, {"user": [], "engineer": []})
+    assert allowed_modes(session, "engineer", is_admin=True) != []
+
+
+def test_admin_gets_custom_modes_too(session):
+    granted = allowed_modes(session, "user", is_admin=True, custom={"my_agent": "some_graph"})
+    assert "my_agent" in granted
+
+
+# --- least privilege on unknown/missing role -------------------------------
+
+def test_unknown_role_falls_back_to_user_not_engineer(session):
+    """Settles the old dependencies.py('user') vs ui.py('engineer') split — safe answer wins."""
+    assert allowed_modes(session, "wat") == DEFAULT_ROLE_MODES["user"]
+    assert allowed_modes(session, None) == DEFAULT_ROLE_MODES["user"]
+    assert can_run_agent(session, None, False, "rails_agent") is False
+
+
+# --- malformed config degrades to defaults, never to open ------------------
+
+@pytest.mark.parametrize("bad", ["not json", "[]", '"a string"', "null", ""])
+def test_malformed_config_falls_back_to_defaults(session, bad):
+    from app.models import SiteSetting
+
+    session.add(SiteSetting(key=ROLE_MODES_SETTING_KEY, value=bad))
+    session.commit()
+    assert allowed_modes(session, "user") == DEFAULT_ROLE_MODES["user"]
+    assert can_run_agent(session, "user", False, "rails_agent") is False
+
+
+def test_junk_entries_within_valid_json_are_skipped(session):
+    _configure(session, {"user": ["chat", 42, None], "bogus": "not-a-list"})
+    assert allowed_modes(session, "user") == ["chat"]
+
+
+def test_unknown_mode_keys_in_config_are_dropped(session):
+    """A stale config naming a mode that no longer exists must not grant it."""
+    _configure(session, {"user": ["chat", "deleted_mode"]})
+    assert allowed_modes(session, "user") == ["chat"]
+
+
+def test_db_unavailable_falls_back_to_defaults(session):
+    class _Broken:
+        def get(self, *a, **kw):
+            raise RuntimeError("no auth DB")
+
+    assert allowed_modes(_Broken(), "user") == DEFAULT_ROLE_MODES["user"]
+    assert can_run_agent(_Broken(), "user", False, "rails_agent") is False
+
+
+# --- custom modes ----------------------------------------------------------
+
+def test_custom_modes_ride_along_with_an_unconfigured_engineer_default(session):
+    granted = allowed_modes(session, "engineer", custom={"my_agent": "some_graph"})
+    assert "my_agent" in granted
+
+
+def test_custom_modes_do_not_ride_along_for_the_user_role(session):
+    granted = allowed_modes(session, "user", custom={"my_agent": "some_graph"})
+    assert "my_agent" not in granted
+
+
+def test_configured_role_must_opt_into_custom_modes_explicitly(session):
+    """Once an admin sets a role's list, nothing gets auto-added behind their back."""
+    _configure(session, {"engineer": ["ticket"]})
+    assert allowed_modes(session, "engineer", custom={"my_agent": "some_graph"}) == ["ticket"]
+
+    _configure_again = {"engineer": ["ticket", "my_agent"]}
+    from app.models import SiteSetting
+
+    session.get(SiteSetting, ROLE_MODES_SETTING_KEY).value = json.dumps(_configure_again)
+    session.commit()
+    assert "my_agent" in allowed_modes(session, "engineer", custom={"my_agent": "some_graph"})
+
+
+# --- visible_agents narrows, never widens ----------------------------------
+
+def test_visible_agents_narrows_the_grant(session):
+    user = _User(role="engineer", visible_agents=json.dumps(["ticket", "engineer"]))
+    assert visible_modes(session, user) == ["ticket", "engineer"]
+
+
+def test_visible_agents_cannot_widen_past_the_role(session):
+    """The escalation this closes: a per-user list naming a mode the role lacks."""
+    user = _User(role="user", visible_agents=json.dumps(["chat", "pyxl"]))
+    assert visible_modes(session, user) == ["chat"]
+
+
+def test_visible_agents_unset_means_the_full_grant(session):
+    user = _User(role="engineer", visible_agents=None)
+    assert visible_modes(session, user) == DEFAULT_ROLE_MODES["engineer"]
+
+
+@pytest.mark.parametrize("raw", ["", "not json", "{}", "[]"])
+def test_malformed_visible_agents_means_no_preference(session, raw):
+    user = _User(role="engineer", visible_agents=raw)
+    assert visible_modes(session, user) == DEFAULT_ROLE_MODES["engineer"]
+
+
+def test_stale_visible_agents_does_not_produce_an_empty_dropdown(session):
+    """Preference names only revoked modes → fall back to the grant, not a dead UI."""
+    _configure(session, {"engineer": ["ticket"]})
+    user = _User(role="engineer", visible_agents=json.dumps(["pyxl"]))
+    assert visible_modes(session, user) == ["ticket"]
+
+
+def test_visible_agents_preserves_grant_order_not_preference_order(session):
+    user = _User(role="engineer", visible_agents=json.dumps(["engineer", "ticket"]))
+    assert visible_modes(session, user) == ["ticket", "engineer"]
+
+
+def test_admin_visible_agents_still_narrows(session):
+    user = _User(role="engineer", is_admin=True, visible_agents=json.dumps(["pyxl"]))
+    assert visible_modes(session, user) == ["pyxl"]

--- a/app/tests/test_resilience_transient_retry.py
+++ b/app/tests/test_resilience_transient_retry.py
@@ -50,6 +50,23 @@ def test_transient_types_preserve_existing_google_behavior():
     assert ResourceExhausted in transient_exception_types()
 
 
+def test_transient_types_include_httpx_stream_read_write_errors():
+    """Gap 1: httpx.ReadError (mid-stream socket read failure, empty str(e)) killed
+    4 real turns because it wasn't classified transient. Its WriteError sibling is
+    the same family. Both must be retryable."""
+    import httpx
+    types = transient_exception_types()
+    assert httpx.ReadError in types
+    assert httpx.WriteError in types
+
+
+def test_is_transient_true_for_httpx_read_error():
+    """ReadError carries no status code and an empty message — the type list is the
+    only signal, so is_transient_error must still say True."""
+    import httpx
+    assert is_transient_error(httpx.ReadError("")) is True
+
+
 def test_transient_types_EXCLUDE_deterministic_errors():
     """The whole point: deterministic bugs must never be retried."""
     import openai
@@ -98,6 +115,57 @@ class _FakeStatusError(Exception):
     def __init__(self, status_code, message=""):
         super().__init__(message)
         self.status_code = status_code
+
+
+# --- the shared invoke_with_transient_retry helper ----------------------------
+# Raw StateGraph nodes (rails_beginner_agent, rails_ai_builder_agent) call the
+# model directly and never touch DynamicModelMiddleware, so they retry via this.
+
+def test_invoke_with_transient_retry_retries_then_succeeds(monkeypatch):
+    import app.agents.leonardo.resilience as res
+    monkeypatch.setattr(res.time, "sleep", lambda *_: None)
+    import httpx
+
+    calls = {"n": 0}
+
+    def fn():
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise httpx.RemoteProtocolError("peer closed connection")
+        return "OK"
+
+    assert res.invoke_with_transient_retry(fn) == "OK"
+    assert calls["n"] == 3
+
+
+def test_invoke_with_transient_retry_does_NOT_retry_deterministic(monkeypatch):
+    import app.agents.leonardo.resilience as res
+    monkeypatch.setattr(res.time, "sleep", lambda *_: None)
+
+    calls = {"n": 0}
+
+    def fn():
+        calls["n"] += 1
+        raise TypeError("unexpected keyword argument 'cache_control'")
+
+    with pytest.raises(TypeError):
+        res.invoke_with_transient_retry(fn)
+    assert calls["n"] == 1
+
+
+def test_invoke_with_transient_retry_gives_up_after_cap(monkeypatch):
+    import app.agents.leonardo.resilience as res
+    monkeypatch.setattr(res.time, "sleep", lambda *_: None)
+
+    calls = {"n": 0}
+
+    def fn():
+        calls["n"] += 1
+        raise ConnectionError("still down")
+
+    with pytest.raises(ConnectionError):
+        res.invoke_with_transient_retry(fn)
+    assert calls["n"] == res._MODEL_RETRY_MAX_ATTEMPTS
 
 
 # --- wiring into DynamicModelMiddleware --------------------------------------

--- a/app/tests/test_role_modes_api.py
+++ b/app/tests/test_role_modes_api.py
@@ -1,0 +1,149 @@
+"""Admin API for role → agent-mode grants (GET/PUT /api/role-modes).
+
+Deliberately admin-only, unlike /api/site-settings/{key} which is
+engineer-or-admin — an engineer editing role grants could widen another role.
+
+Run with: pytest app/tests/test_role_modes_api.py -v
+"""
+import json
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy.pool import StaticPool
+from sqlmodel import Session, SQLModel, create_engine
+
+from app.permissions import ROLE_MODES_SETTING_KEY
+
+
+@pytest.fixture
+def client():
+    import app.models  # noqa: F401
+    from app.dependencies import admin_required, get_db_session
+    from app.models import User
+    from app.routers.api import router
+
+    # StaticPool + check_same_thread: TestClient runs the app on another thread,
+    # and a default in-memory SQLite engine would hand it a fresh, empty DB.
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    SQLModel.metadata.create_all(engine)
+
+    app = FastAPI()
+    app.include_router(router)
+
+    def _session():
+        with Session(engine) as s:
+            yield s
+
+    app.dependency_overrides[get_db_session] = _session
+    app.dependency_overrides[admin_required] = lambda: User(
+        username="admin", password_hash="x", is_admin=True, role="engineer"
+    )
+
+    c = TestClient(app)
+    c._engine = engine
+    return c
+
+
+def _stored(client):
+    from app.models import SiteSetting
+
+    with Session(client._engine) as s:
+        setting = s.get(SiteSetting, ROLE_MODES_SETTING_KEY)
+        return json.loads(setting.value) if setting else None
+
+
+# --- GET -------------------------------------------------------------------
+
+def test_get_returns_defaults_and_the_mode_catalog(client):
+    r = client.get("/api/role-modes")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["role_modes"]["user"] == ["chat"]
+    assert "engineer" in body["role_modes"]
+    assert "pyxl" in body["all_modes"] and "chat" in body["all_modes"]
+    assert body["defaults"]["user"] == ["chat"]
+
+
+def test_get_reflects_a_saved_config(client):
+    client.put("/api/role-modes", json={"role_modes": {"user": ["chat", "beginner"]}})
+    assert client.get("/api/role-modes").json()["role_modes"]["user"] == ["chat", "beginner"]
+
+
+# --- PUT -------------------------------------------------------------------
+
+def test_put_persists_the_grant(client):
+    r = client.put("/api/role-modes", json={"role_modes": {"user": ["chat", "beginner"]}})
+    assert r.status_code == 200
+    assert _stored(client) == {"user": ["chat", "beginner"]}
+
+
+def test_put_preserves_admin_ordering(client):
+    """Order drives the chat dropdown, so it must survive the round trip."""
+    client.put("/api/role-modes", json={"role_modes": {"user": ["pyxl", "chat"]}})
+    assert _stored(client)["user"] == ["pyxl", "chat"]
+
+
+def test_put_dedupes(client):
+    client.put("/api/role-modes", json={"role_modes": {"user": ["chat", "chat"]}})
+    assert _stored(client)["user"] == ["chat"]
+
+
+def test_put_accepts_an_empty_grant(client):
+    """Revoking everything from a role is legitimate — admins keep access regardless."""
+    r = client.put("/api/role-modes", json={"role_modes": {"user": []}})
+    assert r.status_code == 200
+    assert _stored(client) == {"user": []}
+
+
+def test_put_replaces_rather_than_merges(client):
+    client.put("/api/role-modes", json={"role_modes": {"user": ["chat"], "engineer": ["ticket"]}})
+    client.put("/api/role-modes", json={"role_modes": {"user": ["beginner"]}})
+    assert _stored(client) == {"user": ["beginner"]}
+
+
+# --- validation: a typo must fail loudly, not silently narrow access -------
+
+def test_put_rejects_an_unknown_mode(client):
+    r = client.put("/api/role-modes", json={"role_modes": {"user": ["chat", "typo_mode"]}})
+    assert r.status_code == 400
+    assert "typo_mode" in r.json()["detail"]
+    assert _stored(client) is None
+
+
+@pytest.mark.parametrize("payload", [
+    {},
+    {"role_modes": "nope"},
+    {"role_modes": {"user": "chat"}},
+    {"role_modes": {"user": [1, 2]}},
+    {"role_modes": {"": ["chat"]}},
+])
+def test_put_rejects_malformed_payloads(client, payload):
+    assert client.put("/api/role-modes", json=payload).status_code == 400
+
+
+def test_put_rejects_a_config_too_large_to_store(client):
+    """SiteSetting.value is max_length=1000 — reject rather than truncate."""
+    r = client.put("/api/role-modes", json={
+        "role_modes": {f"role_{i}": ["chat", "engineer", "pyxl"] for i in range(60)}
+    })
+    assert r.status_code == 400
+    assert _stored(client) is None
+
+
+# --- authorization ---------------------------------------------------------
+
+def test_endpoints_require_admin():
+    """The dependency itself — a non-admin must not reach either handler."""
+    from app.dependencies import admin_required, get_current_user
+    from app.models import User
+    from fastapi import HTTPException
+
+    engineer = User(username="eng", password_hash="x", is_admin=False, role="engineer")
+    with pytest.raises(HTTPException) as exc:
+        admin_required(current_user=engineer)
+    assert exc.value.status_code == 403

--- a/app/tests/test_websocket_mode_enforcement.py
+++ b/app/tests/test_websocket_mode_enforcement.py
@@ -1,0 +1,248 @@
+"""Server-side enforcement of agent modes on the WebSocket.
+
+The bug these lock down: `agent_name` came straight off the wire
+(request_handler.get_langgraph_app_and_state) and `self.auth_user` — which
+carries the role claim — was set and never read. The only thing stopping a
+`user`-role account from running the engineer agent was the dropdown filter in
+chat.html, i.e. one edited WebSocket frame.
+
+The gate lives in WebSocketHandler._authorize_agent_mode and runs BEFORE the
+type dispatch, so every frame naming a mode is covered — not just chat.
+
+Run with: pytest app/tests/test_websocket_mode_enforcement.py -v
+"""
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from sqlmodel import Session, SQLModel, create_engine
+
+from app.permissions import ROLE_MODES_SETTING_KEY
+
+
+@pytest.fixture
+def engine():
+    """In-memory DB standing in for the auth DB the gate reads grants from."""
+    import app.models  # noqa: F401
+
+    eng = create_engine("sqlite://")
+    SQLModel.metadata.create_all(eng)
+    return eng
+
+
+@pytest.fixture
+def handler(engine):
+    """A WebSocketHandler wired to the in-memory DB, with the socket mocked out."""
+    from app.websocket.web_socket_handler import WebSocketHandler
+
+    manager = MagicMock()
+    manager.app = MagicMock()
+    manager.send_personal_message = AsyncMock()
+
+    websocket = MagicMock()
+    websocket.client = "test-client"
+
+    with patch("app.websocket.request_handler.RequestHandler"):
+        h = WebSocketHandler(websocket, manager)
+
+    # The gate opens its own Session(engine); point that at the fixture DB.
+    h._test_engine = engine
+    h._is_websocket_open = lambda ws: True
+    return h
+
+
+def _as_browser_user(handler, role="user", is_admin=False):
+    """Authenticate the handler as a browser client (the only enforced path)."""
+    handler.authenticated = True
+    handler.auth_user = {
+        "sub": "alice",
+        "user_id": 1,
+        "role": role,
+        "is_admin": is_admin,
+        "type": "ws_auth",
+    }
+
+
+def _configure(engine, mapping):
+    from app.models import SiteSetting
+
+    with Session(engine) as s:
+        existing = s.get(SiteSetting, ROLE_MODES_SETTING_KEY)
+        if existing:
+            existing.value = json.dumps(mapping)
+        else:
+            s.add(SiteSetting(key=ROLE_MODES_SETTING_KEY, value=json.dumps(mapping)))
+        s.commit()
+
+
+async def _authorize(handler, frame):
+    """Run the gate with app.db.engine pointed at the test DB."""
+    with patch("app.db.engine", handler._test_engine), \
+         patch("app.permissions.custom_modes", return_value={}):
+        return await handler._authorize_agent_mode(frame)
+
+
+# --- the core regression --------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_user_role_cannot_run_engineer_agent(handler):
+    """THE bug: a hand-edited frame naming a graph the role was never granted."""
+    _as_browser_user(handler, role="user")
+    assert await _authorize(handler, {"message": "hi", "agent_name": "rails_agent"}) is False
+
+
+@pytest.mark.asyncio
+async def test_denial_tells_the_client_why(handler):
+    _as_browser_user(handler, role="user")
+    await _authorize(handler, {"agent_name": "pyxl_agent"})
+    handler.manager.send_personal_message.assert_awaited_once()
+    payload = handler.manager.send_personal_message.await_args[0][0]
+    assert payload["type"] == "error"
+    assert "access" in payload["content"]
+
+
+@pytest.mark.asyncio
+async def test_user_role_can_run_its_granted_mode(handler):
+    _as_browser_user(handler, role="user")
+    assert await _authorize(handler, {"message": "hi", "agent_name": "rails_plain_chat_mode"}) is True
+
+
+@pytest.mark.asyncio
+async def test_engineer_role_can_run_engineer_agent(handler):
+    _as_browser_user(handler, role="engineer")
+    assert await _authorize(handler, {"message": "hi", "agent_name": "rails_agent"}) is True
+
+
+# --- the gate covers every frame type, not just chat ----------------------
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("frame_type", ["approval_response", "question_response"])
+async def test_resume_frames_are_gated_too(handler, frame_type):
+    """These dispatch to get_langgraph_app_and_state with agent_name as well."""
+    _as_browser_user(handler, role="user")
+    frame = {"type": frame_type, "thread_id": "t1", "agent_name": "rails_agent"}
+    assert await _authorize(handler, frame) is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("frame", [
+    {"type": "ping"},
+    {"type": "cancel", "thread_id": "t1"},
+    {"type": "attach", "thread_id": "t1", "last_seq": 3},
+    {"message": "no agent_name here"},
+])
+async def test_frames_without_an_agent_name_pass_through(handler, frame):
+    _as_browser_user(handler, role="user")
+    assert await _authorize(handler, frame) is True
+
+
+# --- admin superset --------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_admin_can_run_any_mode_regardless_of_role(handler):
+    _as_browser_user(handler, role="user", is_admin=True)
+    assert await _authorize(handler, {"agent_name": "rails_agent"}) is True
+
+
+# --- admin config takes effect on the socket, not just the dropdown -------
+
+@pytest.mark.asyncio
+async def test_admin_granting_a_mode_to_a_role_takes_effect(handler, engine):
+    _as_browser_user(handler, role="user")
+    assert await _authorize(handler, {"agent_name": "rails_beginner_agent"}) is False
+
+    _configure(engine, {"user": ["chat", "beginner"]})
+    assert await _authorize(handler, {"agent_name": "rails_beginner_agent"}) is True
+
+
+@pytest.mark.asyncio
+async def test_admin_revoking_a_mode_from_a_role_takes_effect(handler, engine):
+    _as_browser_user(handler, role="engineer")
+    assert await _authorize(handler, {"agent_name": "pyxl_agent"}) is True
+
+    _configure(engine, {"engineer": ["ticket", "engineer"]})
+    assert await _authorize(handler, {"agent_name": "pyxl_agent"}) is False
+
+
+# --- non-browser callers keep their existing behaviour --------------------
+
+@pytest.mark.asyncio
+async def test_rails_gem_token_is_not_gated(handler):
+    """verify_rails_token returns no role claim; the gem is a trusted internal caller.
+
+    NOTE: that trust is currently unverified (token_service.verify_rails_token does
+    no signature check) — tracked separately. This test pins the gate's behaviour,
+    not an endorsement of that path.
+    """
+    handler.authenticated = True
+    handler.auth_user = {"sub": "rails_gem", "type": "rails_auth", "source": "llama_bot_rails"}
+    assert await _authorize(handler, {"agent_name": "rails_agent"}) is True
+
+
+@pytest.mark.asyncio
+async def test_unauthenticated_is_left_to_ws_auth_required(handler):
+    """WS_AUTH_REQUIRED governs this path; the gate has no role to check."""
+    handler.authenticated = False
+    handler.auth_user = None
+    assert await _authorize(handler, {"agent_name": "rails_agent"}) is True
+
+
+# --- the wiring ------------------------------------------------------------
+# The tests above call the gate directly, so they'd all still pass if the call
+# site in handle_websocket vanished. These drive the real dispatch loop.
+
+
+async def _drive(handler, frames):
+    """Feed frames through handle_websocket, then disconnect to end the loop."""
+    from fastapi import WebSocketDisconnect
+
+    handler.websocket.receive_json = AsyncMock(
+        side_effect=[*frames, WebSocketDisconnect(code=1000, reason="done")]
+    )
+    handler.manager.connect = AsyncMock()
+    handler.manager.disconnect = MagicMock()
+    handler.manager.deduplicator.register = MagicMock(return_value=True)
+    handler.request_handler.start_chat_run = AsyncMock()
+    handler.request_handler.cleanup_connection = MagicMock()
+    handler.request_handler._run_manager = MagicMock()
+
+    with patch("app.db.engine", handler._test_engine), \
+         patch("app.permissions.custom_modes", return_value={}):
+        await handler.handle_websocket()
+
+
+@pytest.mark.asyncio
+async def test_dispatch_loop_blocks_an_ungranted_chat_frame(handler):
+    """End-to-end through handle_websocket: the run must never start."""
+    _as_browser_user(handler, role="user")
+    await _drive(handler, [{"message": "hi", "agent_name": "rails_agent", "thread_id": "t1"}])
+    handler.request_handler.start_chat_run.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_dispatch_loop_allows_a_granted_chat_frame(handler):
+    """The mirror: a granted mode still reaches the agent."""
+    _as_browser_user(handler, role="user")
+    await _drive(handler, [{"message": "hi", "agent_name": "rails_plain_chat_mode", "thread_id": "t1"}])
+    handler.request_handler.start_chat_run.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_dispatch_loop_blocks_an_ungranted_approval_frame(handler):
+    _as_browser_user(handler, role="user")
+    handler.request_handler.start_resume_run = AsyncMock()
+    await _drive(handler, [
+        {"type": "approval_response", "thread_id": "t1", "agent_name": "rails_agent"},
+    ])
+    handler.request_handler.start_resume_run.assert_not_awaited()
+
+
+# --- failure mode ----------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_gate_fails_closed_when_the_grant_cannot_be_read(handler):
+    """A DB blip must not become an open door."""
+    _as_browser_user(handler, role="user")
+    with patch("app.permissions.can_run_agent", side_effect=RuntimeError("db down")), \
+         patch("app.permissions.custom_modes", return_value={}):
+        assert await handler._authorize_agent_mode({"agent_name": "rails_agent"}) is False

--- a/app/websocket/web_socket_handler.py
+++ b/app/websocket/web_socket_handler.py
@@ -17,6 +17,29 @@ logger = logging.getLogger(__name__)
 # Authentication configuration
 WS_AUTH_REQUIRED = os.getenv("WS_AUTH_REQUIRED", "false").lower() == "true"
 
+# Frame fields that are credentials, not data. They must never reach the logs:
+# `api_token` is a bearer credential for a specific Rails user (30-min TTL), and
+# this handler logs whole frames. Before this existed, every chat turn from the
+# Rails-embedded UI wrote a live user token into chat_app.log in plaintext.
+_REDACTED_FRAME_KEYS = frozenset({"api_token", "token"})
+
+
+def _redact_frame(frame):
+    """Copy of `frame` with credential fields masked, for logging.
+
+    Returns the frame unchanged if it isn't dict-like — callers log arbitrary
+    payloads and a logging helper must never be the thing that raises.
+    """
+    try:
+        items = frame.items()
+    except AttributeError:
+        return frame
+    return {
+        k: ("<redacted>" if k in _REDACTED_FRAME_KEYS and v else v)
+        for k, v in items
+    }
+
+
 # Pydantic model for chat request
 class ChatMessage(dict):
     message: str
@@ -80,6 +103,57 @@ class WebSocketHandler:
                 "content": "Invalid or expired token"
             }, self.websocket)
             return False
+
+    async def _authorize_agent_mode(self, json_data: dict) -> bool:
+        """Gate any frame naming an ``agent_name`` against the sender's role grant.
+
+        This is THE server-side check for agent modes. The dropdown filtering in
+        chat.html is a convenience — this is the control. Both read the same
+        resolver (app/permissions.py) so they can't drift.
+
+        Frames with no ``agent_name`` (ping, cancel, attach) pass straight through,
+        which is why this sits before the type dispatch: any future frame type
+        that names a mode is covered without touching this function.
+
+        Only browser JWTs carry a role claim, so only they are enforced:
+          * ``rails_auth`` — the llama_bot_rails gem, a trusted internal caller
+            with no role to check (see token_service.verify_rails_token).
+          * unauthenticated — WS_AUTH_REQUIRED already governs that path below.
+        """
+        agent_name = json_data.get("agent_name")
+        if not agent_name:
+            return True
+        if not self.auth_user or self.auth_user.get("type") != "ws_auth":
+            return True
+
+        from sqlmodel import Session
+
+        from app.db import engine
+        from app.permissions import can_run_agent, custom_modes
+
+        role = self.auth_user.get("role")
+        is_admin = bool(self.auth_user.get("is_admin"))
+        try:
+            with Session(engine) as session:
+                permitted = can_run_agent(session, role, is_admin, agent_name, custom_modes())
+        except Exception as e:
+            # Fail CLOSED: if we can't establish the grant, don't run the agent.
+            logger.error(f"Agent authorization failed for '{agent_name}', denying: {e}")
+            permitted = False
+
+        if permitted:
+            return True
+
+        logger.warning(
+            f"Denied agent '{agent_name}' to user '{self.auth_user.get('sub')}' "
+            f"(role={role}, is_admin={is_admin}) from {self.websocket.client}"
+        )
+        if self._is_websocket_open(self.websocket):
+            await self.manager.send_personal_message({
+                "type": "error",
+                "content": "You don't have access to that mode.",
+            }, self.websocket)
+        return False
 
     async def _check_auth_from_message(self, json_data: dict) -> bool:
         """
@@ -186,6 +260,13 @@ class WebSocketHandler:
                             break
                         continue
 
+                    # Authorize the agent mode BEFORE any dispatch. Sits here so
+                    # every frame that names an agent_name is gated by one check
+                    # — chat, approval_response, question_response, and anything
+                    # added later. Frames without an agent_name pass through.
+                    if isinstance(json_data, dict) and not await self._authorize_agent_mode(json_data):
+                        continue
+
                     # Handle cancel (always allowed) — stop the background run(s)
                     # for the target thread (explicit user "stop").
                     if isinstance(json_data, dict) and json_data.get("type") == "cancel":
@@ -276,7 +357,7 @@ class WebSocketHandler:
                     if thread_id:
                         self._attached_threads.add(str(thread_id))
 
-                    logger.info(f"Received message: {message}")
+                    logger.info(f"Received message: {_redact_frame(message)}")
                     # Start the turn as a background run owned by the per-thread
                     # RunManager (decoupled from this socket, which is attached as
                     # a live subscriber). A new message supersedes any in-flight

--- a/docs/dev/error_telemetry.md
+++ b/docs/dev/error_telemetry.md
@@ -116,6 +116,16 @@ Different error classes need different rungs. **Blindly chaining "retry 3× → 
 
 ### Rungs 1–2 live in `wrap_model_call` (`rails_agent/middleware.py:389`)
 
+> **Rung 1 also lives outside the middleware.** Raw StateGraph nodes
+> (`rails_beginner_agent`, `rails_ai_builder_agent`) invoke the model directly and
+> never touch `wrap_model_call`, so before 2026-07-12 they had *no* transient retry
+> at all — a single connection blip killed the turn. They now wrap each direct
+> `.invoke(...)` in `resilience.invoke_with_transient_retry(fn)`, which shares the
+> same classifier + backoff constants as the middleware loop. **Any new raw-node
+> agent must do the same** (or be built via `create_agent`, which gets the
+> middleware for free). Also note `httpx.ReadError`/`WriteError` (mid-stream socket
+> failures, empty `str(e)`) are classified transient as of the same date.
+
 Today (Google rate-limits only):
 
 ```python

--- a/docs/dev/langgraph_registry_layering.md
+++ b/docs/dev/langgraph_registry_layering.md
@@ -17,7 +17,7 @@ The registry mixed **two ownership tiers** in one file:
 
 - **Platform** graphs (`rails_agent`, `llamabot`, …) — owned upstream, must flow to every
   instance on update.
-- **Client** graphs (`leo`, `user_api_agent`, per-client agents) — owned downstream, must
+- **Client** graphs (`leo`, per-client agents) — owned downstream, must
   never be overwritten.
 
 Leonardo's platform sync (`bin/update`) pulls an **allowlist** of paths wholesale from
@@ -98,7 +98,7 @@ Platform base → image; client overlay → mount.
 
 ## Leonardo changes
 
-- `langgraph/langgraph.local.json` — new client overlay (`leo`, `user_api_agent`).
+- `langgraph/langgraph.local.json` — new client overlay (`leo`).
 - `docker-compose.yml` / `docker-compose-dev.yml` — **dropped** the
   `./langgraph/langgraph.json:/app/app/langgraph.json` mount; **added**
   `./langgraph/langgraph.local.json:/app/app/langgraph.local.json`. The

--- a/docs/dev/user_api_mode.md
+++ b/docs/dev/user_api_mode.md
@@ -1,0 +1,110 @@
+# llamapress_api — Rails HTTP scoped to the signed-in user
+
+`app/lib/llamapress_api.py` is a **library** exporting one tool, `rails_api_request`,
+which calls the Rails app's JSON API **as the signed-in user**, bounded by that user's
+own Rails permissions — plus `LlamaPressAPIState`, the state base that carries the token.
+
+It exists because every other Rails-touching tool in this repo (`bash_command`,
+`rails_api_sh`) shells into the Rails container and gets unrestricted ActiveRecord.
+Those bypass Pundit entirely and are only safe because just the `engineer` role is
+granted them. This tool is the one you can hand to an agent used by people you
+*don't* trust with the box.
+
+**LlamaBot deliberately ships no agent and no chat mode around it.** The working
+example lives in the CLIENT repo: Leonardo's `langgraph/agents/leo/nodes.py`,
+registered via the `langgraph.local.json` overlay + `agent_modes.json`. That
+end-to-end path — custom agent downstream, library from the platform — is the
+product story, and `test_llamapress_api.py` pins the boundary so a built-in mode
+doesn't quietly re-grow here.
+
+## How the scoping actually works
+
+Nothing in Python authorizes anything. The guarantee is inherited from Rails:
+
+1. **Rails mints** a signed token per chat turn — `message_verifier(:llamabot_ws)`,
+   payload `{session_id, user_id}`, 30-minute TTL
+   (`llama_bot_rails/app/channels/llama_bot_rails/chat_channel.rb`).
+2. **LlamaBot cannot forge one.** It has no `secret_key_base`. This is the whole
+   ballgame: a compromised agent cannot sign `user_id: <an admin>`. Verified —
+   a forged token returns `401 LLAMA_AUTH_004 "Token signature verification failed"`.
+3. **The gem verifies + signs in** via warden, so `current_user` in the controller is
+   genuinely that person (`lib/llama_bot_rails/agent_auth.rb`).
+4. **`llama_bot_allow :index, :show`** allowlists which actions a token-authed request
+   may reach at all — 403 before any policy runs.
+5. **Pundit** then narrows per-user as always.
+
+Widening reach is a **Rails-side act** (add `llama_bot_allow`), never a Python-side
+one. Don't add an escape hatch to the tool.
+
+## ⚠️ The gotcha: `llama_bot_allow` only gates controllers that opt in
+
+This is the non-obvious part, and it bit during development.
+
+`llama_bot_allow` constrains a controller **only if that controller includes
+`LlamaBotRails::AgentAuth`**. A controller that never opted in is gated by the app's
+*own* authentication — and the Leonardo skeleton ships with it **commented out**:
+
+```ruby
+# rails/app/controllers/application_controller.rb
+# AUTHENTICATION IS DISABLED BY DEFAULT FOR NEW PROJECTS.
+# before_action :authenticate_user_from_token!
+# before_action :authenticate_user!
+```
+
+Measured on the dev box:
+
+| Request | Result |
+|---|---|
+| `GET /api/users` **with no token** | `401` — AgentAuth working |
+| `GET /users` **with no token** | `500` — routed into the controller, **ungated** |
+
+So without a path restriction, the tool would reach every un-gated route and
+the per-account scoping would be a fiction. Hence `ALLOWED_PATH_PREFIX = "/api/"` in
+`app/lib/llamapress_api.py`.
+
+**That prefix is a convention, not a proof.** A controller added under `/api/` that
+forgets `include LlamaBotRails::AgentAuth` is ungated too. The real fix is for the
+app to enable authentication — then `authenticate_user!` (aliased by the gem to
+`authenticate_user_or_agent!`) demands a user *and* enforces the allowlist on every
+controller. **If you enable `user_api` on an instance, enable the app's auth too.**
+
+## Wiring — how a custom agent uses it
+
+Two imports, in the client repo (e.g. Leonardo `langgraph/agents/<name>/nodes.py`,
+mounted into the container at `/app/app/user_agents`):
+
+```python
+from app.lib.llamapress_api import LlamaPressAPIState, rails_api_request
+
+class MyState(LlamaPressAPIState):   # puts api_token on the schema — mandatory
+    ...
+
+tools = [rails_api_request]
+```
+
+Then register the graph in `langgraph.local.json` and the chat-dropdown entry in
+`agent_modes.json`. Leonardo's `leo` agent is the working reference for all of this.
+
+The token rides the WS frame as `api_token` and lands in state automatically —
+`request_handler.get_langgraph_app_and_state` passes every non-routing field through
+(`app/websocket/request_handler.py`). But **only if declared**: LangGraph filters
+state to the schema, so forgetting the `LlamaPressAPIState` subclass silently
+disables the tool (it fails closed with a "setup issue" message). The built-in
+agents' `RailsAgentState` deliberately does NOT declare it — they don't use the
+tool, and declaring it would persist a bearer credential into their checkpoints.
+
+Where the token comes from: the chat frontend fetches it from the gem's
+`GET /llama_bot/agent/token` (Devise session required, CORS-allowlisted for the
+chat UI's origin) and attaches it to every message. Rails-embedded chat
+(`chat_channel`) mints and passes it directly.
+
+**Never give LlamaBot `secret_key_base` to shortcut any of this.** That collapses
+step 2 and the entire guarantee with it.
+
+## Don't
+
+- Don't register a built-in LlamaBot agent or chat mode around this tool — the
+  agent belongs in the client repo. `test_llamapress_api.py` pins this.
+- Don't put it in an agent alongside tools the Rails token doesn't bound.
+  `bash_command` would hand that agent's users the Rails console.
+- Don't log or prompt-inject the token. It's a bearer credential for that user.

--- a/docs/dev_logs/0.6.0
+++ b/docs/dev_logs/0.6.0
@@ -18,3 +18,16 @@
 - [x] Add a "reply" button so the user can quote Leo and respond to a specific, individual message.
 - [x] Add the fix_permissions tool call into the other items.
 - [x] Remove the deprecated search_tool toolcall, in liue of using glob and grep.
+
+0.6.0d:
+- [x] Add better persistence and retries for network errors
+- [x] Add .ico as an allowed upload item in our file upload
+- [x] UI/UX fix new button responsiveness on small horizontal width for chat
+- [x] Add DeepSeek v4 flash endpoints for Fireworks, GMI, and Azure Foundry
+- [x] Add resilient retries in LlamaBot (for websocket disconnections, etc.)
+- [x] Add auth for Rails access reusing existing Gem functionality
+- [x] langgraph.json in LlamaBot becomes source of truth for Platform nodes. (overrides what's in langgraph.json in Leonardo upstream repo)
+- [x] Improve conversation history mechanics & reloads. (offload to s3 option, compact/summarize postgres, keep lighter weight human/ai message pairs for cold restore (>48 hours))
+
+future: 
+- [] We also need like superadmin configuration for seeing: what LLM models are available (and not available) to use, see .env variables, see config variables, see our instance.json, api_tokens, etc.


### PR DESCRIPTION
- [x] Add better persistence and retries for network errors
- [x] Add .ico as an allowed upload item in our file upload
- [x] UI/UX fix new button responsiveness on small horizontal width for chat
- [x] Add DeepSeek v4 flash endpoints for Fireworks, GMI, and Azure Foundry
- [x] Add resilient retries in LlamaBot (for websocket disconnections, etc.)
- [x] Add auth for Rails access reusing existing Gem functionality
- [x] langgraph.json in LlamaBot becomes source of truth for Platform nodes. (overrides what's in langgraph.json in Leonardo upstream repo)
- [x] Improve conversation history mechanics & reloads. (offload to s3 option, compact/summarize postgres, keep lighter weight human/ai message pairs for cold restore (>48 hours))

future:
- [] We also need like superadmin configuration for seeing: what LLM models are available (and not available) to use, see .env variables, see config variables, see our instance.json, api_tokens, etc.