### PR TITLE
0.6.0e:

### DIFF
--- a/app/agents/leonardo/rails_agent/nodes.py
+++ b/app/agents/leonardo/rails_agent/nodes.py
@@ -32,6 +32,7 @@ from app.agents.leonardo.rails_agent.tools import (
     read_brand_guide, write_brand_guide,
     build_use_skill_tool, list_skills, read_skill, write_skill, edit_skill, delete_skill,
     browser_inspect, browser_inspect_enabled,
+    navigate_browser, get_browser_js_logs, execute_browser_js, live_browser_tools_enabled,
 )
 from app.agents.leonardo.rails_agent.prompts import RAILS_AGENT_PROMPT
 from app.agents.leonardo.project_context import build_system_prompt_with_project_context
@@ -193,17 +194,22 @@ default_tools = [
 
 
 def agent_tools():
-    """The Rails agent's toolset, with browser_inspect gated by a site setting.
+    """The Rails agent's toolset, with browser tools gated by site settings.
 
     browser_inspect (headless Chromium) is opt-in: only included when the
-    `enable_browser_inspect` site setting is on. Disabled by default. Read at
-    workflow build time, so flipping the setting takes effect on the next restart.
+    `enable_browser_inspect` site setting is on. The live-browser tools
+    (navigate/logs/execute-js in the user's own tab) are likewise gated by
+    `enable_live_browser_tools`. Both default off and are read at workflow
+    build time, so flipping a setting takes effect on the next restart.
     """
     tools = list(default_tools)
     tools.append(build_use_skill_tool())
     if browser_inspect_enabled():
         tools.append(browser_inspect)
         logger.info("browser_inspect tool enabled via site setting")
+    if live_browser_tools_enabled():
+        tools.extend([navigate_browser, get_browser_js_logs, execute_browser_js])
+        logger.info("live browser tools enabled via site setting")
     return tools
 
 def build_workflow(checkpointer=None, ask_before_edits=False):

--- a/app/agents/leonardo/rails_agent/tool_prompts.py
+++ b/app/agents/leonardo/rails_agent/tool_prompts.py
@@ -493,3 +493,43 @@ This is an important tool you will use frequently to understand and "see" what t
 If the HTML is excessively large, use the max_chars parameter to fetch only as much as you need; if further detail is needed, ask the user for a narrower target (specific element, component, selector).
 In your explanation, refer to the route, controller, and view path to anchor your advice precisely.
 """
+
+NAVIGATE_BROWSER_DESCRIPTION = """Navigate the USER'S live app preview (the Rails iframe in their open chat tab) to a specific path.
+
+Unlike `browser_inspect` (which spins up a fresh headless browser with no session), this drives the user's own browser tab — their login session, cookies, and client-side state. The user SEES the navigation happen.
+
+The tool freezes execution until the user's browser confirms the navigation (or reports a problem). If the user has no chat tab open, it may wait until they return.
+
+Returns JSON: {"ok": true, "command": "navigate", "path": "...", "page_loaded": true|false}. `page_loaded: false` with a note means confirmation timed out — the navigation may still have completed.
+
+USAGE RULES:
+Call at most ONE browser tool (navigate_browser / get_browser_js_logs / execute_browser_js) per turn, and never in parallel with other tool calls.
+Pass a path like "/users" or "/posts/1/edit", not a full URL.
+"""
+
+GET_BROWSER_JS_LOGS_DESCRIPTION = """Fetch the JavaScript console logs captured in the USER'S live app preview (the Rails iframe in their open chat tab).
+
+Captures console.log/warn/error plus uncaught errors and unhandled promise rejections, as they happened in the user's real session — including logs from before you were asked to help. Holds at most the 100 most recent entries, and the buffer is CLEARED when you read it: a second immediate call returns nothing new.
+
+The tool freezes execution until the user's browser responds. If the user has no chat tab open, it may wait until they return.
+
+Returns JSON: {"ok": true, "command": "get_js_logs", "logs": [{"type": "log"|"warn"|"error", "args": ["..."], "timestamp": ...}, ...]}.
+
+USAGE RULES:
+Call at most ONE browser tool per turn, and never in parallel with other tool calls.
+Great for debugging "it's broken in my browser" reports: reproduce (or have the user reproduce), then read the logs.
+"""
+
+EXECUTE_BROWSER_JS_DESCRIPTION = """Execute JavaScript inside the USER'S live app preview (the Rails iframe in their open chat tab) and return the result.
+
+The code runs in the page's global scope with full access to its DOM, variables, and the user's logged-in session — unlike `browser_inspect`, which uses a fresh headless browser. If the code returns a Promise, the resolved value is returned. The result is JSON-serialized (String() fallback for DOM nodes / circular structures) and truncated at 10000 characters.
+
+The tool freezes execution until the user's browser responds. If the user has no chat tab open, it may wait until they return.
+
+Returns JSON: {"ok": true, "command": "execute_js", "result": "..."} on success, or {"ok": false, "command": "execute_js", "error": "<message + stack>"} if the code threw or the browser did not respond.
+
+USAGE RULES:
+Call at most ONE browser tool per turn, and never in parallel with other tool calls.
+Use expressions that produce a value, e.g. `document.title`, `document.querySelectorAll('[data-controller]').length`, or `fetch('/health').then(r => r.status)`.
+Prefer read-only inspection; this runs in the user's real session, so avoid destructive actions unless the user asked for them.
+"""

--- a/app/agents/leonardo/rails_agent/tools.py
+++ b/app/agents/leonardo/rails_agent/tools.py
@@ -1,5 +1,5 @@
 from langchain.tools import tool, ToolRuntime
-from langgraph.types import Command
+from langgraph.types import Command, interrupt
 from langchain_core.messages import ToolMessage
 from tavily import TavilyClient
 from typing import Optional
@@ -37,6 +37,9 @@ from app.agents.leonardo.rails_agent.tool_prompts import (
     HARD_RESTART_RAILS_DESCRIPTION,
     FIX_PERMISSIONS_DESCRIPTION,
     BROWSER_INSPECT_DESCRIPTION,
+    NAVIGATE_BROWSER_DESCRIPTION,
+    GET_BROWSER_JS_LOGS_DESCRIPTION,
+    EXECUTE_BROWSER_JS_DESCRIPTION,
     USE_SKILL_DESCRIPTION_TEMPLATE,
     LIST_SKILLS_DESCRIPTION,
     READ_SKILL_DESCRIPTION,
@@ -2632,3 +2635,67 @@ def browser_inspect(
             "messages": [ToolMessage(content=content, tool_call_id=tool_call_id)]
         }
     )
+
+def live_browser_tools_enabled() -> bool:
+    """Whether the live-browser tools (navigate/logs/execute-js in the user's tab) are enabled.
+
+    Gated by the ``enable_live_browser_tools`` site setting, which defaults to ``"false"``
+    so driving the user's real browser session is opt-in. Read when an agent's tool list
+    is built (workflow compile time), so flipping the setting takes effect on the next
+    workflow rebuild / app restart. Fails closed (returns ``False``) when the auth DB
+    is unavailable.
+    """
+    import logging
+    try:
+        from sqlmodel import Session
+        from app.db import engine
+        from app.routers.api import get_site_setting
+        if engine is None:
+            return False
+        with Session(engine) as session:
+            return get_site_setting(session, "enable_live_browser_tools", "false") == "true"
+    except Exception as e:
+        logging.getLogger(__name__).warning(
+            f"Could not read enable_live_browser_tools setting; tools disabled: {e}"
+        )
+        return False
+
+
+BROWSER_COMMAND_RESULT_MAX_CHARS = 50_000
+
+
+def _browser_command(command: str, args: dict, tool_call_id: str) -> Command:
+    """Round-trip a command to the user's live browser tab via a LangGraph interrupt.
+
+    The interrupt payload is forwarded to the frontend as a ``browser_command`` WS
+    frame; the frontend executes it against the Rails iframe and resumes the graph
+    with a JSON-string result. No side effects may happen before ``interrupt()`` —
+    the tool body is replayed on resume.
+    """
+    raw = interrupt({"type": "browser_command", "command": command, "args": args})
+    content = str(raw)
+    if len(content) > BROWSER_COMMAND_RESULT_MAX_CHARS:
+        content = content[:BROWSER_COMMAND_RESULT_MAX_CHARS] + "...[truncated]"
+    return Command(
+        update={
+            "messages": [ToolMessage(content=content, tool_call_id=tool_call_id)]
+        }
+    )
+
+
+@tool(description=NAVIGATE_BROWSER_DESCRIPTION)
+def navigate_browser(path: str, runtime: ToolRuntime) -> Command:
+    """Navigate the user's live Rails iframe to a path."""
+    return _browser_command("navigate", {"path": path}, runtime.tool_call_id)
+
+
+@tool(description=GET_BROWSER_JS_LOGS_DESCRIPTION)
+def get_browser_js_logs(runtime: ToolRuntime) -> Command:
+    """Fetch (and clear) the JS console logs captured in the user's live Rails iframe."""
+    return _browser_command("get_js_logs", {}, runtime.tool_call_id)
+
+
+@tool(description=EXECUTE_BROWSER_JS_DESCRIPTION)
+def execute_browser_js(code: str, runtime: ToolRuntime) -> Command:
+    """Execute JavaScript in the user's live Rails iframe and return the serialized result."""
+    return _browser_command("execute_js", {"code": code}, runtime.tool_call_id)

--- a/app/frontend/chat.html
+++ b/app/frontend/chat.html
@@ -493,8 +493,12 @@
 
             // Check for available updates
             try {
-                const updateResponse = await fetch('/api/check-updates');
-                if (updateResponse.ok) {
+                // Only engineers/admins can run the update (POST /api/update 403s
+                // otherwise) — don't show anyone else a dead-end affordance.
+                const canUpdate = (window.LLAMABOT_USER_ROLE || 'engineer') === 'engineer'
+                    || window.LLAMABOT_IS_ADMIN === true;
+                const updateResponse = canUpdate ? await fetch('/api/check-updates') : null;
+                if (updateResponse && updateResponse.ok) {
                     const updateData = await updateResponse.json();
                     if (updateData.updates_available) {
                         window.__llamabotUpdateData = updateData;
@@ -554,6 +558,7 @@
             const pill = qs('update-pill');
             let updateInProgress = false;
             let updateComplete = false;
+            let updateFailed = false;
 
             function showState(state) {
                 ['confirm', 'progress', 'complete', 'error'].forEach(s => {
@@ -641,6 +646,21 @@
                 else { setPill('Update may need a refresh', true); }
             }
 
+            // Definite failure (the server ANSWERED with an error). The backend has
+            // already recorded it and told the mothership, and /api/check-updates
+            // stops offering this version pair — so be honest, fail fast, and don't
+            // leave any affordance that would nag or dead-end the user.
+            function onFailure() {
+                updateInProgress = false;
+                updateFailed = true;
+                const title = qs('update-error-title');
+                if (title) title.textContent = "The update didn't complete";
+                const txt = qs('update-error-text');
+                if (txt) txt.textContent = "Something went wrong applying the update — it's been reported automatically so we can fix it. You're still on your current version and your work is safe. We'll offer the next release when it's ready.";
+                if (modalOpen()) { showState('error'); }
+                else { setPill('Update failed — click for details', true); }
+            }
+
             async function startUpdate() {
                 if (updateInProgress) return;
                 updateInProgress = true;
@@ -665,18 +685,32 @@
                 // Fire the update. POST runs sync + image pull synchronously (server is
                 // still alive), THEN schedules a detached recreate and returns — so the
                 // request usually resolves right as the container restarts. A dropped
-                // connection here is expected, not an error.
+                // connection here is expected, not an error — but an ANSWERED request
+                // that says failure is definite, and must fail fast (no 3-minute poll).
                 let pullDone = false;
+                let postResult = null; // {ok, body} if the server answered; null = connection dropped (restart)
                 const postPromise = fetch('/api/update', {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({ llamabot_version: targetLb, llamapress_version: lp.version })
-                }).then(() => { pullDone = true; }).catch(() => { pullDone = true; });
+                }).then(async (r) => {
+                    let body = null;
+                    try { body = await r.json(); } catch (_) {}
+                    postResult = { ok: r.ok, body };
+                    pullDone = true;
+                }).catch(() => { postResult = null; pullDone = true; });
 
                 // Advance optimistic steps while the pull is in flight.
                 await wait(1800);
                 if (!pullDone) { setStep('sync', 'done'); setStep('pull', 'active'); }
                 await postPromise;
+
+                if (postResult && (!postResult.ok || !(postResult.body && postResult.body.success))) {
+                    if (postResult.body && postResult.body.error) console.error('Update failed:', postResult.body.error);
+                    onFailure();
+                    return;
+                }
+
                 setStep('sync', 'done');
                 setStep('pull', 'done');
                 setStep('restart', 'active');
@@ -735,10 +769,14 @@
                     window.location.reload();
                     return;
                 }
-                // Dismiss the timeout notice.
+                // Dismiss the timeout/failure notice. After a definite failure there
+                // is nothing left to offer (the banner is gone and check-updates
+                // stops re-offering the pair), so clean up fully; after a timeout,
+                // keep the pill as a "maybe refresh" reminder.
                 if (e.target.closest('[data-llamabot="update-modal-dismiss-error"]')) {
                     closeModal();
-                    setPill('Update may need a refresh', true);
+                    if (updateFailed) { hidePill(); }
+                    else { setPill('Update may need a refresh', true); }
                     return;
                 }
             });
@@ -929,7 +967,7 @@
             <div class="hidden" data-llamabot="update-modal-error">
                 <div class="update-modal-head">
                     <span class="update-modal-badge warn"><i class="fa-solid fa-triangle-exclamation"></i></span>
-                    <h2>Taking longer than expected</h2>
+                    <h2 data-llamabot="update-error-title">Taking longer than expected</h2>
                 </div>
                 <p class="update-modal-sub" data-llamabot="update-error-text">The update was started but we couldn't confirm it finished. Your work is safe — keep using the app and refresh in a minute.</p>
                 <div class="update-modal-actions">

--- a/app/frontend/chat/index.js
+++ b/app/frontend/chat/index.js
@@ -1733,6 +1733,41 @@ class ChatApp {
   }
 
   /**
+   * Execute JavaScript inside the Rails iframe via postMessage and return
+   * {ok, result, error}. Responses are correlated by a per-call id, so
+   * concurrent calls can't cross-resolve. Never rejects — timeouts and
+   * missing iframes resolve to {ok: false, error}.
+   */
+  executeJsInIframe(code, timeoutMs = 5000) {
+    return new Promise((resolve) => {
+      const iframe = this.elements.liveSiteFrame;
+      if (!iframe || !iframe.contentWindow) {
+        resolve({ ok: false, result: null, error: 'Rails iframe not available' });
+        return;
+      }
+
+      const id = Math.random().toString(36).substring(2, 11);
+
+      const handleMessage = (event) => {
+        if (event.data && event.data.source === 'llamapress'
+            && event.data.type === 'js-execution-result' && event.data.id === id) {
+          window.removeEventListener('message', handleMessage);
+          clearTimeout(timer);
+          resolve({ ok: !!event.data.ok, result: event.data.result, error: event.data.error || null });
+        }
+      };
+
+      window.addEventListener('message', handleMessage);
+      iframe.contentWindow.postMessage({ source: 'leonardo', type: 'execute-js', id, code }, '*');
+
+      const timer = setTimeout(() => {
+        window.removeEventListener('message', handleMessage);
+        resolve({ ok: false, result: null, error: `Timeout: no response from iframe after ${timeoutMs}ms` });
+      }, timeoutMs);
+    });
+  }
+
+  /**
    * Load settings from cookies
    */
   loadSettingsFromCookies() {

--- a/app/frontend/chat/websocket/MessageHandler.js
+++ b/app/frontend/chat/websocket/MessageHandler.js
@@ -179,6 +179,8 @@ export class MessageHandler {
       this.handleSuggestModeSwitch(data);
     } else if (data.type === 'implement_ticket') {
       this.handleImplementTicket(data);
+    } else if (data.type === 'browser_command') {
+      this.handleBrowserCommand(data);
     } else if (data.type === 'delegation_progress') {
       window.chatApp?.handleDelegationProgress(data);
     } else {
@@ -614,6 +616,105 @@ export class MessageHandler {
    */
   _showWaitingForInputBadge() {
     this.messageRenderer?.faviconBadgeManager?.showQuestion();
+  }
+
+  /**
+   * Handle a browser_command frame (agent interrupt executed programmatically
+   * against the Rails iframe — no card is shown; the result auto-resumes the
+   * agent over the existing question_response channel). The agent must never
+   * be left hanging: every path, including exceptions, sends an answer.
+   */
+  async handleBrowserCommand(data) {
+    // One command at a time. Dropping extras is safe: an unanswered interrupt is
+    // re-emitted as a fresh frame after the next resume turn.
+    if (this._browserCommandInFlight) return;
+    this._browserCommandInFlight = true;
+
+    this.finalizeCurrentThinking();
+
+    const command = data.command || '';
+    let result;
+    try {
+      if (command === 'navigate') {
+        const path = String(data.args?.path || '/');
+        this.messageRenderer.addMessage(`Navigating your preview to ${path}…`, 'system_message', null);
+        if (!this.iframeManager?.liveSiteFrame) {
+          result = { ok: false, command, error: 'Rails iframe not available' };
+        } else {
+          this.iframeManager.navigateToPath(path);
+          const pageLoaded = await this._waitForRailsPageLoaded(7000);
+          result = { ok: true, command, path, page_loaded: pageLoaded };
+          if (!pageLoaded) {
+            result.note = 'timed out waiting for page-loaded after 7000ms; navigation may still have completed';
+          }
+        }
+      } else if (command === 'get_js_logs') {
+        const logs = await window.chatApp.getJsConsoleLogs();
+        result = { ok: true, command, logs };
+        if (!logs.length) result.note = 'no logs captured, or the iframe did not respond';
+      } else if (command === 'execute_js') {
+        const res = await window.chatApp.executeJsInIframe(String(data.args?.code || ''), 5000);
+        result = { ok: res.ok, command, result: res.result, error: res.error };
+      } else {
+        result = { ok: false, command, error: `Unknown browser command: ${command}` };
+      }
+    } catch (e) {
+      result = { ok: false, command, error: String(e) };
+    } finally {
+      this._browserCommandInFlight = false;
+    }
+
+    this._answerBrowserCommand(result, data.thread_id, data.agent_name);
+  }
+
+  /**
+   * Resume the agent with a browser command result, reusing the question_response
+   * channel (the backend's browser_command interrupt returns this JSON string).
+   */
+  _answerBrowserCommand(resultObj, threadId, agentName) {
+    let answer = JSON.stringify(resultObj);
+    if (answer.length > 50000) {
+      answer = JSON.stringify({
+        ok: resultObj.ok,
+        command: resultObj.command,
+        truncated: true,
+        preview: answer.slice(0, 45000),
+      });
+    }
+
+    if (window.chatApp?.webSocketManager) {
+      window.chatApp.webSocketManager.send({
+        type: 'question_response',
+        answer,
+        thread_id: threadId,
+        agent_name: agentName,
+      });
+    }
+
+    window.chatApp?.setAgentRunning(true);
+    window.chatApp?.showThinkingIndicator();
+  }
+
+  /**
+   * Resolve true when the Rails iframe reports a Turbo page load (the
+   * 'llamapress-navigation' events navigation_tracking.js already posts),
+   * false after timeoutMs.
+   */
+  _waitForRailsPageLoaded(timeoutMs) {
+    return new Promise((resolve) => {
+      const handleMessage = (event) => {
+        if (event.data && event.data.source === 'llamapress-navigation' && event.data.type === 'page-loaded') {
+          window.removeEventListener('message', handleMessage);
+          clearTimeout(timer);
+          resolve(true);
+        }
+      };
+      window.addEventListener('message', handleMessage);
+      const timer = setTimeout(() => {
+        window.removeEventListener('message', handleMessage);
+        resolve(false);
+      }, timeoutMs);
+    });
   }
 
   handleQuestionRequest(data) {

--- a/app/routers/api.py
+++ b/app/routers/api.py
@@ -4,6 +4,7 @@ import json
 import logging
 import re
 import os
+import subprocess
 
 from typing import Optional
 from fastapi import APIRouter, Request, Depends, HTTPException, Query, UploadFile, File
@@ -225,8 +226,68 @@ async def api_get_version_notes():
     return {"version": version, "notes": notes}
 
 
+# A per-version-pair "this update already failed here" marker, stored in
+# SiteSetting. Keeps the banner from nagging (and re-burning a dead wait) after
+# a failed attempt; the next release is a new pair, so it un-sticks itself.
+# Deliberately NOT in VALID_SITE_SETTINGS — private, like session_secret.
+
+def _update_failure_key(lb_version: str, lp_version: str) -> Optional[str]:
+    key = f"update_failed:{lb_version}:{lp_version}"
+    return key if len(key) <= 100 else None  # SiteSetting.key max_length
+
+
+def _get_update_failure(session: Session, lb_version: str, lp_version: str) -> Optional[str]:
+    key = _update_failure_key(lb_version, lp_version)
+    if key is None:
+        return None
+    return get_site_setting(session, key, default="") or None
+
+
+def _record_update_failure(session: Session, lb_version: str, lp_version: str, error_tail: str) -> None:
+    """Best-effort: a down auth DB must never mask the honest failure response."""
+    try:
+        from datetime import datetime, timezone
+        from app.models import SiteSetting
+
+        key = _update_failure_key(lb_version, lp_version)
+        if key is None:
+            return
+        value = json.dumps({
+            "at": datetime.now(timezone.utc).isoformat(),
+            "error": error_tail[:900],  # SiteSetting.value max_length=1000
+        })
+        setting = session.get(SiteSetting, key)
+        if setting:
+            setting.value = value
+            setting.updated_at = datetime.now(timezone.utc)
+        else:
+            session.add(SiteSetting(key=key, value=value))
+        session.commit()
+    except Exception as e:
+        logger.warning(f"Could not record update failure marker: {e}")
+
+
+async def _report_update_failure(lb_version: str, lp_version: str,
+                                 error_class: str, error_tail: str, detail: str) -> None:
+    """Fire-and-forget mothership telemetry; never interferes with the response."""
+    try:
+        from app.services.mothership_client import MothershipClient
+
+        await MothershipClient().report_error(
+            thread_id=None,
+            error_class=error_class,
+            error_message=error_tail,
+            traceback_str=detail,
+            fingerprint=f"update_failed:{lb_version}:{lp_version}",
+            llamabot_version=get_container_version(),
+            recovered=False,
+        )
+    except Exception as e:
+        logger.warning(f"Could not report update failure to mothership: {e}")
+
+
 @router.get("/api/check-updates", response_class=JSONResponse)
-async def api_check_updates():
+async def api_check_updates(session: Session = Depends(get_db_session)):
     """Check mothership for available updates to llamabot and llamapress."""
     from app.services.mothership_client import MothershipClient
     mothership = MothershipClient()
@@ -239,6 +300,15 @@ async def api_check_updates():
     result = await mothership.check_updates(llamabot_version, llamapress_version)
     if result is None:
         return {"updates_available": False, "reason": "check_failed"}
+
+    # Don't re-offer a pair that already failed on this instance — the user
+    # clicked, it broke, and mothership was told. Fails open on DB trouble.
+    if result.get("updates_available"):
+        latest = result.get("latest_versions") or {}
+        target_lb = (latest.get("llamabot") or {}).get("version") or llamabot_version
+        target_lp = (latest.get("llamapress") or {}).get("version") or llamapress_version
+        if _get_update_failure(session, target_lb, target_lp):
+            return {"updates_available": False, "reason": "previous_update_failed"}
     return result
 
 
@@ -251,25 +321,56 @@ class UpdateRequest(BaseModel):
 async def api_perform_update(
     request: UpdateRequest,
     current_user: User = Depends(engineer_or_admin_required),
+    session: Session = Depends(get_db_session),
 ):
-    """Update docker-compose.yml image tags, pull new images, and restart."""
+    """Update docker-compose.yml image tags, pull new images, and restart.
+
+    Failures are reported honestly: bin/update exiting non-zero, a timeout, or
+    a broken host bridge all return success=false with an error tail, persist a
+    per-pair failure marker (so /api/check-updates stops offering that pair),
+    and tell the mothership. A container killed mid-restart produces no
+    response at all — the frontend treats a dropped connection as the restart,
+    so nothing catchable here is a success.
+    """
     version_pattern = re.compile(r'^[0-9a-zA-Z.\-]+$')
     if not version_pattern.match(request.llamabot_version) or not version_pattern.match(request.llamapress_version):
         raise HTTPException(status_code=400, detail="Invalid version format")
 
     from app.routers.slash_commands import execute_command
     command = f"bash bin/update {request.llamabot_version} {request.llamapress_version}"
+
+    async def _fail(error_class: str, error_tail: str, detail: str, return_code: int):
+        _record_update_failure(session, request.llamabot_version, request.llamapress_version, error_tail)
+        await _report_update_failure(request.llamabot_version, request.llamapress_version,
+                                     error_class, error_tail, detail)
+        return {
+            "success": False,
+            "stdout": "",
+            "stderr": "",
+            "return_code": return_code,
+            "error": error_tail,
+        }
+
     try:
         result = execute_command(command, timeout=300)
-        return {
-            "success": result.returncode == 0,
-            "stdout": result.stdout.strip() if result.stdout else "",
-            "stderr": result.stderr.strip() if result.stderr else "",
-            "return_code": result.returncode,
-        }
+    except subprocess.TimeoutExpired as e:
+        return await _fail("UpdateTimeout", f"Update timed out after {e.timeout}s", str(e), -1)
     except Exception as e:
-        # Container may be killed mid-response during restart
-        return {"success": True, "stdout": "Update initiated, server restarting...", "stderr": "", "return_code": 0}
+        return await _fail(type(e).__name__, str(e), str(e), -1)
+
+    if result.returncode != 0:
+        output = (result.stderr or "").strip() or (result.stdout or "").strip() \
+            or f"bin/update exited {result.returncode}"
+        return await _fail("UpdateFailed", output[-500:],
+                           f"stdout:\n{result.stdout}\n\nstderr:\n{result.stderr}",
+                           result.returncode)
+
+    return {
+        "success": True,
+        "stdout": result.stdout.strip() if result.stdout else "",
+        "stderr": result.stderr.strip() if result.stderr else "",
+        "return_code": 0,
+    }
 
 
 # ============== WebSocket Authentication API ==============
@@ -1173,7 +1274,7 @@ async def set_visible_agents(
 
 # ============== Site Settings API ==============
 
-VALID_SITE_SETTINGS = {"show_token_wheel", "proactive_build_after_ticket", "enable_browser_inspect"}
+VALID_SITE_SETTINGS = {"show_token_wheel", "proactive_build_after_ticket", "enable_browser_inspect", "enable_live_browser_tools"}
 
 
 # ============== Role → agent-mode permissions (admin only) ==============

--- a/app/routers/ui.py
+++ b/app/routers/ui.py
@@ -209,6 +209,7 @@ async def root(request: Request):
         llamapress_email = _read_leonardo_value("LLAMAPRESS_EMAIL.txt")
         config_script = f'''<script>
 window.LLAMABOT_USER_ROLE = "{getattr(user, "role", "engineer")}";
+window.LLAMABOT_IS_ADMIN = {"true" if getattr(user, "is_admin", False) else "false"};
 window.LLAMABOT_VISIBLE_AGENTS = {json.dumps(visible_agents)};
 window.LLAMABOT_SHOW_TOKEN_WHEEL = {"true" if show_token_wheel else "false"};
 window.LLAMABOT_POSTHOG_KEY = {json.dumps(posthog_key) if posthog_key else "null"};
@@ -1428,6 +1429,7 @@ async def settings_page(
     show_token_wheel = get_site_setting(session, "show_token_wheel", "false") == "true"
     proactive_build = get_site_setting(session, "proactive_build_after_ticket", "false") == "true"
     browser_inspect_on = get_site_setting(session, "enable_browser_inspect", "false") == "true"
+    live_browser_tools_on = get_site_setting(session, "enable_live_browser_tools", "false") == "true"
     is_engineer_or_admin = current_user.role == "engineer" or current_user.is_admin
 
     html = f"""
@@ -1701,6 +1703,19 @@ async def settings_page(
             <div style="padding: 4px 0 0 36px; font-size: 0.75rem; color: rgba(255,255,255,0.35);">
                 Lets the agent inspect live pages with a headless browser (console logs, DOM, screenshots). Takes effect after the next restart.
             </div>
+            <div class="menu-item" style="cursor: default;">
+                <i class="fa-solid fa-window-maximize"></i>
+                <span>Live Browser Tools</span>
+                <label style="position: relative; display: inline-block; width: 44px; height: 24px;">
+                    <input type="checkbox" id="liveBrowserToolsToggle" style="opacity: 0; width: 0; height: 0;"
+                        onchange="toggleLiveBrowserTools(this.checked)">
+                    <span style="position: absolute; cursor: pointer; top: 0; left: 0; right: 0; bottom: 0; background-color: #555; border-radius: 24px; transition: 0.3s;"></span>
+                    <span id="liveBrowserToolsSlider" style="position: absolute; height: 18px; width: 18px; left: 3px; bottom: 3px; background-color: white; border-radius: 50%; transition: 0.3s;"></span>
+                </label>
+            </div>
+            <div style="padding: 4px 0 0 36px; font-size: 0.75rem; color: rgba(255,255,255,0.35);">
+                Lets the agent navigate the user's live app preview, read its console logs, and run JavaScript in it. Takes effect after the next restart.
+            </div>
         </div>'''}
 
         <div class="card">
@@ -1850,6 +1865,38 @@ async def settings_page(
 
         function updateBrowserInspectSlider(enabled) {{
             const slider = document.getElementById('browserInspectSlider');
+            if (!slider) return;
+            const track = slider.previousElementSibling;
+            if (enabled) {{
+                track.style.backgroundColor = '#8b5cf6';
+                slider.style.transform = 'translateX(20px)';
+            }} else {{
+                track.style.backgroundColor = '#555';
+                slider.style.transform = 'translateX(0)';
+            }}
+        }}
+
+        // Live browser tools toggle
+        (function() {{
+            const toggle = document.getElementById('liveBrowserToolsToggle');
+            const slider = document.getElementById('liveBrowserToolsSlider');
+            if (!toggle || !slider) return;
+            const isEnabled = {'true' if live_browser_tools_on else 'false'};
+            toggle.checked = isEnabled;
+            updateLiveBrowserToolsSlider(isEnabled);
+        }})();
+
+        function toggleLiveBrowserTools(enabled) {{
+            updateLiveBrowserToolsSlider(enabled);
+            fetch('/api/site-settings/enable_live_browser_tools', {{
+                method: 'PUT',
+                headers: {{ 'Content-Type': 'application/json' }},
+                body: JSON.stringify({{ value: enabled ? 'true' : 'false' }})
+            }});
+        }}
+
+        function updateLiveBrowserToolsSlider(enabled) {{
+            const slider = document.getElementById('liveBrowserToolsSlider');
             if (!slider) return;
             const track = slider.previousElementSibling;
             if (enabled) {{

--- a/app/tests/test_live_browser_tools.py
+++ b/app/tests/test_live_browser_tools.py
@@ -1,0 +1,174 @@
+"""Tests for the live-browser tools (navigate/logs/execute-js in the user's tab).
+
+Covers:
+- the `enable_live_browser_tools` site-setting gate (fail-closed, default off),
+- inclusion/exclusion in rails_agent's toolset,
+- the browser_command interrupt payload + ToolMessage wiring,
+- the `_check_and_send_interrupts` browser_command -> WS frame mapping,
+- the regression guard that browser_command is NOT a question-type interrupt
+  (user chat text must never resume it as a fake browser result).
+
+Deliberately does NOT call build_workflow (known CI event-loop issue).
+"""
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from app.agents.leonardo.rails_agent.tools import (
+    live_browser_tools_enabled,
+    navigate_browser,
+    get_browser_js_logs,
+    execute_browser_js,
+    _browser_command,
+    BROWSER_COMMAND_RESULT_MAX_CHARS,
+)
+
+LIVE_BROWSER_TOOL_NAMES = {"navigate_browser", "get_browser_js_logs", "execute_browser_js"}
+
+
+def _tool_names(tools):
+    return {getattr(t, "name", None) for t in tools}
+
+
+class TestLiveBrowserToolsEnabledHelper:
+    def test_disabled_when_auth_db_unavailable(self):
+        # engine is None (no AUTH_DB_URI) -> fail closed, tools stay disabled.
+        with patch("app.db.engine", None):
+            assert live_browser_tools_enabled() is False
+
+    def test_disabled_by_default_setting(self):
+        with patch("app.db.engine", object()), \
+             patch("sqlmodel.Session"), \
+             patch("app.routers.api.get_site_setting", return_value="false") as gss:
+            assert live_browser_tools_enabled() is False
+            # Reads the right key with a safe default.
+            assert gss.call_args.args[1] == "enable_live_browser_tools"
+            assert gss.call_args.args[2] == "false"
+
+    def test_enabled_when_setting_true(self):
+        with patch("app.db.engine", object()), \
+             patch("sqlmodel.Session"), \
+             patch("app.routers.api.get_site_setting", return_value="true"):
+            assert live_browser_tools_enabled() is True
+
+
+class TestRailsAgentGate:
+    def _tools(self, enabled):
+        from app.agents.leonardo.rails_agent import nodes
+        with patch.object(nodes, "live_browser_tools_enabled", return_value=enabled), \
+             patch.object(nodes, "browser_inspect_enabled", return_value=False):
+            return _tool_names(nodes.agent_tools())
+
+    def test_live_browser_tools_absent_by_default(self):
+        assert not (LIVE_BROWSER_TOOL_NAMES & self._tools(enabled=False))
+
+    def test_live_browser_tools_present_when_enabled(self):
+        assert LIVE_BROWSER_TOOL_NAMES <= self._tools(enabled=True)
+
+
+class TestBrowserCommandInterrupt:
+    def _invoke(self, tool_fn, expected_payload, **kwargs):
+        """Invoke a tool function with a patched interrupt(); return (payload, Command)."""
+        captured = {}
+
+        def fake_interrupt(payload):
+            captured["payload"] = payload
+            return '{"ok": true}'
+
+        runtime = MagicMock(tool_call_id="tc1")
+        with patch("app.agents.leonardo.rails_agent.tools.interrupt", side_effect=fake_interrupt):
+            cmd = tool_fn.func(runtime=runtime, **kwargs)
+
+        assert captured["payload"] == expected_payload
+        return cmd
+
+    def _tool_message(self, cmd):
+        messages = cmd.update["messages"]
+        assert len(messages) == 1
+        return messages[0]
+
+    def test_navigate_browser_payload_and_tool_message(self):
+        cmd = self._invoke(
+            navigate_browser,
+            {"type": "browser_command", "command": "navigate", "args": {"path": "/users"}},
+            path="/users",
+        )
+        msg = self._tool_message(cmd)
+        assert msg.tool_call_id == "tc1"
+        assert msg.content == '{"ok": true}'
+
+    def test_get_browser_js_logs_payload(self):
+        cmd = self._invoke(
+            get_browser_js_logs,
+            {"type": "browser_command", "command": "get_js_logs", "args": {}},
+        )
+        assert self._tool_message(cmd).tool_call_id == "tc1"
+
+    def test_execute_browser_js_payload(self):
+        cmd = self._invoke(
+            execute_browser_js,
+            {"type": "browser_command", "command": "execute_js", "args": {"code": "1+1"}},
+            code="1+1",
+        )
+        assert self._tool_message(cmd).tool_call_id == "tc1"
+
+    def test_result_truncated_at_cap(self):
+        huge = "x" * (BROWSER_COMMAND_RESULT_MAX_CHARS + 1000)
+        with patch("app.agents.leonardo.rails_agent.tools.interrupt", return_value=huge):
+            cmd = _browser_command("execute_js", {"code": "big()"}, "tc2")
+        content = cmd.update["messages"][0].content
+        assert content.endswith("...[truncated]")
+        assert len(content) == BROWSER_COMMAND_RESULT_MAX_CHARS + len("...[truncated]")
+
+
+class TestCheckAndSendInterruptsMapping:
+    def _run_check(self, interrupt_value):
+        """Drive _check_and_send_interrupts with a stubbed state snapshot; return sent frames."""
+        from app.websocket.request_handler import RequestHandler
+
+        handler = RequestHandler.__new__(RequestHandler)  # skip __init__ plumbing
+        handler._is_websocket_open = MagicMock(return_value=True)
+
+        intr = MagicMock()
+        intr.value = interrupt_value
+        task = MagicMock()
+        task.interrupts = [intr]
+        snapshot = MagicMock()
+        snapshot.tasks = [task]
+
+        app = MagicMock()
+        app.aget_state = AsyncMock(return_value=snapshot)
+
+        websocket = MagicMock()
+        websocket.send_json = AsyncMock()
+
+        message_data = {"thread_id": "t-1", "agent_name": "rails_agent"}
+        found = asyncio.run(
+            handler._check_and_send_interrupts(app, {"configurable": {}}, message_data, websocket)
+        )
+        return found, [c.args[0] for c in websocket.send_json.call_args_list]
+
+    def test_browser_command_frame_shape(self):
+        found, frames = self._run_check(
+            {"type": "browser_command", "command": "execute_js", "args": {"code": "1+1"}}
+        )
+        assert found is True
+        assert frames == [{
+            "type": "browser_command",
+            "command": "execute_js",
+            "args": {"code": "1+1"},
+            "thread_id": "t-1",
+            "agent_name": "rails_agent",
+        }]
+
+    def test_browser_command_missing_args_defaults(self):
+        found, frames = self._run_check({"type": "browser_command", "command": "get_js_logs"})
+        assert found is True
+        assert frames[0]["args"] == {}
+
+
+def test_browser_command_is_not_a_question_interrupt_type():
+    # Regression guard: if browser_command were listed here, a user's chat message
+    # typed while a browser command is pending would be fed into the tool as a
+    # fabricated browser result (see _pending_question_interrupt).
+    from app.websocket.request_handler import RequestHandler
+    assert "browser_command" not in RequestHandler._QUESTION_INTERRUPT_TYPES

--- a/app/tests/test_update_flow.py
+++ b/app/tests/test_update_flow.py
@@ -1,0 +1,260 @@
+"""Self-update flow: POST /api/update must report failures honestly, remember
+them, and tell the mothership; GET /api/check-updates must stop offering a
+version pair that already failed here (the banner otherwise nags forever and
+every click costs the user a 3-minute dead wait).
+
+Run with: pytest app/tests/test_update_flow.py -v
+"""
+import json
+import subprocess
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy.pool import StaticPool
+from sqlmodel import Session, SQLModel, create_engine
+
+from app.dependencies import get_current_user, get_db_session
+from app.models import SiteSetting, User
+
+
+ENGINEER = User(id=1, username="engineer", password_hash="x", role="engineer",
+                is_admin=False, is_active=True)
+ADMIN = User(id=2, username="admin", password_hash="x", role="user",
+             is_admin=True, is_active=True)
+REGULAR = User(id=3, username="viewer", password_hash="x", role="user",
+               is_admin=False, is_active=True)
+
+PAIR = {"llamabot_version": "0.5.0", "llamapress_version": "1.2.0"}
+MARKER_KEY = "update_failed:0.5.0:1.2.0"
+
+UPDATE_OFFER = {
+    "updates_available": True,
+    "latest_versions": {
+        "llamabot": {"version": "0.5.0", "notes": ["stuff"]},
+        "llamapress": {"version": "1.2.0", "notes": []},
+    },
+}
+
+
+def _completed(returncode=0, stdout="", stderr=""):
+    return SimpleNamespace(returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+@pytest.fixture
+def engine():
+    # StaticPool + check_same_thread: TestClient runs the app on another thread,
+    # and a default in-memory SQLite engine would hand it a fresh, empty DB.
+    eng = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    SQLModel.metadata.create_all(eng)
+    return eng
+
+
+@pytest.fixture
+def client(engine):
+    from app.routers.api import router
+
+    app = FastAPI()
+    app.include_router(router)
+
+    def _session():
+        with Session(engine) as s:
+            yield s
+
+    app.dependency_overrides[get_db_session] = _session
+    app.dependency_overrides[get_current_user] = lambda: ENGINEER
+
+    c = TestClient(app)
+    c._app = app
+    c._engine = engine
+    return c
+
+
+@pytest.fixture
+def mothership():
+    instance = MagicMock()
+    instance.enabled = True
+    instance.check_updates = AsyncMock(return_value=UPDATE_OFFER)
+    instance.report_error = AsyncMock(return_value=None)
+    # Both endpoints lazy-import MothershipClient inside the function body, so
+    # patching the source module attribute intercepts them.
+    with patch("app.services.mothership_client.MothershipClient", return_value=instance):
+        yield instance
+
+
+@pytest.fixture
+def versions():
+    with patch("app.routers.api.get_container_version", return_value="0.4.9"), \
+         patch("app.routers.api.get_llamapress_version", return_value="1.1.0"):
+        yield
+
+
+def _get_marker(engine, key=MARKER_KEY):
+    with Session(engine) as s:
+        return s.get(SiteSetting, key)
+
+
+# =========================================================================
+# POST /api/update — honest failure reporting
+# =========================================================================
+
+class TestPerformUpdateHonesty:
+
+    def test_update_timeout_is_reported_as_failure(self, client, mothership, versions):
+        """The headline bug: a 300s subprocess timeout used to return success:true."""
+        with patch("app.routers.slash_commands.execute_command",
+                   side_effect=subprocess.TimeoutExpired(cmd="bin/update", timeout=300)):
+            r = client.post("/api/update", json=PAIR)
+        assert r.status_code == 200
+        body = r.json()
+        assert body["success"] is False
+        assert body.get("error")
+
+    def test_update_oserror_is_reported_as_failure(self, client, mothership, versions):
+        with patch("app.routers.slash_commands.execute_command",
+                   side_effect=FileNotFoundError("nsenter: not found")):
+            r = client.post("/api/update", json=PAIR)
+        body = r.json()
+        assert body["success"] is False
+        assert "nsenter" in body.get("error", "")
+
+    def test_update_nonzero_exit_includes_error_tail(self, client, mothership, versions):
+        with patch("app.routers.slash_commands.execute_command",
+                   return_value=_completed(1, stderr="fatal: could not pull image")):
+            r = client.post("/api/update", json=PAIR)
+        body = r.json()
+        assert body["success"] is False
+        assert "could not pull" in body.get("error", "")
+
+    def test_update_failure_persists_marker(self, client, mothership, versions):
+        with patch("app.routers.slash_commands.execute_command",
+                   return_value=_completed(1, stderr="fatal: could not pull image")):
+            client.post("/api/update", json=PAIR)
+        row = _get_marker(client._engine)
+        assert row is not None
+        value = json.loads(row.value)
+        assert "could not pull" in value["error"]
+        assert value["at"]
+
+    def test_update_failure_reports_to_mothership(self, client, mothership, versions):
+        with patch("app.routers.slash_commands.execute_command",
+                   return_value=_completed(1, stderr="boom")):
+            client.post("/api/update", json=PAIR)
+        assert mothership.report_error.await_count == 1
+        kwargs = mothership.report_error.await_args.kwargs
+        assert kwargs["fingerprint"] == MARKER_KEY
+        assert kwargs["recovered"] is False
+        assert kwargs["error_class"]
+        assert kwargs["error_message"]
+
+    def test_update_success_writes_no_marker_no_telemetry(self, client, mothership, versions):
+        with patch("app.routers.slash_commands.execute_command",
+                   return_value=_completed(0, stdout="Update initiated")):
+            r = client.post("/api/update", json=PAIR)
+        assert r.json()["success"] is True
+        assert _get_marker(client._engine) is None
+        mothership.report_error.assert_not_awaited()
+
+    def test_update_marker_write_is_best_effort(self, client, mothership, versions):
+        """A down auth DB must not turn an honest failure report into a 500."""
+        bad_session = MagicMock()
+        bad_session.get.side_effect = RuntimeError("db down")
+        client._app.dependency_overrides[get_db_session] = lambda: bad_session
+        with patch("app.routers.slash_commands.execute_command",
+                   return_value=_completed(1, stderr="boom")):
+            r = client.post("/api/update", json=PAIR)
+        assert r.status_code == 200
+        body = r.json()
+        assert body["success"] is False
+        assert body.get("error")
+
+    def test_update_forbidden_for_user_role(self, client, mothership, versions):
+        client._app.dependency_overrides[get_current_user] = lambda: REGULAR
+        with patch("app.routers.slash_commands.execute_command") as mock_exec:
+            r = client.post("/api/update", json=PAIR)
+        assert r.status_code == 403
+        mock_exec.assert_not_called()
+
+    def test_update_failure_key_too_long_skips_marker(self, client, mothership, versions):
+        long_pair = {"llamabot_version": "a" * 60, "llamapress_version": "b" * 60}
+        with patch("app.routers.slash_commands.execute_command",
+                   return_value=_completed(1, stderr="boom")):
+            r = client.post("/api/update", json=long_pair)
+        assert r.json()["success"] is False
+        with Session(client._engine) as s:
+            from sqlmodel import select
+            rows = s.exec(select(SiteSetting)).all()
+        assert rows == []
+
+
+# =========================================================================
+# GET /api/check-updates — suppression after a failed attempt
+# =========================================================================
+
+class TestCheckUpdatesSuppression:
+
+    def _seed_marker(self, engine, key=MARKER_KEY):
+        with Session(engine) as s:
+            s.add(SiteSetting(key=key, value=json.dumps({"at": "2026-07-20T00:00:00Z",
+                                                         "error": "boom"})))
+            s.commit()
+
+    def test_check_updates_suppressed_after_failed_pair(self, client, mothership, versions):
+        self._seed_marker(client._engine)
+        r = client.get("/api/check-updates")
+        assert r.status_code == 200
+        assert r.json() == {"updates_available": False,
+                            "reason": "previous_update_failed"}
+
+    def test_check_updates_new_release_unsticks(self, client, mothership, versions):
+        """The marker is per version pair — the NEXT release must re-offer."""
+        self._seed_marker(client._engine)
+        newer = {
+            "updates_available": True,
+            "latest_versions": {
+                "llamabot": {"version": "0.5.1", "notes": []},
+                "llamapress": {"version": "1.2.0", "notes": []},
+            },
+        }
+        mothership.check_updates = AsyncMock(return_value=newer)
+        r = client.get("/api/check-updates")
+        assert r.json()["updates_available"] is True
+        assert r.json()["latest_versions"]["llamabot"]["version"] == "0.5.1"
+
+    def test_check_updates_no_marker_passes_through(self, client, mothership, versions):
+        r = client.get("/api/check-updates")
+        assert r.json() == UPDATE_OFFER
+
+    def test_check_updates_not_configured_still_works(self, client, mothership, versions):
+        mothership.enabled = False
+        r = client.get("/api/check-updates")
+        assert r.json() == {"updates_available": False,
+                            "reason": "mothership_not_configured"}
+
+    def test_check_updates_check_failed_still_works(self, client, mothership, versions):
+        mothership.check_updates = AsyncMock(return_value=None)
+        r = client.get("/api/check-updates")
+        assert r.json() == {"updates_available": False, "reason": "check_failed"}
+
+    def test_check_updates_db_down_fails_open(self, client, mothership, versions):
+        """Suppression must never hide a real update because the DB hiccupped."""
+        bad_session = MagicMock()
+        bad_session.get.side_effect = RuntimeError("db down")
+        client._app.dependency_overrides[get_db_session] = lambda: bad_session
+        r = client.get("/api/check-updates")
+        assert r.json()["updates_available"] is True
+
+    def test_update_failure_then_check_updates_roundtrip(self, client, mothership, versions):
+        """Writer and reader must agree on the key format — end to end."""
+        with patch("app.routers.slash_commands.execute_command",
+                   return_value=_completed(1, stderr="fatal: could not pull image")):
+            client.post("/api/update", json=PAIR)
+        r = client.get("/api/check-updates")
+        assert r.json() == {"updates_available": False,
+                            "reason": "previous_update_failed"}

--- a/app/websocket/request_handler.py
+++ b/app/websocket/request_handler.py
@@ -203,6 +203,11 @@ class RequestHandler:
     # text answer (which the tool wraps into a ToolMessage). A normal chat message sent
     # while one of these is pending should resume the interrupt with that text — NOT be
     # appended as a new HumanMessage ahead of the unanswered tool call.
+    #
+    # "browser_command" is deliberately NOT listed: its interrupt is answered by the
+    # frontend programmatically, so user chat text must never be fed in as a fake
+    # browser result. A user message while one is pending instead goes through
+    # _repair_thread_state_if_needed, which cancels the dangling tool call cleanly.
     _QUESTION_INTERRUPT_TYPES = ("user_question", "uiux_question")
 
     async def _pending_question_interrupt(self, app, config):
@@ -1079,6 +1084,19 @@ class RequestHandler:
                             "agent_name": message_data.get('agent_name'),
                         })
                         logger.info("Graph interrupted for plan mode UI/UX question")
+
+                    # Live-browser command interrupt — executed programmatically by the
+                    # frontend against the Rails iframe; it auto-replies over the
+                    # question_response channel (no card is shown to the user).
+                    elif isinstance(interrupt_value, dict) and interrupt_value.get("type") == "browser_command":
+                        await websocket.send_json({
+                            "type": "browser_command",
+                            "command": interrupt_value.get("command", ""),
+                            "args": interrupt_value.get("args", {}) or {},
+                            "thread_id": message_data.get('thread_id'),
+                            "agent_name": message_data.get('agent_name'),
+                        })
+                        logger.info(f"Graph interrupted for browser command: {interrupt_value.get('command')}")
 
                     # Suggest plan mode interrupt
                     elif isinstance(interrupt_value, dict) and interrupt_value.get("type") == "suggest_mode_switch":

--- a/docs/dev_logs/0.6.0
+++ b/docs/dev_logs/0.6.0
@@ -29,5 +29,10 @@
 - [x] langgraph.json in LlamaBot becomes source of truth for Platform nodes. (overrides what's in langgraph.json in Leonardo upstream repo)
 - [x] Improve conversation history mechanics & reloads. (offload to s3 option, compact/summarize postgres, keep lighter weight human/ai message pairs for cold restore (>48 hours))
 
-future: 
+0.6.0e:
+- [x] Add advanced JavaScript tool calling for Leo to execute tool calls JavaScript on the browser (disabled by default).
+- [x] Improve the update banner experience: honest fail-fast errors (no more 3-minute dead wait), per-version failure marker suppresses the banner after a failed attempt (auto-unsticks on next release), failures reported to mothership via report_error, update UI hidden from roles that can't update.
+
+future (backlog):
 - [] We also need like superadmin configuration for seeing: what LLM models are available (and not available) to use, see .env variables, see config variables, see our instance.json, api_tokens, etc.
+- [] Improving message conversation history user experience.


### PR DESCRIPTION
- [x] Add advanced JavaScript tool calling for Leo to execute tool calls JavaScript on the browser (disabled by default).
- [x] Improve the update banner experience: honest fail-fast errors (no more 3-minute dead wait), per-version failure marker suppresses the banner after a failed attempt (auto-unsticks on next release), failures reported to mothership via report_error, update UI hidden from roles that can't update.