### PR TITLE
0.7.2:

### DIFF
--- a/app/agents/leonardo/agent_factory.py
+++ b/app/agents/leonardo/agent_factory.py
@@ -146,6 +146,18 @@ def repair_orphaned_tool_calls_in_messages(messages: list) -> list:
     :func:`emitted_tool_calls` for why they are just as fatal — and an id-less
     call, which nothing can answer, is dropped from the outgoing message.
 
+    The mirror-image break is repaired here too: an ORPHAN ``ToolMessage`` whose
+    ``tool_call_id`` no ``AIMessage`` in the thread ever announced (left behind
+    when summarization or an older repair dropped the anchoring ``AIMessage``).
+    The provider rejects that just as hard, and dropping it from the outgoing
+    payload is the whole fix — it never has to be deleted from the checkpoint.
+
+    Doing BOTH shapes here is what keeps repair out of stored history: this
+    function rebuilds the list, so it can place a placeholder immediately after
+    the call it answers. A state-level fix cannot (``add_messages`` only
+    appends), which is why the state layer used to delete the messages in
+    between. See app/tests/test_thread_repair_is_non_destructive.py.
+
     This scans the whole thread and injects placeholders so the history is valid
     before the model sees it. Idempotent: returns the SAME list object when
     nothing needed repair (so callers can cheaply detect "no change").
@@ -156,10 +168,30 @@ def repair_orphaned_tool_calls_in_messages(messages: list) -> list:
         for msg in messages
         if isinstance(msg, ToolMessage) and msg.tool_call_id
     }
+    # Every tool_call_id any AIMessage announced. A ToolMessage outside this set
+    # answers nothing. Deliberately whole-thread rather than "announced so far":
+    # we drop only genuinely unanchored results, never a real answer that merely
+    # sits in an odd position.
+    announced_ids = {
+        tc["id"]
+        for msg in messages
+        if isinstance(msg, AIMessage)
+        for tc in emitted_tool_calls(msg)
+        if tc.get("id")
+    }
 
     result = []
     any_repaired = False
     for msg in messages:
+        if isinstance(msg, ToolMessage) and getattr(msg, "tool_call_id", None) not in announced_ids:
+            logger.warning(
+                "repair_orphaned_tool_calls: dropping orphan ToolMessage "
+                "tool_call_id=%s (no AIMessage announced it)",
+                getattr(msg, "tool_call_id", None),
+            )
+            any_repaired = True
+            continue
+
         if isinstance(msg, AIMessage) and emitted_tool_calls(msg):
             msg, dropped = _drop_idless_tool_calls(msg)
             any_repaired = any_repaired or dropped

--- a/app/frontend/chat/config.js
+++ b/app/frontend/chat/config.js
@@ -138,11 +138,13 @@ export function getVSCodeUrl() {
 /**
  * Get Inbox URL based on current protocol.
  *
- * Tickets, Feedback, Requests, Messages and Notifications all live behind this
+ * Messages, Tickets, Feedback, Requests and Notifications all live behind this
  * one tab; the Rails app renders a tab bar inside the frame to move between
  * them. /llama_bot/inbox is an entry point that redirects to the first of those
- * pages the signed-in user is allowed to open, because Tickets is
- * engineers-only and landing everyone there would dead-end the rest.
+ * pages the signed-in user is allowed to open — Messages today, since it is
+ * first in InboxHelper::INBOX_TABS and ungated. Keep the URL as the entry
+ * point rather than a page: tab order is owned by the Rails side, and Tickets
+ * is engineers-only, so a hardcoded page would dead-end whoever loses access.
  */
 export function getInboxUrl() {
   return getRailsUrl() + '/llama_bot/inbox';

--- a/app/frontend/chat/ui/IframeManager.js
+++ b/app/frontend/chat/ui/IframeManager.js
@@ -47,7 +47,7 @@ export class IframeManager {
     // VS CODE iframe
     this.vsCodeFrame = this.querySelector('[data-llamabot="vscode-frame"]');
 
-    // INBOX iframe (tickets, feedback, requests, messages, notifications)
+    // INBOX iframe (messages, tickets, feedback, requests, notifications)
     this.inboxFrame = this.querySelector('[data-llamabot="inbox-frame"]');
 
     // ACTIVITY iframe (audit log / record history)

--- a/app/tests/test_resume_repair_clobbers_interrupt.py
+++ b/app/tests/test_resume_repair_clobbers_interrupt.py
@@ -1,0 +1,261 @@
+"""
+Regression: repair-before-resume silently discarded the user's question answer.
+
+Shipped broken in 0.7.1 to the whole fleet. Every `ask_user_question` /
+`ask_user_uiux_question` card click lost the answer and the agent re-asked the
+same question 2-3 times.
+
+The sequence (all in `app/websocket/request_handler.py`):
+
+  1. The plan-mode agent commits an AIMessage with an `ask_user_question`
+     tool_call and the tool freezes inside `interrupt()`. At that moment the
+     tool_call has NO ToolMessage yet — that is the legitimate pending-interrupt
+     state, not corruption.
+  2. `handle_question_response` called `_repair_thread_state_if_needed`
+     unconditionally BEFORE `astream(Command(resume=answer))`.
+  3. The repair's shape-B pass (dangling tool_calls) had no pending-interrupt
+     awareness, so it classified the paused tool_call as dangling and wrote a
+     synthetic `[Cancelled]` ToolMessage via `aupdate_state`.
+  4. That state write superseded the pending interrupt, so the `Command(resume=)`
+     that followed landed on a thread with no interrupt — the answer was dropped
+     on the floor and the model saw `[Cancelled]` where the answer should be.
+
+0.7.0 had the same unconditional call, but the repair write failed silently
+(caught by the blanket `except`); the 0.7.1 `as_node=` fix made the write
+succeed, which armed the mis-detection.
+
+The fix is a guard inside `_repair_thread_state_if_needed`: a graph paused on an
+interrupt is not corrupted by definition, so leave it alone. The main-chat path
+opts OUT (`preserve_pending_interrupts=False`) because there, cancelling a
+pending `browser_command` tool_call is the deliberate behaviour — see the
+`_QUESTION_INTERRUPT_TYPES` comment.
+"""
+from typing import Annotated, TypedDict
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+from starlette.websockets import WebSocketState
+
+from app.websocket.request_handler import RequestHandler
+
+
+# ---------------------------------------------------------------------------
+# a real paused graph — the only way to prove the answer survives end-to-end
+# ---------------------------------------------------------------------------
+
+class _State(TypedDict):
+    messages: Annotated[list, "add_messages"]
+
+
+def _build_graph(interrupt_payload, answer_prefix):
+    """START -> model -> tools -> END, where `tools` freezes in interrupt().
+
+    Mirrors the real shape: the AIMessage with the tool_call is committed, then
+    the tool blocks, so the checkpoint legitimately holds an unanswered
+    tool_call while the graph is paused.
+    """
+    from langgraph.checkpoint.memory import MemorySaver
+    from langgraph.graph import END, START, StateGraph
+    from langgraph.graph.message import add_messages
+    from langgraph.types import interrupt
+
+    class S(TypedDict):
+        messages: Annotated[list, add_messages]
+
+    def model(state):
+        return {"messages": [AIMessage(content="", id="ai_1", tool_calls=[
+            {"name": "ask_user_question", "id": "call_1", "args": {"question": "Which?"}},
+        ])]}
+
+    def tools(state):
+        value = interrupt(interrupt_payload)
+        return {"messages": [ToolMessage(
+            content=f"{answer_prefix}{value}",
+            tool_call_id="call_1",
+            name="ask_user_question",
+        )]}
+
+    g = StateGraph(S)
+    g.add_node("model", model)
+    g.add_node("tools", tools)
+    g.add_edge(START, "model")
+    g.add_edge("model", "tools")
+    g.add_edge("tools", END)
+    return g.compile(checkpointer=MemorySaver())
+
+
+def _connected_websocket():
+    ws = MagicMock()
+    ws.client_state = WebSocketState.CONNECTED
+    ws.application_state = WebSocketState.CONNECTED
+    ws.send_json = AsyncMock()
+    return ws
+
+
+async def _pause_on_interrupt(graph, config):
+    await graph.ainvoke({"messages": [HumanMessage(content="build me a thing")]}, config)
+    snap = await graph.aget_state(config)
+    assert any(t.interrupts for t in snap.tasks), "graph did not pause on the interrupt"
+    return snap
+
+
+def _contents(snap):
+    return [getattr(m, "content", "") for m in snap.values["messages"]]
+
+
+@pytest.mark.asyncio
+async def test_question_answer_is_not_replaced_by_a_cancelled_toolmessage():
+    """The bug, end to end: click an option, and the answer must reach the tool."""
+    graph = _build_graph(
+        {"type": "user_question", "question": "Which layout?", "options": ["A", "B"]},
+        "User answered: ",
+    )
+    config = {"configurable": {"thread_id": "t_question"}}
+    await _pause_on_interrupt(graph, config)
+
+    handler = RequestHandler(MagicMock())
+    with patch.object(handler, "get_langgraph_app_and_state", return_value=(graph, {}, {})), \
+         patch.object(handler, "_report_error_to_mothership", AsyncMock()):
+        await handler.handle_question_response(
+            {"thread_id": "t_question", "agent_name": "rails_plan_mode_agent", "answer": "Option A"},
+            _connected_websocket(),
+        )
+
+    contents = _contents(await graph.aget_state(config))
+    assert "User answered: Option A" in contents, (
+        f"the user's answer never reached the tool — state is {contents!r}. "
+        "The repair superseded the pending interrupt, so Command(resume=) had "
+        "nothing to resume and the answer was silently discarded."
+    )
+    assert not any("[Cancelled]" in c for c in contents), (
+        f"a synthetic [Cancelled] ToolMessage replaced the answer: {contents!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_approval_decision_is_not_replaced_by_a_cancelled_toolmessage():
+    """`handle_approval_response` repairs before resuming too — same clobber."""
+    graph = _build_graph(
+        {"action_requests": [{"name": "bash_command", "args": {"cmd": "ls"}}]},
+        "User decided: ",
+    )
+    config = {"configurable": {"thread_id": "t_approval"}}
+    await _pause_on_interrupt(graph, config)
+
+    handler = RequestHandler(MagicMock())
+    with patch.object(handler, "get_langgraph_app_and_state", return_value=(graph, {}, {})), \
+         patch.object(handler, "_report_error_to_mothership", AsyncMock()):
+        await handler.handle_approval_response(
+            {"thread_id": "t_approval", "agent_name": "rails_agent",
+             "decisions": [{"type": "accept"}]},
+            _connected_websocket(),
+        )
+
+    contents = _contents(await graph.aget_state(config))
+    assert any("User decided:" in c for c in contents), (
+        f"the HITL decision never reached the tool — state is {contents!r}"
+    )
+    assert not any("[Cancelled]" in c for c in contents), (
+        f"a synthetic [Cancelled] ToolMessage replaced the decision: {contents!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# the guard itself, and what it must NOT swallow
+# ---------------------------------------------------------------------------
+
+class _App:
+    """Records whether the repair actually wrote to state."""
+
+    def __init__(self, messages, tasks=()):
+        self._messages = list(messages)
+        self._tasks = list(tasks)
+        self.updated_with = None
+
+    def get_graph(self):
+        return MagicMock(nodes=("__start__", "model", "tools", "__end__"))
+
+    async def aget_state(self, config):
+        snap = MagicMock()
+        snap.values = {"messages": self._messages}
+        snap.tasks = self._tasks
+        return snap
+
+    async def aupdate_state(self, config, update, as_node=None):
+        self.updated_with = update
+
+
+def _task_with_interrupt(value):
+    intr = MagicMock()
+    intr.value = value
+    task = MagicMock()
+    task.interrupts = [intr]
+    return task
+
+
+def _paused_history():
+    return [
+        HumanMessage(content="build the thing", id="h1"),
+        AIMessage(content="", id="a1", tool_calls=[
+            {"name": "ask_user_question", "id": "call_1", "args": {"question": "?"}},
+        ]),
+    ]
+
+
+def _handler():
+    return RequestHandler.__new__(RequestHandler)
+
+
+@pytest.mark.asyncio
+async def test_repair_leaves_an_interrupt_paused_thread_alone():
+    """A paused graph is not corrupted — the unanswered tool_call is the pause."""
+    app = _App(_paused_history(), tasks=[_task_with_interrupt(
+        {"type": "user_question", "question": "Which?", "options": []}
+    )])
+    await _handler()._repair_thread_state_if_needed(app, {"configurable": {"thread_id": "t"}})
+    assert app.updated_with is None, (
+        "repair wrote to a thread that was merely paused — that write supersedes "
+        "the pending interrupt and the next Command(resume=) is discarded"
+    )
+
+
+@pytest.mark.asyncio
+async def test_repair_still_cancels_a_genuinely_dangling_tool_call():
+    """No pending interrupt => the task really was cancelled mid-execution."""
+    app = _App(_paused_history(), tasks=[])
+    await _handler()._repair_thread_state_if_needed(app, {"configurable": {"thread_id": "t"}})
+    assert app.updated_with is not None, "a genuinely bricked thread must still be repaired"
+    injected = [m for m in app.updated_with["messages"] if isinstance(m, ToolMessage)]
+    assert injected and "[Cancelled]" in injected[0].content
+
+
+@pytest.mark.asyncio
+async def test_main_chat_path_can_still_cancel_a_pending_browser_command():
+    """`browser_command` interrupts are answered by the frontend, never by chat text.
+
+    When the user types into the main chat box while one is pending, that path
+    deliberately cancels the dangling tool_call rather than feeding the text in
+    as a fake browser result — so it opts out of the guard.
+    """
+    app = _App(_paused_history(), tasks=[_task_with_interrupt(
+        {"type": "browser_command", "command": "navigate", "args": {"path": "/users"}}
+    )])
+    await _handler()._repair_thread_state_if_needed(
+        app, {"configurable": {"thread_id": "t"}}, preserve_pending_interrupts=False,
+    )
+    assert app.updated_with is not None, (
+        "the main-chat path must still be able to cancel a pending browser_command"
+    )
+
+
+def test_both_resume_handlers_keep_the_guard_on():
+    """The guard is only useful if the two resume call sites do not opt out."""
+    import inspect
+
+    src = inspect.getsource(RequestHandler)
+    for name in ("handle_question_response", "handle_approval_response"):
+        body = src.split(f"async def {name}(")[1].split("\n    async def ")[0]
+        assert "preserve_pending_interrupts=False" not in body, (
+            f"{name} opts out of the pending-interrupt guard — that is the 0.7.1 bug"
+        )

--- a/app/tests/test_thread_repair_is_non_destructive.py
+++ b/app/tests/test_thread_repair_is_non_destructive.py
@@ -1,0 +1,211 @@
+"""
+Repair the payload, never the past.
+
+There are TWO repair layers for the same invariant ("every tool_call must be
+answered by a ToolMessage, or the provider 400s"):
+
+  Layer 1 — REQUEST TIME. `repair_orphaned_tool_calls_in_messages` /
+    `RepairOrphanedToolCallsMiddleware` (app/agents/leonardo/agent_factory.py).
+    Rebuilds the outgoing message list per model call. Nothing is persisted, and
+    a structural test (test_orphaned_toolcall_repair_all_agents.py) proves all 11
+    Leonardo graphs are wired for it.
+
+  Layer 2 — STATE. `_repair_thread_state_if_needed`
+    (app/websocket/request_handler.py). Rewrites the CHECKPOINT via
+    `aupdate_state`.
+
+Layer 2 is the wrong tool for this invariant, structurally: `add_messages` can
+only APPEND, so a state write cannot place a ToolMessage next to the AIMessage
+that owns it. The old code worked around that by deleting every message after
+the offending AIMessage — buying adjacency with the user's history. Layer 1 has
+no such problem because it rebuilds the list positionally.
+
+These tests pin the resulting division of labour:
+
+  1. Layer 2 never deletes history it does not own (the destructive workaround).
+  2. Layer 2 declines the cases it cannot fix correctly, and leaves them to
+     layer 1 (which fixes them on the very next model call anyway).
+  3. Layer 1 covers BOTH broken shapes — including orphan ToolMessages, which
+     only layer 2 used to handle. Without this, layer 2 is still load-bearing.
+"""
+from unittest.mock import MagicMock
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage, RemoveMessage, ToolMessage
+
+from app.agents.leonardo.agent_factory import repair_orphaned_tool_calls_in_messages
+from app.websocket.request_handler import RequestHandler
+
+
+class _App:
+    """Records exactly what the repair wrote to the checkpoint."""
+
+    def __init__(self, messages, tasks=()):
+        self._messages = list(messages)
+        self._tasks = list(tasks)
+        self.updated_with = None
+
+    def get_graph(self):
+        return MagicMock(nodes=("__start__", "model", "tools", "__end__"))
+
+    async def aget_state(self, config):
+        snap = MagicMock()
+        snap.values = {"messages": self._messages}
+        snap.tasks = self._tasks
+        return snap
+
+    async def aupdate_state(self, config, update, as_node=None):
+        self.updated_with = update
+
+
+def _handler():
+    return RequestHandler.__new__(RequestHandler)
+
+
+def _removed_ids(app):
+    if not app.updated_with:
+        return set()
+    return {
+        m.id for m in app.updated_with["messages"] if isinstance(m, RemoveMessage)
+    }
+
+
+def _thread_that_moved_on_from_a_dead_tool_call():
+    """A dangling tool_call EARLY in a thread that then carried on for a long time.
+
+    Real cause: summarization rewrote history, or a tool crashed and the model
+    continued in text. Layer 1 makes this thread perfectly sendable. The state
+    repair used to delete everything from `later_1` onward.
+    """
+    return [
+        HumanMessage(content="please run the migration", id="h1"),
+        AIMessage(content="", id="a1", tool_calls=[
+            {"id": "call_dead", "name": "bash_command", "args": {}},
+        ]),
+        AIMessage(content="that failed, doing it by hand instead", id="later_1"),
+        HumanMessage(content="ok, now add the index too", id="later_2"),
+        AIMessage(content="added, here is the plan for the rest", id="later_3"),
+        HumanMessage(content="great, keep going", id="later_4"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_state_repair_never_deletes_history_it_does_not_own():
+    """The bulk delete: one stale tool_call cost the user the rest of the thread."""
+    app = _App(_thread_that_moved_on_from_a_dead_tool_call())
+    await _handler()._repair_thread_state_if_needed(app, {"configurable": {"thread_id": "t"}})
+
+    clobbered = _removed_ids(app) & {"later_1", "later_2", "later_3", "later_4"}
+    assert not clobbered, (
+        f"repair deleted {sorted(clobbered)} — messages that had nothing to do "
+        "with the dangling tool_call. One stale call anywhere in a thread wipes "
+        "every message after it, permanently, to buy adjacency for a synthetic "
+        "ToolMessage that layer 1 would have placed correctly for free."
+    )
+
+
+@pytest.mark.asyncio
+async def test_state_repair_declines_what_it_cannot_place_correctly():
+    """An append lands at the END, which is not where the ToolMessage belongs.
+
+    With messages after the offending AIMessage, there is no correct state-level
+    fix — so layer 2 must do nothing and let layer 1 handle it.
+    """
+    app = _App(_thread_that_moved_on_from_a_dead_tool_call())
+    await _handler()._repair_thread_state_if_needed(app, {"configurable": {"thread_id": "t"}})
+
+    assert app.updated_with is None, (
+        "layer 2 wrote a ToolMessage that cannot possibly be adjacent to its "
+        f"AIMessage: {app.updated_with!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_state_repair_still_fixes_the_trailing_case_it_can_place():
+    """When the dangling AIMessage is last, an append IS adjacent — still repair.
+
+    This is the genuinely bricked thread (task cancelled mid-tool-execution) and
+    the case the 0.7.1 `as_node` fix exists for.
+    """
+    app = _App([
+        HumanMessage(content="build the thing", id="h1"),
+        AIMessage(content="", id="a1", tool_calls=[
+            {"id": "call_1", "name": "grep_files", "args": {}},
+        ]),
+    ])
+    await _handler()._repair_thread_state_if_needed(app, {"configurable": {"thread_id": "t"}})
+
+    assert app.updated_with is not None, "a genuinely bricked thread must still be repaired"
+    injected = [m for m in app.updated_with["messages"] if isinstance(m, ToolMessage)]
+    assert injected and injected[0].tool_call_id == "call_1"
+    assert not _removed_ids(app), "nothing needed deleting — the append is already adjacent"
+
+
+@pytest.mark.asyncio
+async def test_partially_answered_trailing_call_is_completed_without_deletion():
+    """Two calls, one answered: appending the missing one keeps the block valid."""
+    app = _App([
+        HumanMessage(content="do both", id="h1"),
+        AIMessage(content="", id="a1", tool_calls=[
+            {"id": "call_a", "name": "x", "args": {}},
+            {"id": "call_b", "name": "y", "args": {}},
+        ]),
+        ToolMessage(content="a done", tool_call_id="call_a", id="tm_a"),
+    ])
+    await _handler()._repair_thread_state_if_needed(app, {"configurable": {"thread_id": "t"}})
+
+    assert app.updated_with is not None
+    injected = {m.tool_call_id for m in app.updated_with["messages"] if isinstance(m, ToolMessage)}
+    assert injected == {"call_b"}
+    assert "tm_a" not in _removed_ids(app), "the answer we already had must survive"
+
+
+# ---------------------------------------------------------------------------
+# layer 1 has to cover BOTH shapes, or layer 2 stays load-bearing
+# ---------------------------------------------------------------------------
+
+def test_request_time_repair_drops_orphan_toolmessages():
+    """A ToolMessage no AIMessage ever announced 400s the provider too.
+
+    Only the state layer handled this shape, which is why it had to keep
+    rewriting checkpoints. Layer 1 must drop it from the outgoing payload so the
+    thread is sendable without ever touching stored history.
+    """
+    msgs = [
+        HumanMessage(content="hi"),
+        ToolMessage(content="stale result", tool_call_id="call_ghost"),
+        AIMessage(content="hello"),
+    ]
+    out = repair_orphaned_tool_calls_in_messages(msgs)
+
+    assert not any(
+        isinstance(m, ToolMessage) and m.tool_call_id == "call_ghost" for m in out
+    ), "the orphan ToolMessage is still in the payload the provider will reject"
+    assert [type(m) for m in out] == [HumanMessage, AIMessage]
+
+
+def test_request_time_repair_keeps_anchored_toolmessages():
+    """Only unanchored ones go — a real answer must never be dropped."""
+    msgs = [
+        AIMessage(content="", tool_calls=[{"id": "call_1", "name": "x", "args": {}}]),
+        ToolMessage(content="the real result", tool_call_id="call_1"),
+    ]
+    assert repair_orphaned_tool_calls_in_messages(msgs) is msgs
+
+
+def test_request_time_repair_fixes_both_shapes_at_once():
+    """An orphan AND a dangling call in one thread: payload comes out valid."""
+    msgs = [
+        ToolMessage(content="stale", tool_call_id="call_ghost"),
+        HumanMessage(content="go"),
+        AIMessage(content="", tool_calls=[{"id": "call_1", "name": "x", "args": {}}]),
+    ]
+    out = repair_orphaned_tool_calls_in_messages(msgs)
+
+    announced = {
+        tc["id"] for m in out if isinstance(m, AIMessage) for tc in (m.tool_calls or [])
+    }
+    answered = {m.tool_call_id for m in out if isinstance(m, ToolMessage)}
+    assert answered == announced == {"call_1"}, (
+        f"payload still violates the tool-call contract: {out!r}"
+    )

--- a/app/websocket/request_handler.py
+++ b/app/websocket/request_handler.py
@@ -403,6 +403,19 @@ class RequestHandler:
         return None
 
     @staticmethod
+    def _snapshot_has_pending_interrupt(state_snapshot) -> bool:
+        """True if the graph is paused inside an `interrupt()` on this snapshot.
+
+        Same source `_pending_question_interrupt` reads, but for ANY interrupt
+        type — a paused graph is a paused graph regardless of what it is waiting
+        for.
+        """
+        for task in getattr(state_snapshot, "tasks", None) or []:
+            if getattr(task, "interrupts", None):
+                return True
+        return False
+
+    @staticmethod
     def _normalize_messages(raw):
         """Return a plain message list from a possibly DeltaChannel-wrapped value.
 
@@ -422,7 +435,9 @@ class RequestHandler:
             return list(raw.value) if raw.value is not None else []
         return list(raw) if isinstance(raw, (list, tuple)) else raw
 
-    async def _repair_thread_state_if_needed(self, app, config):
+    async def _repair_thread_state_if_needed(
+        self, app, config, *, preserve_pending_interrupts: bool = True,
+    ):
         """
         Detect and repair two shapes of corrupted thread state that violate
         the LLM contract `every tool message must follow an assistant message
@@ -437,8 +452,24 @@ class RequestHandler:
             corresponding following ToolMessage. Cause: task cancelled
             mid-tool-execution, or the model emitted a call whose arguments JSON
             did not parse (`invalid_tool_calls`) — no executor ever runs it, so
-            nothing ever answers it. Fix: remove anything after the corrupted
-            AIMessage and inject synthetic "[Cancelled]" ToolMessages.
+            nothing ever answers it. Fix: append synthetic "[Cancelled]"
+            ToolMessages, and ONLY when the dangling AIMessage is the trailing
+            one (see below).
+
+        This layer is a backstop, not the primary defence. The primary one is
+        `repair_orphaned_tool_calls_in_messages` /
+        `RepairOrphanedToolCallsMiddleware`, which rebuilds the outgoing message
+        list on EVERY model call for all 11 Leonardo graphs and persists nothing.
+
+        Why this layer must stay narrow: state updates go through `add_messages`,
+        which can only APPEND. So a state write can only produce a correctly
+        positioned ToolMessage when the dangling AIMessage is at the END of the
+        thread. It used to buy that adjacency everywhere else by deleting every
+        message after the offending AIMessage — which silently destroyed the rest
+        of the user's conversation over a single stale tool_call. It no longer
+        does: a dangling call with live history after it is left to the
+        request-time layer, which places the placeholder correctly and throws
+        nothing away.
 
         Both passes scan `emitted_tool_calls` — what the serializer actually puts
         on the wire (tool_calls + invalid_tool_calls) — not just the executable
@@ -447,6 +478,21 @@ class RequestHandler:
         re-bricking the thread on the next turn.
 
         Both fixes are applied in a single aupdate_state call.
+
+        `preserve_pending_interrupts` (default True) is the safety guard: when
+        the graph is paused inside an `interrupt()`, the waiting tool_call has no
+        ToolMessage yet BY DESIGN — that is the pause, not corruption. Repairing
+        it writes state that supersedes the pending interrupt, so the
+        `Command(resume=...)` that follows lands on a thread with no interrupt
+        and the user's answer is silently discarded (0.7.1 fleet-wide bug: every
+        ask_user_question card click lost its answer and the agent re-asked).
+        A paused graph is not corrupted, so we do nothing and let the resume run.
+
+        Pass False only where abandoning the pause is the intent — the main-chat
+        path, where a user message arriving during a `browser_command` interrupt
+        must cancel that tool_call cleanly (its answer can only come from the
+        frontend, never from chat text). See the `_QUESTION_INTERRUPT_TYPES`
+        comment above.
         """
         from langchain_core.messages import AIMessage, ToolMessage as LCToolMessage
         from langchain_core.messages import RemoveMessage
@@ -455,6 +501,16 @@ class RequestHandler:
         try:
             state_snapshot = await app.aget_state(config)
             if not state_snapshot or not state_snapshot.values:
+                return
+
+            # A graph paused on an interrupt is waiting, not broken. Any write
+            # here would supersede that interrupt and throw away the resume value
+            # the caller is about to deliver.
+            if preserve_pending_interrupts and self._snapshot_has_pending_interrupt(state_snapshot):
+                logger.info(
+                    "Skipping thread state repair: graph is paused on a pending "
+                    "interrupt (its unanswered tool_call is the pause, not corruption)."
+                )
                 return
 
             messages = self._normalize_messages(state_snapshot.values.get("messages", []))
@@ -501,15 +557,31 @@ class RequestHandler:
                     corrupted_index = i
                     break
 
+            # An append only lands adjacent to its AIMessage if nothing but that
+            # call's own ToolMessages follows. Anything else (a later AIMessage,
+            # a HumanMessage — i.e. the conversation moved on) is not repairable
+            # from here without deleting it, so hand it to the request-time layer.
+            if corrupted_index is not None and not all(
+                isinstance(m, LCToolMessage) for m in messages[corrupted_index + 1:]
+            ):
+                logger.info(
+                    f"Dangling tool_call at index {corrupted_index} has live history "
+                    f"after it; leaving it to the request-time repair rather than "
+                    f"deleting {len(messages) - corrupted_index - 1} message(s)."
+                )
+                corrupted_index = None
+
             if not orphan_msgs and corrupted_index is None:
                 return
 
             remove_ops = []
             repair_messages = []
 
-            # Shape A: RemoveMessage each orphan ToolMessage. Orphans removed
-            # here will not be in the messages_to_remove slice below because
-            # the dangling-tool_calls fix only looks after `corrupted_index`.
+            # Shape A: RemoveMessage each orphan ToolMessage. This is a targeted
+            # delete of a message that answers nothing — never a real result, and
+            # never the surrounding conversation. The request-time layer also
+            # drops these from the outgoing payload, so this is belt-and-braces
+            # rather than the thing standing between the user and a 400.
             if orphan_msgs:
                 logger.warning(
                     f"Corrupted thread state detected: {len(orphan_msgs)} orphan ToolMessage(s) "
@@ -520,18 +592,24 @@ class RequestHandler:
                     if mid:
                         remove_ops.append(RemoveMessage(id=mid))
 
-            # Shape B: drop everything after the corrupted AIMessage and inject
-            # synthetic ToolMessages for its dangling tool_calls.
+            # Shape B: append synthetic ToolMessages for the trailing AIMessage's
+            # unanswered tool_calls. Nothing is deleted — the calls already
+            # answered keep their real results, and the appended placeholders
+            # complete the block.
             if corrupted_index is not None:
                 corrupted_msg = messages[corrupted_index]
-                tool_calls = [tc for tc in emitted_tool_calls(corrupted_msg) if tc.get("id")]
+                answered_ids = {
+                    getattr(m, "tool_call_id", None)
+                    for m in messages[corrupted_index + 1:]
+                }
+                tool_calls = [
+                    tc for tc in emitted_tool_calls(corrupted_msg)
+                    if tc.get("id") and tc["id"] not in answered_ids
+                ]
                 logger.warning(
                     f"Corrupted thread state detected at message index {corrupted_index}: "
                     f"AIMessage with {len(tool_calls)} dangling tool_call(s). Repairing..."
                 )
-                for m in messages[corrupted_index + 1:]:
-                    if hasattr(m, "id") and m.id:
-                        remove_ops.append(RemoveMessage(id=m.id))
                 for tc in tool_calls:
                     is_invalid = bool(tc.get("error")) or tc.get("type") == "invalid_tool_call"
                     repair_messages.append(LCToolMessage(
@@ -912,8 +990,16 @@ class RequestHandler:
                     stream_input = Command(resume=resume_value)
                 else:
                     # Auto-repair corrupted thread state (dangling tool_calls without ToolMessages)
-                    # This can happen when a previous task was cancelled mid-tool-execution
-                    await self._repair_thread_state_if_needed(app, config)
+                    # This can happen when a previous task was cancelled mid-tool-execution.
+                    #
+                    # preserve_pending_interrupts=False: we already know no QUESTION
+                    # interrupt is pending here, and a still-pending browser_command
+                    # one must be cancelled — the user typed instead of letting the
+                    # frontend answer it, so we abandon the pause deliberately and
+                    # send their message as a normal turn.
+                    await self._repair_thread_state_if_needed(
+                        app, config, preserve_pending_interrupts=False,
+                    )
                     stream_input = state
 
                 async for chunk in app.astream(stream_input, config=config, stream_mode=["updates", "messages", "custom"], subgraphs=True):
@@ -1245,7 +1331,9 @@ class RequestHandler:
                     "recursion_limit": recursion_limit
                 }
 
-                # Auto-repair corrupted thread state (defensive - less likely in HITL flow)
+                # Auto-repair corrupted thread state (defensive - less likely in HITL flow).
+                # No-ops while the graph is paused on the interrupt we are about to
+                # resume — repairing there would discard the user's decision.
                 await self._repair_thread_state_if_needed(app, config)
 
                 # Build HITLResponse from user decisions
@@ -1472,7 +1560,9 @@ class RequestHandler:
                     "recursion_limit": recursion_limit
                 }
 
-                # Auto-repair corrupted thread state
+                # Auto-repair corrupted thread state. No-ops while the graph is
+                # paused on the question interrupt we are about to resume —
+                # repairing there would discard the user's answer (0.7.1 bug).
                 await self._repair_thread_state_if_needed(app, config)
 
                 # Resume the graph — interrupt() returns this answer string

--- a/docs/2026-08-17-inbox-messages-first-chat-ui-handoff.md
+++ b/docs/2026-08-17-inbox-messages-first-chat-ui-handoff.md
@@ -1,0 +1,80 @@
+# Handoff — Inbox goes Messages-first; chat UI side of the unread badge
+
+**Date:** 2026-08-17
+**Owner of the other half:** `llama_bot_rails` (vendored in `LlamaPress-Simple/vendor/llama_bot_rails`) — changes there are done and green.
+**This doc:** what the LlamaBot chat UI (`app/frontend/chat.html` + `chat/ui/IframeManager.js`) has to do, verify, or deliberately not do.
+
+## What changed on the Rails side (already implemented)
+
+1. **Messages is now the first Inbox tab** (`InboxHelper::INBOX_TABS`). Because
+   `/llama_bot/inbox` redirects to the first tab the visitor may open, the chat UI's
+   Inbox tab now lands on **Messages** instead of Tickets. No URL changed —
+   `getInboxUrl()` (`app/frontend/chat/config.js`) still points at `/llama_bot/inbox`.
+2. **The Inbox tab bar itself now carries a red unread badge on its Messages tab**
+   (`shared/_inbox_nav`, `data-llamabot="inbox-nav-unread-badge"`). Server-rendered on
+   first paint, then kept live by the existing unread bridge.
+3. **`shared/_parent_unread_bridge` now polls even when the page is NOT framed.** It
+   used to bail out immediately if `window.parent === window`. It still posts the same
+   `{source: 'llamabot-notifications', type: 'unread-count', unreadMessages: N}` message
+   up to the parent when it IS framed — **the postMessage contract is unchanged.**
+4. Redundant page chrome removed across the Inbox: the `<h1>` on each page (the tab bar
+   already names it), and on Messages the "Your conversations" subtitle plus the
+   Feedback/Notifications cross-links. Messages now opens with a search box + a
+   "+ New Chat" button in one row, threads immediately underneath.
+
+## What LlamaBot needs to do
+
+**Almost certainly nothing in code.** Verified while writing this:
+
+- `chat.html:422` already renders `<span class="tab-unread-badge hidden"
+  data-llamabot="messages-unread-badge">` inside the Inbox tab, and
+  `IframeManager.setUnreadMessagesCount()` already writes the **number** into it
+  (capped at `99+`, hidden at zero). That is exactly the "number of unread messages on
+  the tab icon" behaviour we want — it is already shipped.
+- The listener (`IframeManager.initUnreadBadgeListener`) matches the message shape the
+  Rails bridge still sends, so item 3 above does not break it.
+
+So the LlamaBot-side task is a **verification pass**, not a build:
+
+- [x] Click the Inbox tab in the chat UI and confirm it opens on **Messages** (not the
+      ticket board) for both an engineer and a plain user.
+      *Verified by construction 2026-08-17:* `InboxController#landing_path` takes the first
+      permitted tab, and Messages is both first in `INBOX_TABS` and `ability: nil`, so no
+      permission path can land anyone elsewhere. The dev box serves this today — the gem is
+      bind-mounted from the submodule into `leonardo-llamapress-1`.
+- [ ] Send a DM to the signed-in user from another account and confirm the count appears
+      **twice**: on the chat UI's Inbox tab, and on the Messages tab of the Rails tab bar
+      inside the frame. Both should clear within ~20s of reading the thread (poll interval).
+      *Still human-only* — needs two real accounts. Both render paths are unit-covered
+      (`app/tests/js/messages_tab_unread_badge.test.mjs` here, gem specs there).
+- [x] Confirm the badge still renders on a cold load (the Inbox frame's `src` is set
+      eagerly in `IframeManager`, so the bridge polls even while the user sits on the App tab).
+      *Covered by* "the inbox frame loads eagerly, so its unread poll runs before the tab is
+      opened".
+
+### Result of the verification pass (2026-08-17)
+
+No behavioural code change was needed — the doc's read of `chat.html` and `IframeManager`
+was correct, and all 12 tests in `app/tests/js/messages_tab_unread_badge.test.mjs` pass.
+Only two stale comments were fixed (`config.js` `getInboxUrl`, `IframeManager.js:50`), which
+both still enumerated the Inbox tabs Tickets-first.
+
+Note for whoever runs these: the `app/tests/js/*.mjs` suite needs **host node 22**, not the
+container's node 18 — the tests import `.js` sources as ES modules and only node ≥22 detects
+module syntax without a `package.json` `type: module`. The suite is not wired into CI.
+
+## Open question for the human
+
+The chat UI tab is labelled **"Inbox"** while its badge counts only direct messages. Now
+that the tab lands on Messages, that is coherent — but if we ever want the badge to cover
+tickets/feedback/requests too, the count has to change on the **Rails** side
+(`Notification.unread_message_count_for` is deliberately DM-only so a feedback mention
+does not light it up), not here. Don't widen it in the frontend.
+
+## Do NOT do
+
+- Do not fetch the unread count from the chat UI directly. Different origin, no Devise
+  session — the iframe counts and posts up for that reason.
+- Do not point the Inbox tab at `/llama_bot/conversations` to "make Messages the default".
+  Tab order is owned by `InboxHelper::INBOX_TABS`, and `/llama_bot/inbox` follows it; a
+  hardcoded URL would dead-end anyone whose permissions change.

--- a/docs/dev_logs/0.7.2
+++ b/docs/dev_logs/0.7.2
@@ -1,0 +1,36 @@
+0.7.2:
+[x] - Fix question-card answers being silently discarded (P0, every 0.7.1 box).
+      Click an option on an ask_user_question card and the agent re-asked the
+      same question 2-3 times; the answer wasn't truncated, it was replaced.
+      Both resume handlers called _repair_thread_state_if_needed BEFORE
+      Command(resume=answer). A tool frozen in interrupt() legitimately has no
+      ToolMessage yet, so the repair read that as a dangling tool_call and wrote
+      a synthetic "[Cancelled]" — and that state write superseded the pending
+      interrupt, so the resume landed on a thread with nothing to resume. The
+      model then saw [Cancelled] where the answer belonged. Checkpoint ground
+      truth on the mothership: 5 [Cancelled] ToolMessages, ZERO "User answered:".
+      Present in 0.7.0 too, but the repair write failed silently there; the
+      0.7.1 as_node fix made it succeed, which armed the mis-detection.
+      Repair is now interrupt-aware — a paused graph is not corrupted, so it
+      no-ops and lets the resume through. HITL approvals had the identical
+      clobber and are fixed by the same guard. The main-chat path opts out
+      (preserve_pending_interrupts=False): cancelling a pending browser_command
+      there is deliberate, since only the frontend can answer that one.
+
+[x] - Stop thread repair from deleting the rest of the conversation. To make an
+      injected ToolMessage sit next to its AIMessage, shape-B repair removed
+      EVERY message after the offending one — so a single stale tool_call
+      anywhere in a thread permanently wiped all history after it. Found while
+      fixing the above; latent since the repair shipped, never diagnosed.
+      Root cause is the layer, not the loop: state updates go through
+      add_messages, which only APPENDS, so a checkpoint write can never place a
+      ToolMessage positionally, and the deletion was buying that adjacency with
+      the user's data. The request-time layer
+      (repair_orphaned_tool_calls_in_messages, wired into all 11 graphs) rebuilds
+      the outgoing list and has no such limit. So: orphan-ToolMessage dropping
+      moved there too — it was the last shape only the state layer covered —
+      and the state layer is now a narrow backstop that appends only when the
+      dangling AIMessage is trailing (where an append is already adjacent),
+      declines anything with live history after it, and deletes no conversation.
+      Rule going forward: repair the payload, never the past.
+      Notes: app/tests/test_thread_repair_is_non_destructive.py


### PR DESCRIPTION
[x] - Fix question-card answers being silently discarded (P0, every 0.7.1 box).
      Click an option on an ask_user_question card and the agent re-asked the
      same question 2-3 times; the answer wasn't truncated, it was replaced.
      Both resume handlers called _repair_thread_state_if_needed BEFORE
      Command(resume=answer). A tool frozen in interrupt() legitimately has no
      ToolMessage yet, so the repair read that as a dangling tool_call and wrote
      a synthetic "[Cancelled]" — and that state write superseded the pending
      interrupt, so the resume landed on a thread with nothing to resume. The
      model then saw [Cancelled] where the answer belonged. Checkpoint ground
      truth on the mothership: 5 [Cancelled] ToolMessages, ZERO "User answered:".
      Present in 0.7.0 too, but the repair write failed silently there; the
      0.7.1 as_node fix made it succeed, which armed the mis-detection.
      Repair is now interrupt-aware — a paused graph is not corrupted, so it
      no-ops and lets the resume through. HITL approvals had the identical
      clobber and are fixed by the same guard. The main-chat path opts out
      (preserve_pending_interrupts=False): cancelling a pending browser_command
      there is deliberate, since only the frontend can answer that one.

[x] - Stop thread repair from deleting the rest of the conversation. To make an
      injected ToolMessage sit next to its AIMessage, shape-B repair removed
      EVERY message after the offending one — so a single stale tool_call
      anywhere in a thread permanently wiped all history after it. Found while
      fixing the above; latent since the repair shipped, never diagnosed.
      Root cause is the layer, not the loop: state updates go through
      add_messages, which only APPENDS, so a checkpoint write can never place a
      ToolMessage positionally, and the deletion was buying that adjacency with
      the user's data. The request-time layer
      (repair_orphaned_tool_calls_in_messages, wired into all 11 graphs) rebuilds
      the outgoing list and has no such limit. So: orphan-ToolMessage dropping
      moved there too — it was the last shape only the state layer covered —
      and the state layer is now a narrow backstop that appends only when the
      dangling AIMessage is trailing (where an append is already adjacent),
      declines anything with live history after it, and deletes no conversation.
      Rule going forward: repair the payload, never the past.
      Notes: app/tests/test_thread_repair_is_non_destructive.py