### PR TITLE
0.7.4:

### DIFF
--- a/app/agents/leonardo/agent_factory.py
+++ b/app/agents/leonardo/agent_factory.py
@@ -30,6 +30,7 @@ from langchain.agents import create_agent
 from langchain.agents.middleware import AgentMiddleware
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 from app.agents.leonardo.turn_metrics_middleware import TurnMetricsMiddleware
+from app.agents.leonardo.rails_error_watch_middleware import RailsErrorWatchMiddleware
 from app.agents.leonardo.tool_output_middleware import ToolResultSizeLimitMiddleware
 import logging
 
@@ -235,13 +236,25 @@ class RepairOrphanedToolCallsMiddleware(AgentMiddleware):
     """Inject placeholder ToolMessages for AIMessage tool_calls that have no response.
 
     Thin ``AgentMiddleware`` wrapper around
-    :func:`repair_orphaned_tool_calls_in_messages`. The placeholders are NOT
-    persisted to state — they exist only for the duration of the LLM call,
-    keeping the fix invisible to the checkpointer.
+    :func:`app.agents.leonardo.message_invariants.normalize_messages_for_provider`,
+    which owns tool-call pairing AND the other invariants providers enforce
+    (supported content types, no empty content, at least one user/tool message).
+    Nothing it changes is persisted to state — the fixes exist only for the
+    duration of the LLM call, keeping them invisible to the checkpointer.
+
+    The class name is unchanged because it is the wiring key ``build_leonardo_agent``
+    and several tests match on.
     """
 
     def _repair(self, messages):
-        return repair_orphaned_tool_calls_in_messages(messages)
+        # The full invariant set, not just tool-call pairing: one validator that
+        # every provider call passes through, whatever the mode or entry point.
+        # Imported here because message_invariants imports from this module.
+        from app.agents.leonardo.message_invariants import (
+            normalize_messages_for_provider,
+        )
+
+        return normalize_messages_for_provider(messages)
 
     def wrap_model_call(self, request, handler):
         messages = self._repair(list(request.messages))
@@ -404,6 +417,12 @@ def build_leonardo_agent(*, middleware=None, **kwargs):
       it sits OUTERMOST at the model-call boundary and therefore measures what
       the user actually waits for, including whatever the inner middleware
       (summarization, repair, brand injection) costs. Purely observational.
+    - ``RailsErrorWatchMiddleware`` — notices mid-turn that the Rails app is
+      crashing and puts the exception in front of the model before it thinks
+      again, so a turn cannot end on the "something broke" page. APPENDED after
+      the message-shaping middleware so it appends to the FINAL message list
+      (summarization and repair have already had their say). Inert unless the
+      request handler installed a watch for the turn.
     - ``ToolResultSizeLimitMiddleware`` — bounds every tool result. APPENDED
       last so it is outermost at the TOOL boundary and sees the final result
       whatever the inner middleware did to it. A single result bigger than the
@@ -420,6 +439,8 @@ def build_leonardo_agent(*, middleware=None, **kwargs):
         mw.insert(2, BrandContextMiddleware())
     if not any(isinstance(m, TurnMetricsMiddleware) for m in mw):
         mw.append(TurnMetricsMiddleware())
+    if not any(isinstance(m, RailsErrorWatchMiddleware) for m in mw):
+        mw.append(RailsErrorWatchMiddleware())
     if not any(isinstance(m, ToolResultSizeLimitMiddleware) for m in mw):
         mw.append(ToolResultSizeLimitMiddleware())
     return create_agent(middleware=mw, **kwargs)

--- a/app/agents/leonardo/delegation.py
+++ b/app/agents/leonardo/delegation.py
@@ -15,7 +15,102 @@ DELEGATION_HEARTBEAT_SECONDS = 15
 
 
 class DelegationTimedOut(TimeoutError):
-    """Raised after the whole nested-agent delegation exceeds its deadline."""
+    """Raised after the whole nested-agent delegation exceeds its deadline.
+
+    Carries ``partial_messages`` — everything the sub-agent had done when the
+    deadline hit. The damage from a timeout was never the timeout: it was the
+    silence. The sub-agent has already edited files, and the parent got no record
+    of which, so it had to re-read the tree or (worse) retry and edit them twice.
+    """
+
+    def __init__(self, message: str = "", *, partial_messages=None):
+        super().__init__(message)
+        self.partial_messages = list(partial_messages or [])
+
+
+def _tool_calls_of(message):
+    return list(getattr(message, "tool_calls", None) or [])
+
+
+def _tool_results_by_id(messages) -> dict:
+    results = {}
+    for msg in messages:
+        call_id = getattr(msg, "tool_call_id", None)
+        if call_id:
+            results[call_id] = msg
+    return results
+
+
+#: Tools whose calls are worth reporting back, and the argument that names the
+#: thing they acted on. Anything else is noise in a recovery report.
+_REPORTABLE_TOOLS = {
+    "write_file": "file_path",
+    "edit_file": "file_path",
+    "bash_command": "command",
+    "write_leonardo_md": "path",
+    "edit_leonardo_md": "path",
+}
+
+_ERROR_MARKERS = ("Error:", "error:", "rails aborted!", "did NOT persist",
+                  "Could not find", "FAILED")
+
+
+def summarize_partial_work(messages, *, max_items: int = 25) -> str:
+    """What the sub-agent actually did, for a parent that has to recover from it.
+
+    A partial report is recoverable; nothing is not. Reports the files written or
+    edited, the commands run and whether they looked like they failed, and the
+    step that was in flight when the deadline hit.
+    """
+    messages = list(messages or [])
+    if not messages:
+        return "No record of what the sub-agent did before the deadline."
+
+    results = _tool_results_by_id(messages)
+    files, commands = [], []
+    in_flight = None
+
+    for msg in messages:
+        for call in _tool_calls_of(msg):
+            name = call.get("name")
+            arg_key = _REPORTABLE_TOOLS.get(name)
+            if arg_key is None:
+                continue
+            value = (call.get("args") or {}).get(arg_key)
+            if not value:
+                continue
+            result = results.get(call.get("id"))
+            if result is None:
+                # No ToolMessage answered it, so this is where it stopped.
+                in_flight = f"{name}({value})"
+                continue
+            content = str(getattr(result, "content", "") or "")
+            failed = any(marker in content for marker in _ERROR_MARKERS)
+            if name in ("write_file", "edit_file"):
+                files.append((str(value), failed))
+            else:
+                commands.append((str(value), failed))
+
+    lines = []
+    if files:
+        lines.append("Files it wrote or edited:")
+        for path, failed in files[:max_items]:
+            lines.append(f"  - {path}{'  (the call reported an error)' if failed else ''}")
+        if len(files) > max_items:
+            lines.append(f"  - …and {len(files) - max_items} more")
+    if commands:
+        lines.append("Commands it ran:")
+        for command, failed in commands[:max_items]:
+            trimmed = command if len(command) <= 200 else command[:200] + "…"
+            lines.append(f"  - {trimmed}{'  (failed)' if failed else ''}")
+        if len(commands) > max_items:
+            lines.append(f"  - …and {len(commands) - max_items} more")
+    if in_flight:
+        lines.append(f"In progress when it ran out of time: {in_flight}")
+
+    if not lines:
+        return "It had not written any files or run any commands yet."
+    return "\n".join(lines)
 
 
 async def run_delegation(
@@ -54,16 +149,30 @@ async def run_delegation(
 
     emit("started", f"{label} started")
     heartbeat_task = asyncio.create_task(heartbeat())
+
+    # Streamed rather than ainvoke'd purely so a timeout can say what happened.
+    # `values` yields the whole state after each step, so whatever the last
+    # completed step left behind is still in hand when the deadline fires.
+    # (`astream` is as cancellable as `ainvoke` — cancellation still reaches the
+    # provider client, which is why neither is run in an executor.)
+    latest: dict = {}
     try:
         async with asyncio.timeout(timeout_seconds):
-            result = await sub_agent.ainvoke(input_data, config=config)
+            async for chunk in sub_agent.astream(
+                input_data, config=config, stream_mode="values"
+            ):
+                if isinstance(chunk, dict):
+                    latest = chunk
         emit("completed", f"{label} completed")
-        return result
+        return latest
     except TimeoutError as exc:
         elapsed = f"{timeout_seconds:g}"
         emit("timed_out", f"{label} timed out after {elapsed}s")
         logger.warning("%s timed out after %ss", label, elapsed)
-        raise DelegationTimedOut(f"timed out after {elapsed}s") from exc
+        raise DelegationTimedOut(
+            f"timed out after {elapsed}s",
+            partial_messages=latest.get("messages") or [],
+        ) from exc
     except Exception:
         emit("failed", f"{label} failed")
         raise

--- a/app/agents/leonardo/message_invariants.py
+++ b/app/agents/leonardo/message_invariants.py
@@ -1,0 +1,296 @@
+"""One validator every provider call passes through.
+
+2026-08-23 fleet telemetry, P1-4. Three different malformed-history shapes were
+still killing turns on customer boxes in 30 days:
+
+  | shape                                                    | boxes | path |
+  |----------------------------------------------------------|-------|------|
+  | ``messages`` must contain at least one message with role  |   4   | the question-card resume |
+  | ``user`` or ``tool``                                       |       | |
+  | ``messages[33].content`` did not match any supported type |   1   | rails_beginner_agent |
+  | assistant ``tool_calls`` not followed by ``tool`` messages|   2   | 0.6.0x boxes |
+
+Only the third had a fix, and it had TWO implementations —
+``repair_orphaned_tool_calls_in_messages`` called by hand inside the raw
+``StateGraph`` nodes ("this raw node never runs AgentMiddleware"), and
+``RepairOrphanedToolCallsMiddleware`` for the factory-built modes. Two
+implementations of one rule means every new path starts out missing it, which is
+exactly how the question-resume path ended up unprotected.
+
+So: one function, :func:`normalize_messages_for_provider`, asserting the
+invariants the providers actually enforce, called at every model-call boundary —
+the middleware for ``create_agent`` modes, and directly by the raw nodes.
+
+It never raises and never drops content it cannot prove is broken. Repairing a
+history is a last resort before a hard 400; being conservative costs a slightly
+odd message, being wrong costs the turn.
+"""
+import json
+import logging
+from typing import Any, Dict, List
+
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
+
+from app.agents.leonardo.agent_factory import (
+    emitted_tool_calls,
+    repair_orphaned_tool_calls_in_messages,
+)
+
+logger = logging.getLogger(__name__)
+
+#: Block types every provider we ship against accepts inside a content list.
+SUPPORTED_BLOCK_TYPES = frozenset({
+    "text", "image", "image_url", "input_image", "video", "video_url",
+    "file", "document", "input_file", "thinking", "redacted_thinking",
+    "reasoning", "tool_use", "tool_result", "cache_control",
+})
+
+#: What an assistant turn with no text becomes. An empty string is rejected
+#: outright by several providers; a space is not, and says nothing.
+_EMPTY_AI_PLACEHOLDER = "(no content)"
+
+_NO_USER_MESSAGE = (
+    "<NOTE_FROM_SYSTEM>Continue from the conversation above.</NOTE_FROM_SYSTEM>"
+)
+
+
+def _is_role(msg, role: str) -> bool:
+    if isinstance(msg, dict):
+        return msg.get("role") == role
+    return getattr(msg, "type", None) == role
+
+
+def _content_of(msg):
+    if isinstance(msg, dict):
+        return msg.get("content")
+    return getattr(msg, "content", None)
+
+
+def _with_content(msg, content):
+    if isinstance(msg, dict):
+        out = dict(msg)
+        out["content"] = content
+        return out
+    try:
+        return msg.model_copy(update={"content": content})
+    except Exception:  # noqa: BLE001 - never let a repair break the turn
+        return msg
+
+
+def _normalize_block(block):
+    """Return a block the provider will accept, or None to drop it."""
+    if isinstance(block, str):
+        return {"type": "text", "text": block} if block.strip() else None
+    if not isinstance(block, dict):
+        # A bare object in a content list is the `content did not match any
+        # supported type` 400. Stringify rather than drop: it may be data the
+        # agent needs.
+        try:
+            return {"type": "text", "text": json.dumps(block, default=str)}
+        except Exception:  # noqa: BLE001
+            return {"type": "text", "text": str(block)}
+
+    block_type = block.get("type")
+    if block_type in SUPPORTED_BLOCK_TYPES:
+        return block
+    if block_type is None:
+        # Untyped dict — treat it as text if it plausibly is, else stringify.
+        if "text" in block:
+            return {"type": "text", "text": str(block["text"])}
+        return {"type": "text", "text": json.dumps(block, default=str)}
+
+    logger.warning(
+        "message_invariants: stringifying unsupported content block type %r",
+        block_type,
+    )
+    return {"type": "text", "text": json.dumps(block, default=str)}
+
+
+def _normalize_content(msg):
+    """Coerce one message's content into something a provider accepts.
+
+    Returns the message unchanged when it already is.
+    """
+    content = _content_of(msg)
+
+    if isinstance(content, list):
+        blocks = [b for b in (_normalize_block(b) for b in content) if b is not None]
+        if not blocks:
+            # A content list that normalized down to nothing is the empty-content
+            # 400 in a different costume.
+            if _is_role(msg, "ai") and emitted_tool_calls(msg):
+                return _with_content(msg, "")  # tool-call-only turns may be empty
+            return _with_content(msg, _EMPTY_AI_PLACEHOLDER)
+        if blocks == list(content):
+            return msg
+        return _with_content(msg, blocks)
+
+    if content is None:
+        return _with_content(msg, "" if _is_role(msg, "ai") else _EMPTY_AI_PLACEHOLDER)
+
+    if isinstance(content, str):
+        if content.strip():
+            return msg
+        # Empty string. Legal on an assistant turn that is only tool calls;
+        # rejected by several providers everywhere else.
+        if _is_role(msg, "ai") and emitted_tool_calls(msg):
+            return msg
+        if _is_role(msg, "tool"):
+            return _with_content(msg, "(the tool returned nothing)")
+        return _with_content(msg, _EMPTY_AI_PLACEHOLDER)
+
+    return _with_content(msg, str(content))
+
+
+def _has_user_or_tool(messages) -> bool:
+    return any(_is_role(m, "human") or _is_role(m, "tool") for m in messages)
+
+
+def normalize_messages_for_provider(messages: List[Any]) -> List[Any]:
+    """Enforce every invariant a provider actually checks, in one place.
+
+    1. Every announced ``tool_calls`` id is answered by a ``tool`` message, and
+       every ``tool`` message answers something (delegated to
+       :func:`repair_orphaned_tool_calls_in_messages`, which owns that rule).
+    2. Every ``content`` is a supported type.
+    3. No message carries empty content where the provider forbids it.
+    4. At least one ``user``/``tool`` message is present.
+
+    Idempotent, and returns the SAME list object when nothing needed changing so
+    callers can cheaply detect "no change".
+    """
+    try:
+        repaired = repair_orphaned_tool_calls_in_messages(list(messages))
+    except Exception:  # noqa: BLE001
+        logger.exception("message_invariants: tool-call repair failed; skipping it")
+        repaired = list(messages)
+
+    changed = repaired is not messages
+    out = []
+    for msg in repaired:
+        fixed = _normalize_content(msg)
+        changed = changed or (fixed is not msg)
+        out.append(fixed)
+
+    # A history with nothing but system/assistant messages is rejected outright:
+    # "`messages` must contain at least one message with role `user` or `tool`".
+    # Seen on the question-card resume path across 4 boxes.
+    if out and not _has_user_or_tool(out):
+        logger.warning(
+            "message_invariants: no user/tool message in a %d-message history; "
+            "appending a continuation note so the provider accepts it",
+            len(out),
+        )
+        out.append(HumanMessage(content=_NO_USER_MESSAGE))
+        changed = True
+
+    return out if changed else messages
+
+
+# ---------------------------------------------------------------------------
+# Diagnosis — what did we actually send?
+# ---------------------------------------------------------------------------
+#
+# P1-3: our DEFAULT model (muse-spark-1.2-contributor) returns a bare
+# `400 invalid_request_error` with `'param': None` — 32 occurrences on 7 boxes in
+# 7 days, the largest live LlamaBot error class, and nothing in the payload to act
+# on from the mothership. So when a provider rejects a request, describe the SHAPE
+# of what we sent. Content is deliberately never included: we need the shape, not
+# the text.
+
+def describe_message_shape(messages, *, tools=None, model=None) -> Dict[str, Any]:
+    """A redacted, structural description of a model request, for error reports."""
+    per_message = []
+    total_chars = 0
+    for index, msg in enumerate(messages or []):
+        content = _content_of(msg)
+        if isinstance(content, list):
+            content_kind = "list"
+            parts = [
+                (b.get("type") if isinstance(b, dict) else type(b).__name__)
+                for b in content
+            ]
+            chars = sum(len(str(b)) for b in content)
+        elif isinstance(content, str):
+            content_kind = "str"
+            parts = []
+            chars = len(content)
+        else:
+            content_kind = type(content).__name__
+            parts = []
+            chars = len(str(content or ""))
+        total_chars += chars
+
+        calls = emitted_tool_calls(msg) if _is_role(msg, "ai") else []
+        entry = {
+            "i": index,
+            "role": (msg.get("role") if isinstance(msg, dict)
+                     else getattr(msg, "type", type(msg).__name__)),
+            "content": content_kind,
+            "chars": chars,
+            "empty": chars == 0,
+        }
+        if parts:
+            entry["blocks"] = parts
+        if calls:
+            entry["tool_calls"] = [c.get("name") for c in calls]
+            entry["tool_call_ids"] = [c.get("id") for c in calls]
+        tool_call_id = getattr(msg, "tool_call_id", None) or (
+            msg.get("tool_call_id") if isinstance(msg, dict) else None
+        )
+        if tool_call_id:
+            entry["tool_call_id"] = tool_call_id
+        per_message.append(entry)
+
+    announced = {
+        cid
+        for m in (messages or []) if _is_role(m, "ai")
+        for cid in (c.get("id") for c in emitted_tool_calls(m)) if cid
+    }
+    answered = {
+        (getattr(m, "tool_call_id", None) or (m.get("tool_call_id") if isinstance(m, dict) else None))
+        for m in (messages or []) if _is_role(m, "tool")
+    }
+    answered.discard(None)
+
+    return {
+        "model": model,
+        "message_count": len(messages or []),
+        "total_content_chars": total_chars,
+        "approx_tokens": total_chars // 4,
+        "tool_count": len(tools or []),
+        "has_user_or_tool": _has_user_or_tool(messages or []),
+        "unanswered_tool_call_ids": sorted(announced - answered),
+        "unanchored_tool_message_ids": sorted(answered - announced),
+        "messages": per_message,
+    }
+
+
+def looks_like_bad_request(exc) -> bool:
+    """True for a provider rejecting the request itself (a 400), not a transport blip."""
+    if exc.__class__.__name__ in ("BadRequestError", "InvalidRequestError",
+                                  "UnprocessableEntityError"):
+        return True
+    status = getattr(exc, "status_code", None) or getattr(exc, "code", None)
+    return status in (400, 422)
+
+
+def log_bad_request_shape(exc, messages, *, tools=None, model=None, label: str = "") -> Dict[str, Any]:
+    """Log (and return) the shape of a request a provider rejected.
+
+    Returned so the caller can attach it to a ``report_error`` payload; the
+    mothership has nothing else to go on when the provider says ``'param': None``.
+    """
+    shape = describe_message_shape(messages, tools=tools, model=model)
+    try:
+        logger.error(
+            "Provider rejected the request (%s) %s — request shape: %s",
+            exc.__class__.__name__, label, json.dumps(shape, default=str)[:8000],
+        )
+    except Exception:  # noqa: BLE001
+        logger.error("Provider rejected the request (%s) %s", exc.__class__.__name__, label)
+    try:
+        exc.llamabot_request_shape = shape
+    except Exception:  # noqa: BLE001 - some exception types forbid attributes
+        pass
+    return shape

--- a/app/agents/leonardo/message_invariants.py
+++ b/app/agents/leonardo/message_invariants.py
@@ -159,11 +159,15 @@ def normalize_messages_for_provider(messages: List[Any]) -> List[Any]:
     Idempotent, and returns the SAME list object when nothing needed changing so
     callers can cheaply detect "no change".
     """
+    # NOT ``list(messages)``: repair_orphaned_tool_calls_in_messages returns the
+    # SAME list object when it changes nothing, and a defensive copy here would
+    # throw that signal away — every call would then look "changed" and no caller
+    # could detect a no-op. It does not mutate what it is given.
     try:
-        repaired = repair_orphaned_tool_calls_in_messages(list(messages))
+        repaired = repair_orphaned_tool_calls_in_messages(messages)
     except Exception:  # noqa: BLE001
         logger.exception("message_invariants: tool-call repair failed; skipping it")
-        repaired = list(messages)
+        repaired = messages
 
     changed = repaired is not messages
     out = []

--- a/app/agents/leonardo/project_context.py
+++ b/app/agents/leonardo/project_context.py
@@ -173,7 +173,12 @@ def resolve_base_prompt(static_default: str, agent_mode: Optional[str]) -> str:
 
     ``agent_mode=None`` short-circuits to the static default — preserving today's
     behavior exactly for callers that don't pass a mode.
+
+    Whichever prompt wins, its gated sections are resolved before it is returned,
+    so the prompt can never advertise a tool this box does not have.
     """
+    from app.agents.leonardo.prompt_gates import apply_prompt_gates
+
     if agent_mode:
         cached = system_prompt_cache.get_cached(agent_mode)  # None on miss / any error
         if cached and len(cached) >= MIN_PROMPT_LEN:
@@ -181,8 +186,11 @@ def resolve_base_prompt(static_default: str, agent_mode: Optional[str]) -> str:
                 f"Using mothership-delivered system prompt for agent_mode={agent_mode} "
                 f"({len(cached)} chars)"
             )
-            return cached
-    return static_default
+            return apply_prompt_gates(cached)
+    # Every base prompt passes through the gates here — one choke point, so a
+    # section describing a tool that is switched off on this box can never reach
+    # the model. See app/agents/leonardo/prompt_gates.py.
+    return apply_prompt_gates(static_default)
 
 
 def build_system_prompt_with_project_context(

--- a/app/agents/leonardo/prompt_gates.py
+++ b/app/agents/leonardo/prompt_gates.py
@@ -1,0 +1,92 @@
+"""One source of truth for "is this tool actually available on this box".
+
+A prompt that documents a tool the registry does not have is a bug class, not a
+one-off. `browser_inspect` is gated by the ``enable_browser_inspect`` site
+setting, which defaults to off — but both Rails prompts described it
+unconditionally, so on a default box the agent dutifully called it and got
+``Error: browser_inspect is not a valid tool``. It reported that itself, eight
+times across seven boxes, and each time fell back to guessing whether the page
+it had just written actually rendered.
+
+The fix is to key BOTH the tool list and the prompt off the same predicate.
+Wrap the gated part of a prompt in a marker pair::
+
+    <!--IF:browser_inspect-->
+    ### Self-Checking Pages with browser_inspect
+    ...
+    <!--END:browser_inspect-->
+
+and :func:`apply_prompt_gates` removes the whole block when the gate is off.
+Blocks for unknown gate names are left alone (a mothership-delivered prompt
+override may name a gate this build has never heard of; silently deleting its
+content would be worse than leaving a marker visible).
+
+Gate predicates must fail CLOSED — an unreadable site setting means "the tool is
+not there", which is exactly what the tool list concludes, so the two can never
+disagree.
+"""
+import logging
+import re
+from typing import Callable, Dict
+
+logger = logging.getLogger(__name__)
+
+_BLOCK_RE = re.compile(
+    r"[ \t]*<!--\s*IF:(?P<name>[A-Za-z0-9_]+)\s*-->.*?<!--\s*END:(?P=name)\s*-->[ \t]*\n?",
+    re.DOTALL,
+)
+
+
+def _browser_inspect_gate() -> bool:
+    from app.agents.leonardo.rails_agent.tools import browser_inspect_enabled
+    return browser_inspect_enabled()
+
+
+def _live_browser_tools_gate() -> bool:
+    from app.agents.leonardo.rails_agent.tools import live_browser_tools_enabled
+    return live_browser_tools_enabled()
+
+
+# name -> the SAME predicate the tool list uses. Imported lazily inside each
+# predicate: this module is imported by project_context, which tools.py itself
+# reaches through.
+GATES: Dict[str, Callable[[], bool]] = {
+    "browser_inspect": _browser_inspect_gate,
+    "live_browser_tools": _live_browser_tools_gate,
+}
+
+
+def gate_is_open(name: str) -> bool:
+    predicate = GATES.get(name)
+    if predicate is None:
+        return True  # unknown gate: leave the block alone
+    try:
+        return bool(predicate())
+    except Exception:  # noqa: BLE001 - fail closed, exactly like the tool list
+        logger.warning("Prompt gate %r could not be read; treating it as off.", name)
+        return False
+
+
+def apply_prompt_gates(prompt: str) -> str:
+    """Strip every ``<!--IF:name-->...<!--END:name-->`` block whose gate is off.
+
+    Open gates keep their content and lose only the markers, so an enabled tool
+    reads exactly as it did before this existed.
+    """
+    if not prompt or "<!--IF:" not in prompt.replace(" ", ""):
+        return prompt
+
+    open_cache: Dict[str, bool] = {}
+
+    def _replace(match: re.Match) -> str:
+        name = match.group("name")
+        if name not in open_cache:
+            open_cache[name] = gate_is_open(name)
+        if not open_cache[name]:
+            return ""
+        body = match.group(0)
+        body = re.sub(r"[ \t]*<!--\s*IF:%s\s*-->[ \t]*\n?" % re.escape(name), "", body)
+        body = re.sub(r"[ \t]*<!--\s*END:%s\s*-->[ \t]*\n?" % re.escape(name), "", body)
+        return body
+
+    return _BLOCK_RE.sub(_replace, prompt)

--- a/app/agents/leonardo/rails_agent/middleware.py
+++ b/app/agents/leonardo/rails_agent/middleware.py
@@ -399,6 +399,27 @@ class DeepSeekReasoningMiddleware(AgentMiddleware):
 # tests reaching mw._MODEL_RETRY_MAX_ATTEMPTS) resolve unchanged.
 
 
+def _record_bad_request_shape(exc, request, llm_model):
+    """Attach a redacted description of a rejected request to the exception."""
+    from app.agents.leonardo.message_invariants import (
+        log_bad_request_shape,
+        looks_like_bad_request,
+    )
+
+    if not looks_like_bad_request(exc):
+        return
+    try:
+        log_bad_request_shape(
+            exc,
+            list(getattr(request, "messages", None) or []),
+            tools=getattr(request, "tools", None),
+            model=llm_model,
+            label=f"model={llm_model}",
+        )
+    except Exception:  # noqa: BLE001 - diagnosis must never mask the real error
+        logger.debug("could not describe the rejected request", exc_info=True)
+
+
 class DynamicModelMiddleware(AgentMiddleware):
     """Middleware that dynamically switches LLM based on state.llm_model.
 
@@ -437,6 +458,12 @@ class DynamicModelMiddleware(AgentMiddleware):
             except Exception as e:
                 attempt += 1
                 if attempt >= _MODEL_RETRY_MAX_ATTEMPTS or not is_transient_error(e):
+                    # A provider that rejects the REQUEST tells us nothing
+                    # actionable ("'param': None" — 32 occurrences on 7 boxes in
+                    # 7 days for our own default model). Describe the shape of
+                    # what we sent, redacted, so the fleet report has something
+                    # to diagnose from.
+                    _record_bad_request_shape(e, req, llm_model)
                     raise
                 logger.warning(
                     f"Transient model error on {llm_model} (attempt {attempt}/"
@@ -460,6 +487,12 @@ class DynamicModelMiddleware(AgentMiddleware):
             except Exception as e:
                 attempt += 1
                 if attempt >= _MODEL_RETRY_MAX_ATTEMPTS or not is_transient_error(e):
+                    # A provider that rejects the REQUEST tells us nothing
+                    # actionable ("'param': None" — 32 occurrences on 7 boxes in
+                    # 7 days for our own default model). Describe the shape of
+                    # what we sent, redacted, so the fleet report has something
+                    # to diagnose from.
+                    _record_bad_request_shape(e, req, llm_model)
                     raise
                 logger.warning(
                     f"Transient model error on {llm_model} (attempt {attempt}/"

--- a/app/agents/leonardo/rails_agent/nodes.py
+++ b/app/agents/leonardo/rails_agent/nodes.py
@@ -23,7 +23,7 @@ from langchain_core.messages import SystemMessage
 
 from app.agents.leonardo.rails_agent.state import RailsAgentState
 from app.agents.leonardo.rails_agent.tools import (
-    write_todos, ls, read_file, write_file, edit_file,
+    write_todos, ls, read_file, write_file, edit_file, check_page,
     glob_files, grep_files,
     bash_command, tail_rails_logs, hard_restart_rails, fix_permissions,
     git_status, git_commit, git_command, github_cli_command, internet_search,
@@ -173,7 +173,7 @@ When summarizing the conversation, focus on Ruby on Rails code changes including
 # Tool list - all tools available to the Rails agent
 default_tools = [
     write_todos,
-    ls, read_file, write_file, edit_file,
+    ls, read_file, write_file, edit_file, check_page,
     glob_files, grep_files,
     bash_command,
     tail_rails_logs,

--- a/app/agents/leonardo/rails_agent/prompts.py
+++ b/app/agents/leonardo/rails_agent/prompts.py
@@ -354,6 +354,14 @@ Every UI you touch should clear this bar before you mark a TODO complete:
 5. Refine view to use real data
 ```
 
+### Migrations: Run It or the App Is Down
+
+**Never end a turn with an unrun migration.** Rails checks for pending migrations on every request, so one unrun migration does not break one page — it breaks *every* page of the user's app, immediately, with a stack trace.
+
+- Write a migration, run it in the same turn. `write_file`/`edit_file` on anything under `db/migrate/` runs `bin/rails db:migrate` for you and reports the result — read that result.
+- If it fails, the app is down. Fix the migration; do not move on, and do not tell the user the feature is ready.
+- Never write a second migration for a change the first one already covers — edit the existing one. Two migrations for one change is `ActiveRecord::DuplicateMigrationNameError`.
+
 ### When the User Is on a Specific Page
 
 If `<CONTEXT>` indicates the user is on, e.g., `/tenders/5/builder`, and they ask for ANY change:
@@ -1364,6 +1372,19 @@ The chat interface has a debug recording feature hidden behind the **+** button 
 
 Tell the user: "Add some `console.log('🪲 DEBUG:', yourVariable)` statements where you think the issue is. Then click the **+** button next to the chat input, click the bug icon 🐛 (it'll turn red), and reproduce the problem. The logs will appear in your message box — just hit send and I'll help debug."
 
+### Load Every Page You Touch (Do This — Don't Wait for the User)
+
+After writing or editing any view, controller, route, helper or partial, call `check_page` on the route it affects. If it does not come back 2xx, fix it before you reply to the user.
+
+```
+check_page(path="/leads")
+```
+
+It returns the status, and on a failure the exception class, message and the first app frames of the backtrace. It is cheap — no browser, no screenshot — so call it freely. The app answers on `http://llamapress:3000` from inside the container; `check_page` already knows that, so pass the path only.
+
+A 302 means the route works but redirected you (usually to a login page). That is not a bug, but it did not prove the page renders — sign in the way the app expects, or check a page that does not require it.
+
+<!--IF:browser_inspect-->
 ### Self-Verifying UI Changes with browser_inspect (Do This — Don't Wait for the User)
 
 After editing any view, JS, or CSS file, call the `browser_inspect` tool to verify the page renders correctly. You don't need to ask the user to test it — do it yourself.
@@ -1382,6 +1403,22 @@ Returns: HTTP status, page title, all console errors, network failures (CDN miss
 - After any `.html.erb`, `.js`, `.css` edit — confirm the page loads without JS errors
 - When a JS library or Stimulus controller might not have mounted — check with selectors + js_evaluate
 - When the user reports "the page looks broken" or "something isn't working" — see the actual page
+<!--END:browser_inspect-->
+
+### Never Call a Method on Something That Might Be Nil
+
+`undefined method 'any?' for nil` and `undefined method '[]' for nil` are the two most common ways a page you just wrote 500s. Two rules:
+
+1. A view must not call a method on a value that may be nil. Guard it.
+2. A controller must assign every instance variable its view reads, on **every** path — including the early returns.
+
+```erb
+<%# wrong — @comments is nil when the controller returned early %>
+<% if @comments.any? %>
+
+<%# right %>
+<% if @comments.present? %>
+```
 
 ### Viewing Logs Manually
 **Rails logs:** Guide user to run `./bin/rails_logs` in Leonardo terminal
@@ -1794,6 +1831,8 @@ Usage:
 - The edit will FAIL if `old_string` is not unique in the file. Either provide a larger string with more surrounding context to make it unique or use `replace_all` to change every instance of `old_string`.
 - Use `replace_all` for replacing and renaming strings across the file. This parameter is useful if you want to rename a variable for instance.
 - You may need to escape quotes in the old_string to match properly, especially for longer multi-line strings.
+- **One edit per file per response.** Several `edit_file` calls in one response run at the same time and all read the same starting content, so later edits are written against a file that no longer looks like that. Make several changes to one file either as one larger edit, or one at a time across responses. Editing DIFFERENT files in one response is fine.
+- Success means the bytes are on disk: this tool re-reads the file and will tell you plainly if the edit did not persist. If it says the edit did not land, it did not land — re-read the file, do not carry on as if it had.
 
 If a tool call fails with an error or "old_string not found," you must stop retrying.
 Instead:
@@ -1814,7 +1853,7 @@ Usage:
 - You can optionally specify a line offset and limit (especially handy for long files), but it's recommended to read the whole file by not providing these parameters
 - Any lines longer than 2000 characters will be truncated
 - Results are returned using cat -n format, with line numbers starting at 1
-- You have the capability to call multiple tools in a single response. It is always better to speculatively read multiple files as a batch that are potentially useful.
+- You have the capability to call multiple tools in a single response. It is always better to speculatively read multiple files as a batch that are potentially useful. Batch READS freely; batch WRITES only across DIFFERENT files. Two edits to the same file in one response are edits to the same base content — sequence them instead.
 - If you read a file that exists but has empty contents you will receive a system reminder warning in place of file contents."""
 
 LIST_DIRECTORY_DESCRIPTION = """

--- a/app/agents/leonardo/rails_agent/sub_agents.py
+++ b/app/agents/leonardo/rails_agent/sub_agents.py
@@ -43,6 +43,7 @@ from app.agents.leonardo.llm_factory import get_llm, system_message_for_model
 from app.agents.leonardo.model_policy import enabled_default_model
 from app.agents.leonardo.delegation import (
     DELEGATION_TIMEOUT_SECONDS,
+    summarize_partial_work,
     DelegationTimedOut,
     run_delegation,
 )
@@ -321,15 +322,20 @@ async def delegate_task(
             ]
         })
 
-    except DelegationTimedOut:
+    except DelegationTimedOut as timeout:
         logger.warning("Sub-agent delegation timed out")
+        # Report what it got done. The sub-agent has usually already edited
+        # files; without this the parent must re-read the tree, or retry and
+        # edit them twice. A partial report is recoverable, nothing is not.
         return Command(update={
             "messages": [
                 ToolMessage(
                     content=(
-                        "[DELEGATED TASK FAILED]\n\n"
-                        f"Timed out after {DELEGATION_TIMEOUT_SECONDS}s — you may retry "
-                        "delegate_task once."
+                        "[DELEGATED TASK TIMED OUT]\n\n"
+                        f"It ran out of time after {DELEGATION_TIMEOUT_SECONDS}s. "
+                        "Anything listed below was already done — do NOT redo it. Pick "
+                        "up from here yourself, or delegate only what is left.\n\n"
+                        + summarize_partial_work(timeout.partial_messages)
                     ),
                     tool_call_id=tool_call_id
                 )
@@ -494,15 +500,16 @@ async def delegate_research(
             ]
         })
 
-    except DelegationTimedOut:
+    except DelegationTimedOut as timeout:
         logger.warning("Research sub-agent delegation timed out")
         return Command(update={
             "messages": [
                 ToolMessage(
                     content=(
-                        "[RESEARCH FAILED]\n\n"
-                        f"Timed out after {DELEGATION_TIMEOUT_SECONDS}s — you may retry "
-                        "delegate_research once."
+                        "[RESEARCH TIMED OUT]\n\n"
+                        f"It ran out of time after {DELEGATION_TIMEOUT_SECONDS}s. "
+                        "What it had looked at so far:\n\n"
+                        + summarize_partial_work(timeout.partial_messages)
                     ),
                     tool_call_id=tool_call_id
                 )

--- a/app/agents/leonardo/rails_agent/tool_prompts.py
+++ b/app/agents/leonardo/rails_agent/tool_prompts.py
@@ -533,3 +533,22 @@ Call at most ONE browser tool per turn, and never in parallel with other tool ca
 Use expressions that produce a value, e.g. `document.title`, `document.querySelectorAll('[data-controller]').length`, or `fetch('/health').then(r => r.status)`.
 Prefer read-only inspection; this runs in the user's real session, so avoid destructive actions unless the user asked for them.
 """
+
+
+CHECK_PAGE_DESCRIPTION = """Load one page of the user's Rails app and report whether it actually rendered.
+
+This is your always-available page verifier. Use it after writing or editing ANY
+view, controller, route, helper or partial — before you tell the user you are done.
+
+Parameters:
+- path: the route to load, e.g. "/", "/leads", "/projects/1". A full URL is also
+  accepted but must point at the user's own app.
+
+Returns the HTTP status, and — when the page did not render — the exception class,
+the message, and the first few backtrace lines pulled from the Rails log. That is
+usually enough to fix it without opening anything else.
+
+Cheap and quiet: no browser, no screenshot, tiny output. Call it freely.
+
+A redirect (302) means the route works but sent you somewhere else (usually a login
+page); it is not an error, but it did not prove the page renders."""

--- a/app/agents/leonardo/rails_agent/tools.py
+++ b/app/agents/leonardo/rails_agent/tools.py
@@ -35,6 +35,7 @@ from app.agents.leonardo.rails_agent.tool_prompts import (
     WRITE_LEONARDO_MD_DESCRIPTION,
     TAIL_RAILS_LOGS_DESCRIPTION,
     HARD_RESTART_RAILS_DESCRIPTION,
+    CHECK_PAGE_DESCRIPTION,
     FIX_PERMISSIONS_DESCRIPTION,
     BROWSER_INSPECT_DESCRIPTION,
     NAVIGATE_BROWSER_DESCRIPTION,
@@ -415,6 +416,125 @@ def normalize_whitespace(s: str) -> str:
     return s.strip()
 
 
+def _drop_line_indentation(chars: list, spans: list):
+    """Remove the single leading space at each line start (post-normalization).
+
+    ``normalize_whitespace`` collapses a run of spaces/tabs to ONE space, so an
+    indented line still starts with a space and an agent that gets indentation
+    wrong still fails to match. Matching ignores that leading space; the raw span
+    is contiguous, so the file's own indentation inside the region is untouched.
+    """
+    out_chars: list = []
+    out_spans: list = []
+    at_line_start = True
+    for c, span in zip(chars, spans):
+        if at_line_start and c == " ":
+            continue  # skip indentation for matching purposes only
+        out_chars.append(c)
+        out_spans.append(span)
+        at_line_start = c == "\n"
+    return out_chars, out_spans
+
+
+def _normalized_spans(text: str, *, ignore_indentation: bool = False):
+    """``normalize_whitespace(text)`` plus, per output char, its raw span.
+
+    ``edit_file``'s "normalized" match path used to hand
+    ``content.replace(normalized_old, ...)`` a string that had been normalized —
+    which, by definition, is usually NOT present in the raw file. The replace
+    matched nothing, the file was written back unchanged, and the tool reported
+    ``Successfully replaced string (match type: normalized)``. That silent no-op
+    is what blanked a customer's Sales Funnel page: the agent believed the fix
+    had landed and moved on (8 friction reports, 6 boxes, 30 days).
+
+    This maps the normalized text back onto the real bytes, so a normalized match
+    can be applied to the region it actually corresponds to.
+
+    Mirrors ``normalize_whitespace`` exactly: CRLF -> LF, runs of spaces/tabs ->
+    one space, runs of 3+ newlines -> two, then strip.
+    """
+    chars: list = []
+    spans: list = []
+    i, n = 0, len(text)
+    while i < n:
+        c = text[i]
+        if c == "\r" and i + 1 < n and text[i + 1] == "\n":
+            chars.append("\n")
+            spans.append((i, i + 2))
+            i += 2
+        elif c in " \t":
+            start = i
+            while i < n and text[i] in " \t":
+                i += 1
+            chars.append(" ")
+            spans.append((start, i))
+        else:
+            chars.append(c)
+            spans.append((i, i + 1))
+            i += 1
+
+    # Collapse runs of 3+ newlines down to two (the surviving pair keeps the
+    # span of the whole run, so a replacement covers all of it).
+    collapsed_chars: list = []
+    collapsed_spans: list = []
+    j = 0
+    while j < len(chars):
+        if chars[j] == "\n":
+            k = j
+            while k < len(chars) and chars[k] == "\n":
+                k += 1
+            run = k - j
+            keep = min(run, 2)
+            for offset in range(keep):
+                collapsed_chars.append("\n")
+                if offset == keep - 1:
+                    collapsed_spans.append((spans[j + offset][0], spans[k - 1][1]))
+                else:
+                    collapsed_spans.append(spans[j + offset])
+            j = k
+        else:
+            collapsed_chars.append(chars[j])
+            collapsed_spans.append(spans[j])
+            j += 1
+
+    if ignore_indentation:
+        collapsed_chars, collapsed_spans = _drop_line_indentation(
+            collapsed_chars, collapsed_spans
+        )
+
+    # .strip()
+    start_i, end_i = 0, len(collapsed_chars)
+    while start_i < end_i and collapsed_chars[start_i].isspace():
+        start_i += 1
+    while end_i > start_i and collapsed_chars[end_i - 1].isspace():
+        end_i -= 1
+
+    return "".join(collapsed_chars[start_i:end_i]), collapsed_spans[start_i:end_i]
+
+
+def locate_normalized_span(content: str, old_string: str, *, ignore_indentation: bool = False):
+    """Raw ``(start, end)`` in ``content`` matching ``old_string`` modulo whitespace.
+
+    Returns ``None`` when there is no such region, or when there is more than one
+    (ambiguous: picking one silently is how you edit the wrong method). Refusing
+    an ambiguous match is deliberate — the caller falls through to a truthful
+    "could not find it", which costs one retry.
+    """
+    needle_chars, _ = _normalized_spans(old_string, ignore_indentation=ignore_indentation)
+    needle = "".join(needle_chars) if isinstance(needle_chars, list) else needle_chars
+    if not needle:
+        return None
+
+    normalized, spans = _normalized_spans(content, ignore_indentation=ignore_indentation)
+    first = normalized.find(needle)
+    if first == -1:
+        return None
+    if normalized.find(needle, first + 1) != -1:
+        return None
+
+    return spans[first][0], spans[first + len(needle) - 1][1]
+
+
 # NOTE: Auto-checkpoint functionality has been disabled.
 # Users now manually create checkpoints via the History panel UI.
 # The checkpoint_service is still used by the /api/checkpoints endpoint for manual creation.
@@ -536,10 +656,31 @@ def write_file(
             }
         )
 
+    verification = verify_write(full_path, content)
+    if verification is not None:
+        error_message = (
+            f"Error: writing '{file_path}' did NOT persist. {verification}\n\n"
+            f"Do not assume this write landed — read the file back and try again."
+        )
+        return Command(
+            update={
+                "messages": [ToolMessage(
+                    error_message,
+                    artifact={"status": "error", "message": error_message},
+                    tool_call_id=runtime.tool_call_id,
+                )],
+                "failed_tool_calls_count": 1,
+            }
+        )
+
     success_message = f"Updated file {file_path}"
 
     if is_new_file:
         success_message += _mount_visibility_warning(file_path)
+
+    # A migration that is written but not run takes the whole app down. Run it
+    # here, at the write, so no mode and no prompt can skip it.
+    success_message += migration_followup(file_path)
 
     tool_output = {
         "status": "success",
@@ -553,6 +694,105 @@ def write_file(
             ],
         }
     )
+
+
+# =============================================================================
+# Pending migrations — run them, never leave them
+# =============================================================================
+#
+# `ActiveRecord::PendingMigrationError` is the highest-occurrence error anywhere
+# in the fleet: 288 occurrences across 21 customer boxes in 7 days (2026-08-23).
+# Rails checks for pending migrations on EVERY request, so one unrun migration
+# does not break one page — it breaks the customer's whole app, instantly, with a
+# stack trace. To a non-technical user that reads as "my app is destroyed".
+#
+# The agent's own write is the trigger, so this is enforced at the write, not in
+# the prompt: a prompt rule is something the agent can talk past, and 288
+# occurrences say it did. Enforcing here also covers every mode at once,
+# including the raw StateGraph ones that run no middleware.
+
+_MIGRATION_TIMEOUT_SECONDS = 180
+
+
+def is_migration_path(file_path: str) -> bool:
+    """True for a Rails migration file — the write that arms this rule."""
+    normalized = str(file_path or "").replace("\\", "/").lstrip("./")
+    return "db/migrate/" in f"/{normalized}" and normalized.endswith(".rb")
+
+
+def run_pending_migrations() -> str:
+    """Run ``db:migrate`` in the Rails container and describe what happened.
+
+    Always returns prose for the agent to read; never raises. A failure has to be
+    reported honestly — a half-applied schema with the agent claiming success is
+    strictly worse than the pending migration it replaced.
+    """
+    try:
+        output = rails_api_sh(
+            "bin/rails db:migrate 2>&1", WORKDIR, _MIGRATION_TIMEOUT_SECONDS
+        )
+    except Exception as e:  # noqa: BLE001
+        output = f"could not run the migration: {e}"
+
+    output = truncate_output((output or "").strip(), 4000)
+    failed = (not output) or bool(
+        re.search(
+            r"(rails aborted!|StandardError|error|Error:|Migration\w*Error|"
+            r"could not run the migration|EXEC ERROR|Bundler::)",
+            output,
+        )
+    ) and "migrated (" not in output
+
+    if failed:
+        return (
+            "\n\n<PENDING_MIGRATION>\n"
+            "You wrote a migration, so `bin/rails db:migrate` was run for you "
+            "automatically — and it FAILED. Until it succeeds, EVERY page of the "
+            "user's app returns ActiveRecord::PendingMigrationError, not just the "
+            "feature you were building.\n\n"
+            "Fix the migration and it will run again on your next write to it, or "
+            "run `bin/rails db:migrate` yourself once you have. Do NOT tell the "
+            "user the feature is ready, and do not write a second migration for "
+            "the same change — edit this one.\n\n"
+            f"Output:\n{output}\n"
+            "</PENDING_MIGRATION>"
+        )
+
+    return (
+        "\n\nRan `bin/rails db:migrate` automatically (an unrun migration breaks "
+        f"every page of the app, not just this feature):\n{output}"
+    )
+
+
+def migration_followup(file_path: str) -> str:
+    """The text to append to a write tool's result, if it touched a migration."""
+    if not is_migration_path(file_path):
+        return ""
+    return run_pending_migrations()
+
+
+def verify_write(full_path: Path, expected: str):
+    """Read the file back and confirm it holds ``expected``. None means it does.
+
+    A write tool that reports success without reading back is reporting an
+    intention. On the fleet that intention was wrong often enough to blank a
+    customer's page (8 friction reports, 6 boxes, 30 days) — and because the
+    agent believed it, it told the customer the fix had landed and moved on.
+    Returns a short reason string when the bytes on disk do not match.
+    """
+    try:
+        actual = full_path.read_text()
+    except Exception as e:  # noqa: BLE001
+        return f"the file could not be read back after writing ({e})"
+
+    if actual == expected:
+        return None
+    if len(actual) != len(expected):
+        return (
+            f"the file on disk is {len(actual)} characters, the content written "
+            f"was {len(expected)}"
+        )
+    return "the file on disk differs from what was written"
 
 
 def _mount_visibility_warning(file_path: str) -> str:
@@ -668,45 +908,30 @@ def _apply_edit(
             }
         )
 
-    # Try exact match first
+    # Match ladder: exact, then whitespace-normalized — and nothing looser.
+    #
+    # There used to be two "fuzzy" rungs that took difflib's longest common
+    # substring when it covered >50-70% of old_string. A longest-common-substring
+    # is not a match; on leo-* boxes it landed mid-string in an unrelated method
+    # and truncated it, while reporting success. A truthful failure costs one
+    # retry. A false success costs a customer's page.
     search_string = old_string
     match_found = old_string in content
     match_type = "exact"
 
-    # If exact match fails, try normalized matching
     if not match_found:
-        normalized_content = normalize_whitespace(content)
-        normalized_old = normalize_whitespace(old_string)
-
-        if normalized_old in normalized_content:
-            # Find the actual substring in the original content that matches the normalized version
-            # We'll use fuzzy matching to locate it
+        # Rung 2: whitespace-normalized. Rung 3 additionally forgives the leading
+        # indentation of each line — the single most common way an agent's
+        # old_string differs from the file it just read.
+        span = (locate_normalized_span(content, old_string)
+                or locate_normalized_span(content, old_string, ignore_indentation=True))
+        if span is not None:
+            # The REAL bytes of that region, not the normalized text — replacing
+            # with the normalized string matches nothing and writes back
+            # unchanged content under a success message.
+            search_string = content[span[0]:span[1]]
             match_found = True
             match_type = "normalized"
-            search_string = normalized_old
-
-            # Use difflib to find the best matching region
-            matcher = difflib.SequenceMatcher(None, content, old_string)
-            match = matcher.find_longest_match(0, len(content), 0, len(old_string))
-
-            if match.size > len(old_string) * 0.7:  # At least 70% match
-                # Extract the actual substring from content
-                search_string = content[match.a:match.a + match.size]
-                match_found = True
-                match_type = "fuzzy"
-
-    # If still no match, try fuzzy matching as last resort
-    if not match_found:
-        matcher = difflib.SequenceMatcher(None, content, old_string)
-        similarity = matcher.ratio()
-
-        if similarity > 0.6:  # 60% similarity threshold
-            match = matcher.find_longest_match(0, len(content), 0, len(old_string))
-
-            if match.size > len(old_string) * 0.5:  # At least 50% of the string
-                search_string = content[match.a:match.a + match.size]
-                match_found = True
-                match_type = "fuzzy"
 
     # If still no match found, provide detailed error with diff
     if not match_found:
@@ -777,6 +1002,25 @@ def _apply_edit(
         new_content = content.replace(search_string, new_string, 1)
         result_msg = f"Successfully replaced string in '{file_path}' (match type: {match_type})"
 
+    # Never report a replacement that did not change anything.
+    if new_content == content:
+        error_message = (
+            f"Error: the edit to '{file_path}' would not change the file — "
+            f"old_string and new_string produce identical content. Nothing was "
+            f"written. Re-read the file and check you are editing what you think "
+            f"you are."
+        )
+        return Command(
+            update={
+                "messages": [ToolMessage(
+                    error_message,
+                    artifact={"status": "error", "message": error_message},
+                    tool_call_id=tool_call_id,
+                )],
+                "failed_tool_calls_count": 1,
+            }
+        )
+
     try:
         full_path.write_text(new_content)
         chown_for_ubuntu(full_path)  # Fix permissions for ubuntu user
@@ -794,7 +1038,29 @@ def _apply_edit(
             }
         )
 
+    # Read-after-write. Say "success" only about bytes we have read back off the
+    # disk. Everything upstream of this line is an intention, not a fact.
+    verification = verify_write(full_path, new_content)
+    if verification is not None:
+        error_message = (
+            f"Error: the edit to '{file_path}' did NOT persist. {verification}\n\n"
+            f"The file on disk does not contain your change. Re-read it and try "
+            f"again — do not assume this edit landed."
+        )
+        return Command(
+            update={
+                "messages": [ToolMessage(
+                    error_message,
+                    artifact={"status": "error", "message": error_message},
+                    tool_call_id=tool_call_id,
+                )],
+                "failed_tool_calls_count": 1,
+            }
+        )
+
     # git_status(tool_call_id) # hacky - this will update the git status page so the user can see the changes.
+    result_msg += migration_followup(file_path)
+
     tool_output = {
         "status": "success",
         "message": result_msg
@@ -1053,6 +1319,10 @@ _EXEC_ENV_ALLOWLIST = frozenset({
     # Where the app calls back to
     "LLAMABOT_API_URL", "LLAMABOT_WEBSOCKET_URL", "LLAMAPRESS_API_URL",
     "RAILS_BASE_URL", "INSTANCE_NAME",
+    # The box's public hostname. The prompts tell the agent to read this to give
+    # the user their shareable URL, and declare it safe to share; scrubbing it
+    # made the documented command return an empty string.
+    "HOSTED_DOMAIN",
 })
 
 #: Cache of container name -> list of env var NAMES it defines. The container's
@@ -1399,6 +1669,176 @@ def tail_rails_logs(
     )
 
 
+# =============================================================================
+# check_page — the always-available page verifier
+# =============================================================================
+#
+# 2026-08-23: the Rails prompts told the agent to self-verify pages with
+# `browser_inspect`, which is gated OFF by default, so on a default box the call
+# came back "browser_inspect is not a valid tool" and the agent shipped the page
+# unverified. The customer-app error stream is dominated by failures a single
+# page load catches instantly (NoMethodError 16 boxes / NameError 13 /
+# ActionView::SyntaxErrorInTemplate 10, in 7 days). `browser_inspect` is heavy
+# for good reason — headless Chromium and a 25-50k-token screenshot — so this is
+# the cheap always-on counterpart: one HTTP GET, and the exception off the Rails
+# log when it fails.
+
+# The base URL that works from INSIDE the container. Shared with the Rails error
+# feed so there is one answer to "where is the app", and named in the prompt as
+# the same string.
+RAILS_BASE_URL = os.getenv("RAILS_BASE_URL", "http://llamapress:3000")
+
+# The whole point is to stay tiny — this tool is called after every view edit.
+CHECK_PAGE_MAX_CHARS = 2500
+CHECK_PAGE_BACKTRACE_LINES = 6
+CHECK_PAGE_TIMEOUT_SECONDS = 20
+
+
+def _rails_exception_from_logs(log_text: str) -> Optional[str]:
+    """Pull the most recent exception out of a Rails log tail.
+
+    Rails logs an unhandled exception as a header line naming the class, then an
+    indented backtrace::
+
+        NoMethodError (undefined method `any?' for nil):
+
+        app/views/comments/index.html.erb:67:in `_app_views...'
+        app/controllers/comments_controller.rb:8:in `index'
+
+    Pure string work so it can be tested without Docker or a Rails app. Returns
+    None when the tail holds no exception, which is itself information: the
+    failure did not come from the app.
+    """
+    if not log_text:
+        return None
+
+    lines = log_text.splitlines()
+    header_re = re.compile(r"^\s*([A-Z][A-Za-z0-9_]*(?:::[A-Z][A-Za-z0-9_]*)*)\s*\((.*)\):\s*$")
+
+    for i in range(len(lines) - 1, -1, -1):
+        match = header_re.match(lines[i])
+        if not match:
+            continue
+        exception_class, message = match.group(1), match.group(2)
+        frames = []
+        for line in lines[i + 1:]:
+            stripped = line.strip()
+            if not stripped:
+                continue
+            # App frames first; stop once the trace leaves the user's code, since
+            # everything after that is framework noise.
+            if not (stripped.startswith("app/") or stripped.startswith("lib/")
+                    or stripped.startswith("config/") or stripped.startswith("db/")):
+                break
+            frames.append(stripped)
+            if len(frames) >= CHECK_PAGE_BACKTRACE_LINES:
+                break
+        report = f"{exception_class}: {message}"
+        if frames:
+            report += "\n" + "\n".join(frames)
+        return report
+
+    return None
+
+
+def _tail_rails_log_text(lines: int = 300) -> str:
+    """Best-effort read of the Rails container's recent log output."""
+    try:
+        container_name = get_rails_container_name()
+        result = subprocess.run(
+            [
+                "curl", "--silent", "--show-error",
+                "--unix-socket", "/var/run/docker.sock",
+                f"http://localhost/containers/{container_name}/logs"
+                f"?stdout=true&stderr=true&tail={lines}",
+            ],
+            capture_output=True, timeout=15,
+        )
+        if result.returncode != 0:
+            return ""
+        return _demultiplex_docker_log_stream(result.stdout)
+    except Exception as e:  # noqa: BLE001 - diagnosis must never raise
+        logging.getLogger(__name__).debug("check_page could not read Rails logs: %s", e)
+        return ""
+
+
+def _check_page_url(path: str) -> str:
+    """Resolve what the model passed into a URL on the user's own app."""
+    path = (path or "").strip()
+    if path.startswith("http://") or path.startswith("https://"):
+        return path
+    if not path.startswith("/"):
+        path = "/" + path
+    return RAILS_BASE_URL + path
+
+
+@tool(description=CHECK_PAGE_DESCRIPTION)
+def check_page(
+    path: str,
+    runtime: ToolRuntime,
+) -> Command:
+    """GET one page of the Rails app and report the status, plus the exception if it broke."""
+    from app.agents.utils.url_guard import UrlNotAllowed, validate_outbound_url
+
+    tool_call_id = runtime.tool_call_id
+    url = _check_page_url(path)
+
+    # Same SSRF guard as browser_inspect: `path` comes from the model, which can
+    # be steered by untrusted page content, so it may only reach the app's own
+    # origin or the public internet.
+    try:
+        validate_outbound_url(url)
+    except UrlNotAllowed as e:
+        return Command(update={"messages": [ToolMessage(
+            f"Refused to load {url}: {e}", tool_call_id=tool_call_id)]})
+
+    try:
+        import httpx
+        response = httpx.get(
+            url, timeout=CHECK_PAGE_TIMEOUT_SECONDS, follow_redirects=False,
+        )
+        status = response.status_code
+    except Exception as e:  # noqa: BLE001
+        # The app not answering at all is a real, reportable result — usually a
+        # boot failure, which the log will name.
+        detail = _rails_exception_from_logs(_tail_rails_log_text())
+        message = f"Could not reach {url}: {e}"
+        if detail:
+            message += f"\n\nMost recent exception in the Rails log:\n{detail}"
+        else:
+            message += (
+                "\n\nNothing in the Rails log explains it — the app may still be "
+                "booting, or the container may be down (try tail_rails_logs)."
+            )
+        return Command(update={"messages": [ToolMessage(
+            truncate_output(message, CHECK_PAGE_MAX_CHARS), tool_call_id=tool_call_id)]})
+
+    if 200 <= status < 300:
+        # Deliberately says nothing else. This runs after every view edit; if it
+        # returned page content it would become the next context-bloat source.
+        return Command(update={"messages": [ToolMessage(
+            f"{status} OK — {url} rendered.", tool_call_id=tool_call_id)]})
+
+    if 300 <= status < 400:
+        location = response.headers.get("location", "(no Location header)")
+        return Command(update={"messages": [ToolMessage(
+            f"{status} redirect — {url} sent you to {location}. The route works, but "
+            f"the page itself did not render (this is usually a login redirect, not a bug).",
+            tool_call_id=tool_call_id)]})
+
+    detail = _rails_exception_from_logs(_tail_rails_log_text())
+    message = f"{status} — {url} did NOT render."
+    if detail:
+        message += f"\n\n{detail}"
+    else:
+        message += (
+            "\n\nNo exception in the recent Rails log. A 404 usually means the route "
+            "is missing (check config/routes.rb); for anything else try tail_rails_logs."
+        )
+    return Command(update={"messages": [ToolMessage(
+        truncate_output(message, CHECK_PAGE_MAX_CHARS), tool_call_id=tool_call_id)]})
+
+
 @tool(description=HARD_RESTART_RAILS_DESCRIPTION)
 def hard_restart_rails(
     runtime: ToolRuntime,
@@ -1549,19 +1989,16 @@ def bash_command(
 ) -> Command:
     """Execute a bash command in the Rails container."""
     tool_call_id = runtime.tool_call_id
-    # Safeguard against secret exfiltration attempts
-    forbidden_patterns = [".env", "ENV["]
-    for pattern in forbidden_patterns:
-        if pattern.lower() in command.lower():
-            result = f"Blocked: use of '{pattern}' is not allowed for security reasons. Contact a LlamaPress admin for guidance in retrieving sensitive .env information."
-            return Command(
-                update={
-                    "messages": [
-                        ToolMessage(result, tool_call_id=tool_call_id)
-                    ],
-                }
-            )
 
+    # NOTE: there used to be a `[".env", "ENV["]` substring blocklist here. It is
+    # gone, and deliberately not replaced with a better pattern: secrets are taken
+    # away at the exec instead (see _EXEC_ENV_ALLOWLIST — every variable the
+    # container defines is blanked unless it is named there). The blocklist could
+    # not win a string match against a shell (`printenv`, `export -p`,
+    # `ruby -e 'p ENV'`, any base64 of those), and meanwhile it blocked ordinary
+    # Ruby: `Rails.env` contains ".env", and the system prompt told the agent to
+    # run `rails runner "puts ENV['HOSTED_DOMAIN']"` — a command the filter then
+    # refused. Two friction reports, both false positives.
     raw_result = rails_api_sh(command, workdir, timeout_seconds)
 
     # Truncate large outputs to prevent context window explosion

--- a/app/agents/leonardo/rails_ai_builder_agent/nodes.py
+++ b/app/agents/leonardo/rails_ai_builder_agent/nodes.py
@@ -25,7 +25,7 @@ from app.agents.leonardo.rails_agent.state import RailsAgentState
 # an explicit llm_model silently ignores the fleet default.
 from app.agents.leonardo.model_policy import enabled_default_model
 from app.agents.leonardo.rails_agent.tools import (
-    write_todos, write_file, read_file, ls, edit_file, glob_files, grep_files, bash_command,
+    write_todos, write_file, read_file, ls, edit_file, check_page, glob_files, grep_files, bash_command,
     ls_agents, read_agent_file, write_agent_file, edit_agent_file,
     read_langgraph_json, edit_langgraph_json,
     read_brand_guide, write_brand_guide,
@@ -34,8 +34,10 @@ from app.agents.leonardo.rails_agent.sub_agents import delegate_research
 from app.agents.leonardo.rails_ai_builder_agent.prompts import RAILS_AI_BUILDER_AGENT_PROMPT
 from app.agents.leonardo.project_context import build_system_prompt_with_project_context, brand_context_section
 from app.agents.leonardo.llm_factory import get_llm, invoke_with_cache, system_message_for_model
-from app.agents.leonardo.agent_factory import repair_orphaned_tool_calls_in_messages
+from app.agents.leonardo.message_invariants import normalize_messages_for_provider
 from app.agents.leonardo.resilience import invoke_with_transient_retry
+from app.agents.leonardo.rails_agent.nodes import SUMMARIZATION_PROMPT
+from app.agents.leonardo.summarization import compact_messages_if_needed
 
 import logging
 logger = logging.getLogger(__name__)
@@ -69,7 +71,7 @@ def get_sys_msg():
 
 default_tools = [
     write_todos,
-    ls, read_file, write_file, edit_file, glob_files, grep_files, bash_command,
+    ls, read_file, write_file, edit_file, check_page, glob_files, grep_files, bash_command,
     delegate_research,  # Read-only sub-agent for codebase investigation
     # Agent file tools
     ls_agents, read_agent_file, write_agent_file, edit_agent_file,
@@ -88,7 +90,16 @@ def leonardo_ai_builder(state: RailsAgentState) -> Command[Literal["tools"]]:
 
    view_path = (state.get('debug_info') or {}).get('view_path')
 
-   messages = [system_message_for_model(get_sys_msg(), llm_model)] + state["messages"]
+   # Context management — this raw StateGraph node runs no AgentMiddleware, so
+   # nothing trims or summarizes it on its own. Same shared middleware every
+   # create_agent mode uses; see app/agents/leonardo/summarization.py.
+   # Compact the conversation only: the system message and the per-turn notes
+   # below are rebuilt every turn and must not be summarized away.
+   convo, compaction_ops = compact_messages_if_needed(
+      state["messages"], summary_prompt=SUMMARIZATION_PROMPT,
+   )
+
+   messages = [system_message_for_model(get_sys_msg(), llm_model)] + convo
 
    if view_path:
       messages = messages + [HumanMessage(content="<NOTE_FROM_SYSTEM> The user is currently viewing their Ruby on Rails webpage route at: " + view_path + " </NOTE_FROM_SYSTEM>")]
@@ -98,12 +109,12 @@ def leonardo_ai_builder(state: RailsAgentState) -> Command[Literal["tools"]]:
    # without this a dangling AIMessage tool_call 400s every later turn
    # ('insufficient tool messages'). SI#112. Covers all cache_control/tools
    # branches since only HumanMessages are appended after this point.
-   messages = repair_orphaned_tool_calls_in_messages(messages)
+   messages = normalize_messages_for_provider(messages)
 
    # Tools
    tools = [
       write_todos,
-      ls, read_file, write_file, edit_file, glob_files, grep_files, bash_command,
+      ls, read_file, write_file, edit_file, check_page, glob_files, grep_files, bash_command,
       delegate_research,  # Read-only sub-agent for codebase investigation
       # Agent file tools
       ls_agents, read_agent_file, write_agent_file, edit_agent_file,
@@ -119,9 +130,11 @@ def leonardo_ai_builder(state: RailsAgentState) -> Command[Literal["tools"]]:
       response = invoke_with_transient_retry(
          lambda: invoke_with_cache(llm, messages, llm_model),
          label=f"rails_ai_builder_agent/{llm_model}",
+         messages=messages,
       )
       # Reset counter by subtracting current count (since reducer uses operator.add)
-      return {"messages": [response], "failed_tool_calls_count": -failed_tool_calls_count} # by adding a negative number, we subtract the current count and reset it to 0.
+      # compaction_ops first, or the node re-summarizes from scratch every call.
+      return {"messages": compaction_ops + [response], "failed_tool_calls_count": -failed_tool_calls_count} # by adding a negative number, we subtract the current count and reset it to 0.
 
    # Bind tools - parallel_tool_calls is not supported by Gemini
    if llm_model.startswith("gemini"):
@@ -132,8 +145,9 @@ def leonardo_ai_builder(state: RailsAgentState) -> Command[Literal["tools"]]:
    response = invoke_with_transient_retry(
       lambda: invoke_with_cache(llm_with_tools, messages, llm_model),
       label=f"rails_ai_builder_agent/{llm_model}",
+      messages=messages, tools=tools,
    )
-   return {"messages": [response]}
+   return {"messages": compaction_ops + [response]}
 
 # Graph
 def build_workflow(checkpointer=None):

--- a/app/agents/leonardo/rails_beginner_agent/nodes.py
+++ b/app/agents/leonardo/rails_beginner_agent/nodes.py
@@ -20,7 +20,7 @@ from app.agents.leonardo.rails_agent.state import RailsAgentState
 # an explicit llm_model silently ignores the fleet default.
 from app.agents.leonardo.model_policy import enabled_default_model
 from app.agents.leonardo.rails_agent.tools import (
-    write_todos, write_file, read_file, ls, edit_file, bash_command, tail_rails_logs, hard_restart_rails, fix_permissions,
+    write_todos, write_file, read_file, ls, edit_file, check_page, bash_command, tail_rails_logs, hard_restart_rails, fix_permissions,
     glob_files, grep_files, internet_search,
     read_leonardo_md, write_leonardo_md, edit_leonardo_md,
     read_brand_guide, write_brand_guide,
@@ -34,8 +34,12 @@ from app.agents.leonardo.rails_beginner_agent.prompts import BEGINNER_AGENT_PROM
 from app.agents.leonardo.project_context import build_beginner_system_prompt, brand_context_section
 from app.agents.leonardo.friction import report_friction, with_friction_section
 from app.agents.leonardo.llm_factory import get_llm, system_message_for_model
-from app.agents.leonardo.agent_factory import repair_orphaned_tool_calls_in_messages
+from app.agents.leonardo.message_invariants import normalize_messages_for_provider
 from app.agents.leonardo.resilience import invoke_with_transient_retry
+# Reuse the Rails summarization prompt verbatim (DRY) — beginner mode builds the
+# same kind of app, so it needs the same things carried across a compaction.
+from app.agents.leonardo.rails_agent.nodes import SUMMARIZATION_PROMPT
+from app.agents.leonardo.summarization import compact_messages_if_needed
 
 import logging
 logger = logging.getLogger(__name__)
@@ -105,7 +109,7 @@ def suggest_plan_mode(
 
 default_tools = [
     write_todos,
-    ls, read_file, write_file, edit_file, bash_command, tail_rails_logs, hard_restart_rails, fix_permissions,
+    ls, read_file, write_file, edit_file, check_page, bash_command, tail_rails_logs, hard_restart_rails, fix_permissions,
     glob_files, grep_files, internet_search,
     read_leonardo_md, write_leonardo_md, edit_leonardo_md,
     read_brand_guide, write_brand_guide,  # Brand guide (colors, logos, notes)
@@ -138,7 +142,7 @@ def beginner_turn_tools(browser_inspect_on: bool = False) -> list:
     """
     tools = [
         write_todos,
-        ls, read_file, write_file, edit_file, bash_command, tail_rails_logs, hard_restart_rails,
+        ls, read_file, write_file, edit_file, check_page, bash_command, tail_rails_logs, hard_restart_rails,
         glob_files, grep_files, internet_search,
         read_leonardo_md, write_leonardo_md, edit_leonardo_md,
         list_skills, read_skill, write_skill, edit_skill, delete_skill,
@@ -160,7 +164,22 @@ def leonardo_beginner(state: RailsAgentState, browser_inspect_on: bool = False) 
 
     view_path = (state.get('debug_info') or {}).get('view_path')
 
-    messages = [system_message_for_model(get_sys_msg(), llm_model)] + state["messages"]
+    # Context management. This raw StateGraph node runs NO AgentMiddleware, so
+    # nothing here trims or summarizes on its own — before this, beginner mode
+    # was the only Rails mode with no ceiling at all, and it walked its history
+    # straight into the provider's 1,048,576-token wall (2026-08-23 telemetry:
+    # p90 655k tokens vs ~163k for every mode that HAS the middleware; 32 of 33
+    # all-time context-length crashes). `compact_messages_if_needed` is a thin
+    # adapter over the SAME `RailsSummarizationMiddleware` those modes run, not
+    # a second implementation of the rule.
+    #
+    # Compact the CONVERSATION only. The system message and the per-turn notes
+    # below are rebuilt every turn and must not be summarized away.
+    convo, compaction_ops = compact_messages_if_needed(
+        state["messages"], summary_prompt=SUMMARIZATION_PROMPT,
+    )
+
+    messages = [system_message_for_model(get_sys_msg(), llm_model)] + convo
     if view_path:
         messages = messages + [HumanMessage(
             content="<NOTE_FROM_SYSTEM> The user is currently viewing their Ruby on Rails webpage route at: " + view_path + " </NOTE_FROM_SYSTEM>"
@@ -172,7 +191,7 @@ def leonardo_beginner(state: RailsAgentState, browser_inspect_on: bool = False) 
     # tool call leaves a dangling AIMessage tool_call and every later turn 400s
     # ('insufficient tool messages'). SI#112. Only appends HumanMessages follow,
     # so one repair here covers the failure-limit and main invoke branches.
-    messages = repair_orphaned_tool_calls_in_messages(messages)
+    messages = normalize_messages_for_provider(messages)
 
     tools = beginner_turn_tools(browser_inspect_on)
 
@@ -187,8 +206,15 @@ def leonardo_beginner(state: RailsAgentState, browser_inspect_on: bool = False) 
         response = invoke_with_transient_retry(
             lambda: llm.invoke(messages),
             label=f"rails_beginner_agent/{llm_model}",
+            messages=messages,
         )
-        return {"messages": [response], "failed_tool_calls_count": -failed_tool_calls_count}
+        # compaction_ops FIRST so the REMOVE_ALL + summary land before the new
+        # response — without persisting them the node re-summarizes from scratch
+        # on every single model call.
+        return {
+            "messages": compaction_ops + [response],
+            "failed_tool_calls_count": -failed_tool_calls_count,
+        }
 
     if llm_model.startswith("gemini"):
         llm_with_tools = llm.bind_tools(tools)
@@ -198,8 +224,9 @@ def leonardo_beginner(state: RailsAgentState, browser_inspect_on: bool = False) 
     response = invoke_with_transient_retry(
         lambda: llm_with_tools.invoke(messages),
         label=f"rails_beginner_agent/{llm_model}",
+        messages=messages, tools=tools,
     )
-    return {"messages": [response]}
+    return {"messages": compaction_ops + [response]}
 
 
 def build_workflow(checkpointer=None):

--- a/app/agents/leonardo/rails_beginner_agent/prompts.py
+++ b/app/agents/leonardo/rails_beginner_agent/prompts.py
@@ -508,7 +508,10 @@ You run inside one container. When you run a `bash_command`, it runs in a differ
 | `write_personality_file` | Write IDENTITY.md, SOUL.md, or USER.md | When you learn the user's name or preferences over time |
 | `delegate_task` | Hand off building work to a helper | Scaffolds, imports, multi-file changes |
 | `delegate_research` | Ask a helper to look something up (read-only) | Inspecting spreadsheets, exploring the codebase |
+| `check_page` | Load a page and see if it actually rendered | After editing ANY view, controller or route |
+<!--IF:browser_inspect-->
 | `browser_inspect` | Check if a page loaded without errors (hidden from user) | After editing any view or JS file |
+<!--END:browser_inspect-->
 | `use_skill` | Load a saved step-by-step playbook and follow it | The moment the task matches a skill in the `use_skill` list, or the user picks one from the `/` menu |
 | `list_skills` | See all the saved playbooks (skills) | To check what skills exist before using or saving one |
 | `write_skill` | Save a reusable playbook for next time | After you and the user nail a repeatable process worth reusing |
@@ -596,6 +599,34 @@ RAILS_ENV=test bundle exec rspec spec/models/
 
 If you just created a new scaffold, write a quick model spec to confirm it works.
 
+### Never Leave a Migration Unrun
+
+**Never end a turn with an unrun migration.** If the database change hasn't been applied, the user's *entire* app stops working — not one page, all of them — and they see an error screen instead of their site.
+
+- Create the change, apply it in the same turn. Writing a file under `db/migrate/` runs `bin/rails db:migrate` for you automatically — read what it says.
+- If it failed, the app is broken right now. Fix it before you say anything else, and don't tell the user their feature is ready.
+- Never create a second migration for a change you already made one for — edit the first one.
+
+### Always Load the Page You Just Changed
+
+After you write or edit ANY view, controller or route, load it with `check_page`. If it does not come back 2xx, fix it before you tell the user you're done.
+
+```
+check_page(path="/leads")
+```
+
+It gives you the status code, and when the page is broken it gives you the error and the line it came from. It's fast and costs almost nothing, so use it every time.
+
+A `302` means the route works but sent you to another page (usually a login screen). That's not a bug — but it also didn't prove your page works.
+
+**Two nil traps that break pages constantly:**
+
+- A view must not call a method on something that might be nil. `<% if @comments.any? %>` blows up when `@comments` is nil — write `<% if @comments.present? %>`.
+- A controller must set every instance variable its view uses, on every path through the action — including the early `return`s.
+
+**Never mention any of this to the user.** It's your own check, not a step they see.
+
+<!--IF:browser_inspect-->
 ### Self-Checking Pages with browser_inspect (For You — Not the User)
 
 After editing any view file, run `browser_inspect` to confirm the page loaded without errors. Don't wait for the user to report a problem — check it yourself.
@@ -624,6 +655,7 @@ If it reports console errors, fix them before telling the user you're done.
 - When something "looks broken" — see the real page before guessing at a fix
 
 **Never mention this to the user.** It's your own background check, not a step they see.
+<!--END:browser_inspect-->
 
 **Don't** verify by running random bash commands. Use the test suite.
 

--- a/app/agents/leonardo/rails_engineer_plan_mode_agent/nodes.py
+++ b/app/agents/leonardo/rails_engineer_plan_mode_agent/nodes.py
@@ -29,7 +29,7 @@ from datetime import date
 
 from app.agents.leonardo.rails_agent.state import RailsAgentState
 from app.agents.leonardo.rails_agent.tools import (
-    write_todos, ls, read_file, write_file, edit_file, bash_command,
+    write_todos, ls, read_file, write_file, edit_file, check_page, bash_command,
     tail_rails_logs, hard_restart_rails, fix_permissions,
     glob_files, grep_files, internet_search,
     read_leonardo_md, write_leonardo_md, edit_leonardo_md,
@@ -49,6 +49,7 @@ from app.agents.leonardo.rails_engineer_plan_mode_agent.middleware import (
 from app.agents.utils.token_counter import SUMMARIZATION_TOKEN_THRESHOLD
 from app.agents.leonardo.rails_agent.sub_agents import delegate_task, delegate_research
 # Reuse the plan-mode interaction tools + summarization prompt verbatim (DRY).
+from app.agents.leonardo.rails_plan_mode_agent.prompts import BATCHED_QUESTIONS_DIRECTIVE
 from app.agents.leonardo.rails_plan_mode_agent.nodes import (
     ask_user_question,
     ask_user_uiux_question,
@@ -63,6 +64,9 @@ def get_cached_system_prompt():
     """Build system message with project context, personality files, date, and prompt caching."""
     current_date = date.today().strftime("%Y-%m-%d")
     date_suffix = f"\n\n---\n**Today's Date:** {current_date}"
+    # Appended last so it also overrides a mothership-delivered prompt, which
+    # still carries the old "one question per turn" rule.
+    date_suffix += BATCHED_QUESTIONS_DIRECTIVE
     full_prompt = with_friction_section(build_beginner_system_prompt(
         ENGINEER_PLAN_PROMPT,
         suffix=date_suffix,
@@ -90,7 +94,7 @@ default_tools = [
     ask_user_uiux_question,
     # Standard tools (same as engineer)
     write_todos,
-    ls, read_file, write_file, edit_file, bash_command,
+    ls, read_file, write_file, edit_file, check_page, bash_command,
     tail_rails_logs, hard_restart_rails, fix_permissions,
     glob_files, grep_files, internet_search,
     read_leonardo_md, write_leonardo_md, edit_leonardo_md,

--- a/app/agents/leonardo/rails_engineer_plan_mode_agent/prompts.py
+++ b/app/agents/leonardo/rails_engineer_plan_mode_agent/prompts.py
@@ -2,7 +2,7 @@
 Prompt for the Rails Engineer Plan Mode Agent.
 
 Engineer Plan Mode is the engineering counterpart to Beginner Plan Mode. It uses the
-SAME plan-first mechanism — ask simple questions one at a time, present a plan, get
+SAME plan-first mechanism — ask simple questions in small batches, present a plan, get
 approval, then build and verify — but it retains the full engineering depth of Engineer
 Mode (Turbo/Stimulus patterns, scaffolding, data modeling, sub-agent orchestration,
 RSpec verification).
@@ -34,7 +34,7 @@ The person you are talking to is **NOT an engineer.** Talk to them like a smart 
 
 You follow a strict 6-phase workflow. **Always know which phase you are in.** Move through the phases in order. Do NOT skip phases. Do NOT start building before the user approves the plan.
 
-### Phase 1: CLARIFY (Ask Questions — one at a time)
+### Phase 1: CLARIFY (Ask Questions — 2-4 at a time)
 
 **Goal:** Understand what the user wants before doing anything.
 
@@ -43,11 +43,11 @@ You follow a strict 6-phase workflow. **Always know which phase you are in.** Mo
 When the user describes what they want:
 1. Call `list_memories` to check if you already know anything relevant about this user or project.
 2. Think about what you genuinely need to know to build this well.
-3. Call `ask_user_question` with **ONE question at a time.** Include helpful `options` so they can just click an answer instead of typing — they can always type their own.
+3. Call `ask_user_question` with a `questions` list — **2-4 questions at once**. Include helpful `options` on each so they can just click an answer instead of typing — they can always type their own.
 
-**CRITICAL: One question per turn.** Do NOT stack multiple questions. Ask one, wait for the answer, then ask the next. You'll usually need 2–5 questions total — feed them one at a time so it never feels overwhelming.
+**CRITICAL: Batch your questions.** Put 2-4 related questions in ONE `ask_user_question` call via the `questions` list — the user answers them together on one card and you get every answer back at once, which is far faster for them than one question per turn. Only split a question out when its wording genuinely depends on the answer to an earlier one. Never ask more than 4 at once; save the rest for the next round. Stop asking once you know enough to be confident.
 
-**MANDATORY — set `ui_related: true` for ANY look-and-feel question.** If the question is about how something LOOKS or is laid out — footers, headers, heroes, navbars, buttons, cards, colors, fonts, spacing, layout, styling, "what vibe/style", "which design" — you MUST pass `ui_related: true` on that `ask_user_question` call. This adds a "See visual options" choice for the user. NEVER hand-write your own "show me some visual options" text option — that does nothing; the `ui_related: true` flag is the ONLY thing that gives the user real previews. When they pick it, immediately follow up with `ask_user_uiux_question` showing 2-4 live previews. When in doubt on a visual question, set it true.
+**MANDATORY — set `ui_related: true` for ANY look-and-feel question.** If the question is about how something LOOKS or is laid out — footers, headers, heroes, navbars, buttons, cards, colors, fonts, spacing, layout, styling, "what vibe/style", "which design" — you MUST set `ui_related: true` on THAT QUESTION in the `questions` list. It is per-question — in a batch you can flag question 2 as visual while 1 and 3 stay plain text. This adds a "See visual options" choice for the user. NEVER hand-write your own "show me some visual options" text option — that does nothing; the `ui_related: true` flag is the ONLY thing that gives the user real previews. When they pick it, immediately follow up with `ask_user_uiux_question` showing 2-4 live previews for THAT question only — the answers they gave to the other questions in the batch still stand, so do not re-ask those. When in doubt on a visual question, set it true.
 - Example (visual → flag ON): question "What style should the footer be?", options ["Minimal", "Standard", "Full-featured"], **`ui_related: true`**.
 - Example (non-visual → flag OFF): question "Should this page be public or logged-in only?", options ["Anyone", "Logged-in only"], `ui_related: false`.
 
@@ -92,7 +92,7 @@ Once the user has answered your questions:
 
 **Goal:** Fill in gaps that research surfaced.
 
-If research revealed a real choice the user should make, ask it with `ask_user_question` (still one at a time, max 1–3 total, still plain language). Frame it around what you found: "I see you already have a customers list — want this added to that, or kept separate?"
+If research revealed a real choice the user should make, ask it with `ask_user_question` (batched, max 1–3 total, still plain language). Frame it around what you found: "I see you already have a customers list — want this added to that, or kept separate?"
 
 If nothing needs clarifying, skip straight to Phase 4.
 
@@ -196,7 +196,7 @@ After implementation:
 
 1. **Never skip the plan phase.** Even simple requests get a quick plan and approval.
 2. **Never build before approval.** The plan phase exists so the user feels in control.
-3. **Ask, don't assume** — but ask in plain language, one question at a time. One extra question beats building the wrong thing.
+3. **Ask, don't assume** — but ask in plain language, batched into one card. One extra question beats building the wrong thing.
 4. **Stay in your phase.** Don't jump ahead; don't silently go back.
 5. **The plan is the contract.** During the build, follow it. If it must change, update it first and tell the user.
 6. **Test before declaring done** (Phase 4.5 + Phase 6). Every plan step needs at least one passing test. Keep all of it silent — the user just hears that it works.

--- a/app/agents/leonardo/rails_error_watch_middleware.py
+++ b/app/agents/leonardo/rails_error_watch_middleware.py
@@ -1,0 +1,137 @@
+"""Puts a live Rails crash in front of the model, mid-turn.
+
+The model-call boundary is the injection point for one reason: it is the only
+place LangGraph lets you add a message to a run that is already in flight
+without cancelling and restarting it, and it is the point the model actually
+reads. Leo finishes the tool it is running, and before its next thought it sees
+that the app just crashed — functionally the same as the user pasting the error
+in, except the user never had to see the broken page.
+
+Design constraints, each pinned by a test in
+``app/tests/test_rails_error_watch_middleware.py``:
+
+1. **Inert without a watch.** Headless runs and tests never installed one, so
+   the request is passed through untouched and nothing is polled.
+2. **Never fatal.** A crash-recovery feature that can crash a turn is worse than
+   no feature. Every failure path returns the original request.
+3. **Transparent.** The handler's result is returned unmodified.
+4. **Protocol-safe.** Never appends after an unanswered ``tool_calls`` message.
+
+All the "should we say something" logic lives in ``app/lib/rails_error_watch``
+so it can be tested without LangGraph. See docs/dev/rails_auto_recovery.md.
+"""
+import logging
+
+from langchain.agents.middleware import AgentMiddleware
+from langchain_core.messages import AIMessage, HumanMessage
+
+from app.lib.rails_error_watch import ARMING_WINDOW_SECONDS, current_error_watch
+
+logger = logging.getLogger(__name__)
+
+
+def _default_feed_factory(watch):
+    from app.services.rails_error_feed import RailsErrorFeedClient
+
+    return RailsErrorFeedClient(token=watch.api_token)
+
+
+class RailsErrorWatchMiddleware(AgentMiddleware):
+    """Polls the Rails error feed once per model call and injects what is new."""
+
+    def __init__(self, *, feed_factory=None):
+        super().__init__()
+        # Injectable so tests drive a fake feed instead of HTTP.
+        self._feed_factory = feed_factory or _default_feed_factory
+        self._explained = None
+
+    @staticmethod
+    def _has_unanswered_tool_calls(messages) -> bool:
+        if not messages:
+            return False
+        last = messages[-1]
+        return isinstance(last, AIMessage) and bool(getattr(last, "tool_calls", None))
+
+    async def _maybe_inject(self, request):
+        watch = current_error_watch()
+        if watch is None:
+            self._explain_once(None, "no watch installed for this turn")
+            return request
+        if not watch.armed:
+            self._explain_once(watch, f"agent {watch.agent_name!r} is read-only")
+            return request
+
+        arming = watch.cursor is None
+
+        feed = self._feed_factory(watch)
+        result = await feed.fetch(
+            since=watch.cursor,
+            within=ARMING_WINDOW_SECONDS if arming else None,
+        )
+        if result is None:
+            self._explain_once(watch, "error feed unreachable (old gem, 403, or Rails down)")
+            # Rails is restarting, the gem predates the endpoint, or the token
+            # expired. Stay unarmed and try again on the next model call.
+            return request
+
+        cursor, errors = result
+        watch.prime(cursor) if arming else watch.advance(cursor)
+        self._explain_once(
+            watch, f"armed, cursor={watch.cursor}, {len(errors)} recent error(s)"
+        )
+
+        # On the arming call these crashes predate the turn — the user asked for
+        # help with an app that was already down. Report them, but do not tell
+        # the agent it caused something it could not have.
+        report = watch.plan_injection(errors, pre_existing=arming)
+        if not report:
+            return request
+
+        messages = list(request.messages)
+        if self._has_unanswered_tool_calls(messages):
+            # The tool results are still coming. Injecting here would break the
+            # tool-call protocol; the next model call picks this up instead —
+            # the fingerprint is unspent because plan_injection already ran, so
+            # re-report it explicitly rather than dropping it on the floor.
+            watch.seen_fingerprints.difference_update(
+                {e.get("fingerprint") for e in errors if e.get("fingerprint")}
+            )
+            watch.injections = max(0, watch.injections - 1)
+            return request
+
+        messages.append(HumanMessage(content=report))
+        logger.info(
+            "rails auto-recovery: injected crash report on thread %s (attempt %s)",
+            watch.thread_id,
+            watch.injections,
+        )
+        return request.override(messages=messages)
+
+    def _explain_once(self, watch, reason):
+        """Say once per turn why auto-recovery is or is not going to speak up.
+
+        Without this the feature is undiagnosable from the outside: a quiet turn
+        looks identical whether the watch was disarmed, the feed was
+        unreachable, or there was simply nothing wrong.
+        """
+        key = id(watch) if watch is not None else "none"
+        if self._explained == key:
+            return
+        self._explained = key
+        logger.info("rails auto-recovery: %s", reason)
+
+    async def _safe_inject(self, request):
+        try:
+            return await self._maybe_inject(request)
+        except Exception as exc:  # noqa: BLE001 - must never break a turn
+            logger.debug("rails auto-recovery skipped: %s", exc)
+            return request
+
+    async def awrap_model_call(self, request, handler):
+        return await handler(await self._safe_inject(request))
+
+    def wrap_model_call(self, request, handler):
+        # The sync path exists only because AgentMiddleware declares it. Every
+        # Leonardo agent runs through astream, so polling here would mean
+        # blocking HTTP on the model-call path for no reachable benefit.
+        return handler(request)

--- a/app/agents/leonardo/rails_plain_chat_mode/nodes.py
+++ b/app/agents/leonardo/rails_plain_chat_mode/nodes.py
@@ -23,6 +23,8 @@ from app.agents.leonardo.model_policy import enabled_default_model
 from app.agents.leonardo.rails_agent.state import RailsAgentState
 from app.agents.leonardo.project_context import brand_context_section
 from app.agents.leonardo.resilience import invoke_with_transient_retry
+from app.agents.leonardo.summarization import compact_messages_if_needed
+from app.agents.leonardo.message_invariants import normalize_messages_for_provider
 
 load_dotenv()
 
@@ -54,6 +56,18 @@ def get_sys_msg():
     }
 
 
+# Plain chat has no tools and no code to carry forward, so the summary only has
+# to preserve the thread of the conversation itself.
+SUMMARIZATION_PROMPT = """Summarize the conversation so far so it can continue without the earlier messages.
+
+Keep: what the user asked about, the answers and advice already given, any decisions
+they made, and any facts about them or their project that came up. Write it as notes
+to yourself, not as a message to the user.
+
+Conversation:
+{messages}"""
+
+
 def plain_chat(state: RailsAgentState):
     llm_model = state.get("llm_model") or enabled_default_model()
     logger.info(f"Using LLM model: {llm_model}")
@@ -62,15 +76,24 @@ def plain_chat(state: RailsAgentState):
     llm = get_llm(llm_model)
 
     sys_msg = system_message_for_model(get_sys_msg(), llm_model)
+
+    # Context management — raw node, no AgentMiddleware, so nothing trims this
+    # on its own. A long chat thread has no ceiling without it. Same shared
+    # middleware every create_agent mode runs.
+    convo, compaction_ops = compact_messages_if_needed(
+        state["messages"], summary_prompt=SUMMARIZATION_PROMPT,
+    )
     # Raw node — no DynamicModelMiddleware, so the rung-1 transient retry has to
     # be at the call site, same as rails_beginner_agent / rails_ai_builder_agent.
     # Without it a mid-stream provider drop (RemoteProtocolError: incomplete
     # chunked read) kills the turn outright. See test_stream_truncated_response.py.
+    outgoing = normalize_messages_for_provider([sys_msg] + convo)
     response = invoke_with_transient_retry(
-        lambda: llm.invoke([sys_msg] + state["messages"]),
+        lambda: llm.invoke(outgoing),
         label=f"rails_plain_chat_mode/{llm_model}",
+        messages=outgoing,
     )
-    return {"messages": [response]}
+    return {"messages": compaction_ops + [response]}
 
 
 def build_workflow(checkpointer=None):

--- a/app/agents/leonardo/rails_plan_mode_agent/nodes.py
+++ b/app/agents/leonardo/rails_plan_mode_agent/nodes.py
@@ -31,7 +31,7 @@ from datetime import date
 
 from app.agents.leonardo.rails_agent.state import RailsAgentState
 from app.agents.leonardo.rails_agent.tools import (
-    write_todos, ls, read_file, write_file, edit_file, bash_command,
+    write_todos, ls, read_file, write_file, edit_file, check_page, bash_command,
     tail_rails_logs, hard_restart_rails, fix_permissions,
     glob_files, grep_files, internet_search,
     read_leonardo_md, write_leonardo_md, edit_leonardo_md,
@@ -39,7 +39,10 @@ from app.agents.leonardo.rails_agent.tools import (
     build_use_skill_tool, list_skills, read_skill, write_skill, edit_skill, delete_skill,
     write_personality_file,
 )
-from app.agents.leonardo.rails_plan_mode_agent.prompts import PLAN_MODE_AGENT_PROMPT
+from app.agents.leonardo.rails_plan_mode_agent.prompts import (
+    PLAN_MODE_AGENT_PROMPT,
+    BATCHED_QUESTIONS_DIRECTIVE,
+)
 from app.agents.leonardo.project_context import build_beginner_system_prompt
 from app.agents.leonardo.friction import report_friction, with_friction_section
 from app.agents.leonardo.rails_plan_mode_agent.middleware import (
@@ -99,6 +102,9 @@ def get_cached_system_prompt():
     """Build system message with project context, personality files, date, and prompt caching."""
     current_date = date.today().strftime("%Y-%m-%d")
     date_suffix = f"\n\n---\n**Today's Date:** {current_date}"
+    # Appended last so it also overrides a mothership-delivered prompt, which
+    # still carries the old "one question per turn" rule.
+    date_suffix += BATCHED_QUESTIONS_DIRECTIVE
     full_prompt = with_friction_section(build_beginner_system_prompt(
         PLAN_MODE_AGENT_PROMPT,
         suffix=date_suffix,
@@ -120,54 +126,137 @@ def get_cached_system_prompt():
 # Plan Mode Tools
 # =============================================================================
 
-ASK_USER_QUESTION_DESCRIPTION = """Ask the user ONE question at a time. Use this to:
+MAX_BATCHED_QUESTIONS = 4
+
+ASK_USER_QUESTION_DESCRIPTION = """Ask the user up to 4 questions at once. Use this to:
 - Clarify what they want (Phase 1: Clarify)
 - Ask follow-up questions after research (Phase 3: Refine)
 - Get approval for the plan (Phase 4: Present Plan)
 
-IMPORTANT: Only ask ONE question per tool call. If you have multiple questions, call this tool once, wait for the answer, then ask the next question. This keeps it simple and non-overwhelming for the user.
+BATCH YOUR QUESTIONS. If you have 2-4 things to ask, put them ALL in one call via the
+`questions` parameter. The user answers them together on one card and you get every
+answer back in a single result — far faster for them than one question per turn. Only
+ask one at a time when a later question genuinely depends on the answer to an earlier
+one. Never ask more than 4 in one call; ask the rest on the next turn.
 
 Parameters:
-- question: The question to ask, in plain non-technical language
-- options: (Optional) A list of suggested answers the user can pick from. The user can also type their own answer. Use this to make it easy for non-technical users to respond.
-- context: (Optional) Brief context about why you're asking (shown as a subtitle)
-- ui_related: (Optional, default false) Set to true when the question involves a VISUAL or
-  UI/UX decision (layout, colors, components, button/card styling, section arrangement, etc.).
-  When true, the user is shown one extra subtle "See visual options" choice alongside your
-  options. If they pick it, the tool result will explicitly ask you to follow up by calling
-  ask_user_uiux_question with 2-4 concrete live HTML previews for this decision. Leave it
-  false for non-visual questions.
+- questions: A list of 1-4 question objects (PREFERRED). Each object is:
+    - question: The question to ask, in plain non-technical language
+    - options: (Optional) suggested answers the user can click. They can also type their own.
+    - ui_related: (Optional, default false) see below — this is PER QUESTION.
+- question / options / ui_related: (Legacy) the single-question form. Equivalent to passing
+  a one-item `questions` list. Use `questions` instead.
+- context: (Optional) Brief context about why you're asking (shown once, above the questions)
 
-This tool will freeze execution and wait for the user to respond. The user's answer is returned as the tool result."""
+ui_related — set true on ANY question that involves a VISUAL or UI/UX decision (layout,
+colors, components, button/card styling, section arrangement, etc.). That question gets an
+extra subtle "See visual options" choice. If the user picks it, the tool result will ask you
+to follow up by calling ask_user_uiux_question with 2-4 concrete live HTML previews for THAT
+specific question — the other questions' answers still stand, so do not re-ask them. Leave it
+false for non-visual questions. It is per-question: in a batch you can flag question 2 as
+visual while 1 and 3 are plain text questions.
+
+This tool will freeze execution and wait for the user to respond. The user's answers are
+returned as the tool result."""
+
+
+class QuestionSpec(TypedDict, total=False):
+    """One question in an ask_user_question batch.
+
+    Attributes:
+        question: The question text, in plain non-technical language.
+        options: Suggested answers the user can click instead of typing.
+        ui_related: True for a visual/UI-UX decision — adds a per-question
+            "See visual options" choice that asks for live previews instead.
+    """
+
+    question: str
+    options: list[str]
+    ui_related: bool
+
+
+def normalize_questions(
+    questions: list[dict] = None,
+    question: str = "",
+    options: list[str] = None,
+    ui_related: bool = False,
+) -> tuple[list[dict], int]:
+    """Fold the batch and legacy single-question forms into one list.
+
+    Returns ``(questions, dropped)`` where ``dropped`` counts questions past the
+    4-question cap. We truncate rather than render a wall of questions, and tell the
+    model what was dropped so it can ask them next turn instead of losing them.
+    """
+    raw = list(questions or [])
+    if not raw and question:
+        raw = [{"question": question, "options": options, "ui_related": ui_related}]
+
+    normalized = []
+    for item in raw:
+        if not isinstance(item, dict):
+            continue
+        text = str(item.get("question") or "").strip()
+        if not text:
+            continue
+        normalized.append({
+            "question": text,
+            "options": [str(o) for o in (item.get("options") or [])],
+            "ui_related": bool(item.get("ui_related")),
+        })
+
+    dropped = max(0, len(normalized) - MAX_BATCHED_QUESTIONS)
+    return normalized[:MAX_BATCHED_QUESTIONS], dropped
 
 
 @tool(description=ASK_USER_QUESTION_DESCRIPTION)
 def ask_user_question(
-    question: str,
     runtime: ToolRuntime,
+    questions: list[QuestionSpec] = None,
+    question: str = "",
     options: list[str] = None,
     context: str = "",
     ui_related: bool = False,
 ) -> Command:
-    """Ask the user a question, freeze execution, and resume with their answer."""
+    """Ask the user 1-4 questions, freeze execution, and resume with their answers."""
     tool_call_id = runtime.tool_call_id
 
+    batch, dropped = normalize_questions(questions, question, options, ui_related)
+    if not batch:
+        return Command(update={"messages": [ToolMessage(
+            content=(
+                "No question was asked — `questions` was empty. Call ask_user_question "
+                "again with a `questions` list of 1-4 question objects."
+            ),
+            tool_call_id=tool_call_id,
+        )]})
+
     # interrupt() freezes the agent here. The value is sent to the frontend
-    # as a question_request. When the user answers, interrupt() returns the answer.
-    # ui_related toggles an extra "See visual options" choice on the frontend card; if
-    # the user picks it the resumed answer asks us to call ask_user_uiux_question next.
+    # as a question_request. When the user answers, interrupt() returns the answers.
+    # The first question is also mirrored into the legacy top-level fields so a stale
+    # cached frontend still renders something instead of an empty card.
+    # ui_related toggles a per-question "See visual options" choice on the card; if the
+    # user picks it the resumed answer asks us to call ask_user_uiux_question for that
+    # one question next, keeping the answers already given to the others.
     user_answer = interrupt({
         "type": "user_question",
-        "question": question,
-        "options": options or [],
+        "questions": batch,
+        "question": batch[0]["question"],
+        "options": batch[0]["options"],
+        "ui_related": batch[0]["ui_related"],
         "context": context,
-        "ui_related": ui_related,
     })
+
+    content = f"User answered: {user_answer}"
+    if dropped:
+        content += (
+            f"\n\n(Note: you passed more than {MAX_BATCHED_QUESTIONS} questions; the last "
+            f"{dropped} were not shown to the user. Ask those on your next turn.)"
+        )
 
     return Command(
         update={
             "messages": [ToolMessage(
-                content=f"User answered: {user_answer}",
+                content=content,
                 tool_call_id=tool_call_id
             )]
         }
@@ -281,7 +370,7 @@ default_tools = [
     ask_user_uiux_question,
     # Standard tools (same as beginner)
     write_todos,
-    ls, read_file, write_file, edit_file, bash_command,
+    ls, read_file, write_file, edit_file, check_page, bash_command,
     tail_rails_logs, hard_restart_rails, fix_permissions,
     glob_files, grep_files, internet_search,
     read_leonardo_md, write_leonardo_md, edit_leonardo_md,

--- a/app/agents/leonardo/rails_plan_mode_agent/prompts.py
+++ b/app/agents/leonardo/rails_plan_mode_agent/prompts.py
@@ -67,11 +67,11 @@ You follow a strict 6-phase workflow. **Always know which phase you are in.** Mo
 When the user describes what they want:
 1. Call `list_memories` to check if you know anything relevant about this user or project.
 2. Think about what you need to know to build this well.
-3. Call `ask_user_question` with **ONE question at a time**. Include helpful `options` so they can just click an answer instead of typing. They can always type something custom too.
+3. Call `ask_user_question` with a `questions` list — **2-4 questions at once**. Include helpful `options` on each so they can just click an answer instead of typing. They can always type something custom too.
 
-**CRITICAL: One question per turn.** Do NOT ask multiple questions at once. Ask one, wait for the answer, then ask the next one. This keeps it easy and non-overwhelming. You'll typically need 2-5 questions total, but feed them one at a time.
+**CRITICAL: Batch your questions.** Put 2-4 related questions in ONE `ask_user_question` call via the `questions` list — the user answers them together on one card and you get every answer back at once, which is far faster for them than one question per turn. Only split a question out when its wording genuinely depends on the answer to an earlier one. Never ask more than 4 at once; save the rest for the next round. Stop asking once you know enough to be confident.
 
-**MANDATORY — set `ui_related: true` for ANY look-and-feel question.** If the question is about how something LOOKS or is laid out — footers, headers, heroes, navbars, buttons, cards, colors, fonts, spacing, layout, styling, "what vibe/style", "which design" — you MUST pass `ui_related: true` on that `ask_user_question` call. This adds a "See visual options" choice for the user. NEVER hand-write your own "show me some visual options" text option — that does nothing; the `ui_related: true` flag is the ONLY thing that gives the user real previews. When they pick it, immediately follow up with `ask_user_uiux_question` showing 2-4 live previews. When in doubt on a visual question, set it true.
+**MANDATORY — set `ui_related: true` for ANY look-and-feel question.** If the question is about how something LOOKS or is laid out — footers, headers, heroes, navbars, buttons, cards, colors, fonts, spacing, layout, styling, "what vibe/style", "which design" — you MUST set `ui_related: true` on THAT QUESTION in the `questions` list. It is per-question — in a batch you can flag question 2 as visual while 1 and 3 stay plain text. This adds a "See visual options" choice for the user. NEVER hand-write your own "show me some visual options" text option — that does nothing; the `ui_related: true` flag is the ONLY thing that gives the user real previews. When they pick it, immediately follow up with `ask_user_uiux_question` showing 2-4 live previews for THAT question only — the answers they gave to the other questions in the batch still stand, so do not re-ask those. When in doubt on a visual question, set it true.
 - Example (visual → flag ON): question "What style should the footer be?", options ["Minimal", "Standard", "Full-featured"], **`ui_related: true`**.
 - Example (non-visual → flag OFF): question "Should this page be public or logged-in only?", options ["Anyone", "Logged-in only"], `ui_related: false`.
 
@@ -261,4 +261,34 @@ If the user's message contains a reference like `@cookbook:<slug> (https://llama
 5. **The plan is the contract.** During implementation, follow it exactly. If you realize something needs to change, tell the user and update the plan first.
 6. **Test before declaring done.** Write the tests from your internal test plan (Phase 4.5), run RSpec, and get them green before you tell the user it's done. Every plan step needs at least one passing test that proves it. Keep all of this silent — the user just hears that it works.
 7. **Use tools, not bash, for file operations.** Use `read_file`, `edit_file`, `write_file`, `glob_files`, `grep_files` — NOT `cat`, `sed`, `grep` via bash.
+"""
+
+
+# Appended AFTER the base prompt (see get_cached_system_prompt), so it lands after a
+# mothership-delivered prompt override too. The mothership still ships the older
+# "ONE question per turn" copy of these prompts; editing prompts.py alone does NOT
+# reach the model on a box that has an override cached. This directive is what makes
+# batching actually happen on the fleet, and it stays correct once the mothership
+# catches up (it just repeats what the prompt already says).
+BATCHED_QUESTIONS_DIRECTIVE = """
+
+---
+
+## Asking the user questions (supersedes any instruction above about ONE question at a time)
+
+`ask_user_question` takes a **`questions` list and shows 2-4 questions on a single card**.
+The user answers them all at once and you get every answer back in one result.
+
+- **Default to batching.** Every question you could ask right now goes in ONE call.
+- Only hold a question back when its wording genuinely depends on the answer to an
+  earlier one.
+- Never put more than 4 in one call — ask the rest on your next turn.
+- `options` and `ui_related` are set **per question**, inside the list. Flag only the
+  look-and-feel questions as `ui_related`.
+- If the user asks for visual options on one question, follow up with
+  `ask_user_uiux_question` for **that question only** — the answers they gave to the
+  others still stand, so do not re-ask those.
+
+Asking one question per turn when you could have asked three is a bad experience: it
+costs the user two extra round-trips for nothing.
 """

--- a/app/agents/leonardo/rails_testing_agent/nodes.py
+++ b/app/agents/leonardo/rails_testing_agent/nodes.py
@@ -31,7 +31,7 @@ from datetime import date
 
 from app.agents.leonardo.rails_agent.state import RailsAgentState
 from app.agents.leonardo.rails_agent.tools import (
-    write_todos, ls, read_file, write_file, edit_file, bash_command,
+    write_todos, ls, read_file, write_file, edit_file, check_page, bash_command,
     fix_permissions,
     # Agent file tools (for reading test patterns from other agents)
     ls_agents, read_agent_file, write_agent_file, edit_agent_file,
@@ -176,7 +176,7 @@ def get_cached_system_prompt():
 # Tool list - tools available to the Testing agent
 default_tools = [
     write_todos,
-    ls, read_file, write_file, edit_file,
+    ls, read_file, write_file, edit_file, check_page,
     bash_command,  # For running rspec tests
     fix_permissions,  # Fix permission issues in Rails container
     delegate_research,  # Read-only sub-agent for codebase investigation

--- a/app/agents/leonardo/rails_ticket_mode_agent/nodes.py
+++ b/app/agents/leonardo/rails_ticket_mode_agent/nodes.py
@@ -31,7 +31,7 @@ import base64
 
 from app.agents.leonardo.rails_agent.state import RailsAgentState
 from app.agents.leonardo.rails_agent.tools import (
-    write_todos, ls, read_file, write_file, edit_file, bash_command,
+    write_todos, ls, read_file, write_file, edit_file, check_page, bash_command,
     fix_permissions,
     rails_api_sh,
     save_memory, list_memories, delete_memory,
@@ -289,7 +289,7 @@ def offer_implementation(
 # Tool list - tools available to the Ticket Mode agent (NO internet_search)
 default_tools = [
     write_todos,
-    ls, read_file, write_file, edit_file,
+    ls, read_file, write_file, edit_file, check_page,
     bash_command,
     fix_permissions,     # Fix permission issues in Rails container
     delegate_task,       # Sub-agent delegation for focused research tasks

--- a/app/agents/leonardo/rails_ticket_mode_agent/sub_agents.py
+++ b/app/agents/leonardo/rails_ticket_mode_agent/sub_agents.py
@@ -35,6 +35,7 @@ from app.agents.leonardo.model_policy import enabled_default_model
 from app.agents.leonardo.friction import report_friction, with_friction_section
 from app.agents.leonardo.delegation import (
     DELEGATION_TIMEOUT_SECONDS,
+    summarize_partial_work,
     DelegationTimedOut,
     run_delegation,
 )
@@ -274,15 +275,17 @@ async def delegate_task(
             ]
         })
 
-    except DelegationTimedOut:
+    except DelegationTimedOut as timeout:
         logger.warning("Ticket Mode sub-agent delegation timed out")
         return Command(update={
             "messages": [
                 ToolMessage(
                     content=(
-                        "[DELEGATED TASK FAILED]\n\n"
-                        f"Timed out after {DELEGATION_TIMEOUT_SECONDS}s — you may retry "
-                        "delegate_task once."
+                        "[DELEGATED TASK TIMED OUT]\n\n"
+                        f"It ran out of time after {DELEGATION_TIMEOUT_SECONDS}s. "
+                        "Anything listed below was already done — do NOT redo it. Pick "
+                        "up from here yourself, or delegate only what is left.\n\n"
+                        + summarize_partial_work(timeout.partial_messages)
                     ),
                     tool_call_id=tool_call_id
                 )

--- a/app/agents/leonardo/rails_ticket_plan_mode_agent/middleware.py
+++ b/app/agents/leonardo/rails_ticket_plan_mode_agent/middleware.py
@@ -34,7 +34,7 @@ class TicketPlanModeContextMiddleware(AgentMiddleware):
     """Inject ticket-mode restrictions AND the plan-first grounding reminder.
 
     One combined `<CONTEXT type="mode">` block: keeps the Ticket Mode write rules and
-    adds the Ticket Plan Mode requirement to ask clarifying questions (one at a time,
+    adds the Ticket Plan Mode requirement to ask clarifying questions (2-4 at a time,
     visual options for look-and-feel decisions) before drafting the observation, then
     proceed with the normal research -> ticket -> offer-to-implement flow.
     """
@@ -43,7 +43,7 @@ class TicketPlanModeContextMiddleware(AgentMiddleware):
         context = (
             '<CONTEXT type="mode">TICKET PLAN MODE: READ any file, WRITE only .md files in '
             'rails/requirements/. No code changes. FIRST ground the story — call '
-            'ask_user_question ONE question at a time (set ui_related=true for any '
+            'ask_user_question with a `questions` list of 2-4 at once (set ui_related=true on any '
             'look-and-feel question; follow up with ask_user_uiux_question for visual '
             'options) before drafting the observation. THEN proceed as Ticket Mode: '
             'delegated research -> write_final_ticket -> offer_implementation.</CONTEXT>'

--- a/app/agents/leonardo/rails_ticket_plan_mode_agent/nodes.py
+++ b/app/agents/leonardo/rails_ticket_plan_mode_agent/nodes.py
@@ -32,7 +32,7 @@ from datetime import date
 
 from app.agents.leonardo.rails_agent.state import RailsAgentState
 from app.agents.leonardo.rails_agent.tools import (
-    write_todos, ls, read_file, write_file, edit_file, bash_command,
+    write_todos, ls, read_file, write_file, edit_file, check_page, bash_command,
     fix_permissions,
     save_memory, list_memories, delete_memory,
     build_use_skill_tool, list_skills, read_skill, write_skill, edit_skill, delete_skill,
@@ -57,6 +57,7 @@ from app.agents.leonardo.rails_ticket_mode_agent.nodes import (
 from app.agents.leonardo.rails_ticket_mode_agent.sub_agents import delegate_task
 from app.agents.leonardo.rails_agent.sub_agents import delegate_research
 # Reuse Plan Mode's interaction tools verbatim (DRY).
+from app.agents.leonardo.rails_plan_mode_agent.prompts import BATCHED_QUESTIONS_DIRECTIVE
 from app.agents.leonardo.rails_plan_mode_agent.nodes import (
     ask_user_question,
     ask_user_uiux_question,
@@ -70,6 +71,9 @@ def get_cached_system_prompt():
     """Build system message with project context, date, and prompt caching enabled."""
     current_date = date.today().strftime("%Y-%m-%d")
     date_suffix = f"\n\n---\n**Today's Date:** {current_date}"
+    # Appended last so it also overrides a mothership-delivered prompt, which
+    # still carries the old "one question per turn" rule.
+    date_suffix += BATCHED_QUESTIONS_DIRECTIVE
     full_prompt = with_friction_section(build_system_prompt_with_project_context(
         TICKET_PLAN_MODE_AGENT_PROMPT,
         suffix=date_suffix,
@@ -94,7 +98,7 @@ default_tools = [
     ask_user_uiux_question,
     # Standard tools
     write_todos,
-    ls, read_file, write_file, edit_file,
+    ls, read_file, write_file, edit_file, check_page,
     bash_command,
     fix_permissions,     # Fix permission issues in Rails container
     delegate_task,       # Sub-agent delegation for focused research tasks

--- a/app/agents/leonardo/rails_ticket_plan_mode_agent/prompts.py
+++ b/app/agents/leonardo/rails_ticket_plan_mode_agent/prompts.py
@@ -5,7 +5,7 @@ Ticket Plan Mode is Ticket Mode with a plan-first clarification wrapper. It uses
 SAME ticket-writing machinery as Ticket Mode — collect the story, delegate deep
 technical research, write the implementation-ready ticket, then offer to auto-implement
 it — but BEFORE settling the story it actively GROUNDS the user's feedback by asking
-clarifying questions one at a time (the plan-mode mechanism), with live visual options
+clarifying questions in small batches (the plan-mode mechanism), with live visual options
 when the choice is about how something LOOKS.
 
 To stay DRY and keep one source of truth, this prompt is COMPOSED:
@@ -31,7 +31,7 @@ The person you are talking to is **NOT an engineer.** Ask in plain, everyday lan
 
 ---
 
-## PHASE 0: GROUND THE STORY (clarifying questions — one at a time)
+## PHASE 0: GROUND THE STORY (clarifying questions — 2-4 at a time)
 
 **MANDATORY: You MUST call `ask_user_question` at least once before drafting the observation template or delegating any research.** No matter how clear the request seems, start by asking. This is what makes Ticket Plan Mode different from regular Ticket Mode — we pin down the story together first.
 
@@ -39,11 +39,11 @@ Do this right after the user describes their issue (you may still do the playboo
 
 1. Call `list_memories` once (the playbook already requires this) so your questions respect what you already know.
 2. Think about what you genuinely need to know to write a ticket that an engineer could pick up cold: which page/element, what they see now vs. what they expect, who it affects, and how you'd know it's fixed (verification criteria).
-3. Call `ask_user_question` with **ONE question at a time.** Always include helpful `options` so they can click an answer instead of typing — they can always type their own.
+3. Call `ask_user_question` with a `questions` list — **2-4 questions at once**. Always include helpful `options` on each so they can click an answer instead of typing — they can always type their own.
 
-**CRITICAL: One question per turn.** Do NOT stack multiple questions. Ask one, wait for the answer, then ask the next. You'll usually need 2-5 questions total — feed them one at a time so it never feels overwhelming. Stop asking once the story is grounded enough to draft a confident observation.
+**CRITICAL: Batch your questions.** Put 2-4 related questions in ONE `ask_user_question` call via the `questions` list — the user answers them together on one card and you get every answer back at once, which is far faster for them than one question per turn. Only split a question out when its wording genuinely depends on the answer to an earlier one. Never ask more than 4 at once; save the rest for the next round. Stop asking once you know enough to be confident. Stop asking once the story is grounded enough to draft a confident observation.
 
-**MANDATORY — set `ui_related: true` for ANY look-and-feel question.** If the question is about how something LOOKS or is laid out — layout, colors, fonts, spacing, buttons, cards, sections, "which design", "what vibe" — you MUST pass `ui_related: true` on that `ask_user_question` call. This gives the user a "See visual options" choice. NEVER hand-write your own "show me some options" text choice — that does nothing; the `ui_related: true` flag is the ONLY thing that surfaces real previews. When they pick it, immediately follow up with `ask_user_uiux_question` showing 2-4 live HTML previews so they can choose the desired behavior **by sight**. When in doubt on a visual question, set it true.
+**MANDATORY — set `ui_related: true` for ANY look-and-feel question.** If the question is about how something LOOKS or is laid out — layout, colors, fonts, spacing, buttons, cards, sections, "which design", "what vibe" — you MUST set `ui_related: true` on THAT QUESTION in the `questions` list. It is per-question — in a batch you can flag question 2 as visual while 1 and 3 stay plain text. This gives the user a "See visual options" choice. NEVER hand-write your own "show me some options" text choice — that does nothing; the `ui_related: true` flag is the ONLY thing that surfaces real previews. When they pick it, immediately follow up with `ask_user_uiux_question` showing 2-4 live HTML previews for THAT question only so they can choose the desired behavior **by sight** — the answers they gave to the other questions in the batch still stand, so do not re-ask those. When in doubt on a visual question, set it true.
 - Example (visual → flag ON): "When this is fixed, how should the total line look?", options ["Bold at the bottom", "Highlighted row", "Same as now but correct number"], **`ui_related: true`**.
 - Example (non-visual → flag OFF): "Who runs into this — everyone, or just admins?", options ["Everyone", "Just admins", "Not sure"], `ui_related: false`.
 

--- a/app/agents/leonardo/rails_user_feedback_agent/sub_agents.py
+++ b/app/agents/leonardo/rails_user_feedback_agent/sub_agents.py
@@ -35,6 +35,7 @@ from app.agents.leonardo.llm_factory import get_llm
 from app.agents.leonardo.model_policy import enabled_default_model
 from app.agents.leonardo.delegation import (
     DELEGATION_TIMEOUT_SECONDS,
+    summarize_partial_work,
     DelegationTimedOut,
     run_delegation,
 )
@@ -238,15 +239,16 @@ async def delegate_task(
             ]
         })
 
-    except DelegationTimedOut:
+    except DelegationTimedOut as timeout:
         logger.warning("User Mode sub-agent delegation timed out")
         return Command(update={
             "messages": [
                 ToolMessage(
                     content=(
-                        "[DELEGATED RESEARCH FAILED]\n\n"
-                        f"Timed out after {DELEGATION_TIMEOUT_SECONDS}s — you may retry "
-                        "delegate_task once."
+                        "[DELEGATED RESEARCH TIMED OUT]\n\n"
+                        f"It ran out of time after {DELEGATION_TIMEOUT_SECONDS}s. "
+                        "What it had looked at so far:\n\n"
+                        + summarize_partial_work(timeout.partial_messages)
                     ),
                     tool_call_id=tool_call_id
                 )

--- a/app/agents/leonardo/resilience.py
+++ b/app/agents/leonardo/resilience.py
@@ -174,7 +174,23 @@ def _record_raw_model_call(turn, started_at: float, response) -> None:
         logger.debug("turn_metrics: raw model call not recorded: %s", e)
 
 
-def invoke_with_transient_retry(fn, *, label: str = "model call"):
+def _describe_if_bad_request(exc, messages, tools, label):
+    """Log the redacted shape of a request a provider rejected (raw-node path)."""
+    if messages is None:
+        return
+    try:
+        from app.agents.leonardo.message_invariants import (
+            log_bad_request_shape,
+            looks_like_bad_request,
+        )
+
+        if looks_like_bad_request(exc):
+            log_bad_request_shape(exc, messages, tools=tools, label=label)
+    except Exception:  # noqa: BLE001 - diagnosis must never mask the real error
+        logger.debug("could not describe the rejected request", exc_info=True)
+
+
+def invoke_with_transient_retry(fn, *, label: str = "model call", messages=None, tools=None):
     """Call ``fn()`` with rung-1 transient-error retry semantics, returning its result.
 
     For raw StateGraph nodes (e.g. rails_beginner_agent, rails_ai_builder_agent)
@@ -206,6 +222,9 @@ def invoke_with_transient_retry(fn, *, label: str = "model call"):
         except Exception as e:
             attempt += 1
             if attempt >= _MODEL_RETRY_MAX_ATTEMPTS or not is_transient_error(e):
+                # Same diagnosis the middleware path records: a provider 400
+                # carries nothing actionable, so describe the shape we sent.
+                _describe_if_bad_request(e, messages, tools, label)
                 _record_raw_model_call(turn, started_at, None)
                 raise
             logger.warning(

--- a/app/agents/leonardo/summarization.py
+++ b/app/agents/leonardo/summarization.py
@@ -862,3 +862,84 @@ def make_summarization_middleware(
         summary_prompt=summary_prompt,
         keep_initial_human=keep_initial_human,
     )
+
+
+# ---------------------------------------------------------------------------
+# Context management for RAW StateGraph nodes
+# ---------------------------------------------------------------------------
+#
+# `create_agent` modes get compaction for free: they pass
+# `make_summarization_middleware()` into the middleware stack and LangGraph runs
+# `before_model` for them. A raw `StateGraph` node — one that calls
+# `llm.invoke(messages)` itself — runs NO middleware, so nothing ever trims it
+# and its history climbs until the provider rejects the turn (2026-08-23 fleet
+# telemetry: `rails_beginner_agent` p90 655k tokens, 32 of 33 all-time
+# 1,048,576-token crashes).
+#
+# This is deliberately a thin adapter over the SAME middleware, not a second
+# implementation of the rule — two implementations of one rule is how beginner
+# mode ended up without it.
+
+_COMPACTOR_CACHE: dict = {}
+
+
+def _compactor(summary_prompt: str, keep_initial_human: int):
+    key = (summary_prompt, keep_initial_human)
+    mw = _COMPACTOR_CACHE.get(key)
+    if mw is None:
+        mw = make_summarization_middleware(
+            summary_prompt=summary_prompt,
+            keep_initial_human=keep_initial_human,
+        )
+        _COMPACTOR_CACHE[key] = mw
+    return mw
+
+
+def compact_messages_if_needed(
+    messages,
+    *,
+    summary_prompt: str,
+    keep_initial_human: int = 3,
+    runtime=None,
+):
+    """Compact a raw ``StateGraph`` node's conversation before it hits the model.
+
+    Pass ``state["messages"]`` — the conversation only, NOT the system message
+    or any per-turn notes the node appends, which are rebuilt every turn and
+    must not be summarized away.
+
+    Returns ``(messages_for_the_model, ops_to_persist)``:
+
+    - ``messages_for_the_model`` is what to hand the provider this turn.
+    - ``ops_to_persist`` is the message-channel write that makes the compaction
+      stick (``[RemoveMessage(REMOVE_ALL_MESSAGES), summary, *tail]``, which the
+      ``DeltaChannel`` reducer in ``app/agents/utils/delta_state.py`` honors).
+      Merge it into the node's return value ahead of the model response, or the
+      node pays for a fresh summarization on every single model call.
+
+    Both are empty-safe: when nothing needs doing the original list comes back
+    and ``ops_to_persist`` is ``[]``. Compaction failing must never be the thing
+    that kills a turn, so any exception falls through to the uncompacted list.
+    """
+    from langchain_core.messages import RemoveMessage
+
+    msgs = list(messages or [])
+    if not msgs:
+        return msgs, []
+
+    try:
+        result = _compactor(summary_prompt, keep_initial_human).before_model(
+            {"messages": msgs}, runtime
+        )
+    except Exception:
+        logger.exception(
+            "Context compaction failed; proceeding with the uncompacted history."
+        )
+        return msgs, []
+
+    ops = list((result or {}).get("messages") or [])
+    if not ops:
+        return msgs, []
+
+    kept = [m for m in ops if not isinstance(m, RemoveMessage)]
+    return kept, ops

--- a/app/frontend/chat.html
+++ b/app/frontend/chat.html
@@ -326,7 +326,7 @@
                                 <i class="fa-solid fa-upload"></i> Upload file
                             </button>
                             <button data-llamabot="browse-files-btn" class="file-attach-menu-item">
-                                <i class="fa-solid fa-folder-open"></i> Browse and attach
+                                <i class="fa-solid fa-folder-open"></i> My Uploads
                             </button>
                         </div>
                         <!-- File browser panel -->
@@ -1019,6 +1019,11 @@
                 <div class="asset-modal-header-actions">
                     <button data-llamabot="asset-modal-refresh" class="asset-modal-icon-btn" data-tooltip="Refresh the asset list" data-tooltip-pos="bottom" aria-label="Refresh">
                         <i class="fa-solid fa-rotate"></i>
+                    </button>
+                    <!-- Fills the screen and hides the file list — a spreadsheet in the
+                         default 1100px modal only gets ~800px of width. -->
+                    <button data-llamabot="asset-modal-expand" class="asset-modal-icon-btn" data-tooltip="Expand to full screen" data-tooltip-pos="bottom" aria-label="Expand preview to full screen" aria-pressed="false">
+                        <i class="fa-solid fa-up-right-and-down-left-from-center"></i>
                     </button>
                     <button data-llamabot="asset-modal-close" class="asset-modal-icon-btn" data-tooltip="Close (Esc)" data-tooltip-pos="bottom" aria-label="Close">
                         <i class="fa-solid fa-xmark"></i>

--- a/app/frontend/chat/checkpoints/GitHubAuthModal.js
+++ b/app/frontend/chat/checkpoints/GitHubAuthModal.js
@@ -2,15 +2,205 @@
  * GitHubAuthModal - GitHub Device Flow OAuth modal
  *
  * Shows a modal with the device code and link to github.com/login/device.
- * Polls the backend until the user completes authorization.
+ * Polls the backend until the user completes authorization — see
+ * DeviceAuthPoller below for why that poll is not a plain setInterval.
  */
 
+export const POLL_ENDPOINT = '/api/github/poll-auth';
+export const DEFAULT_INTERVAL = 5;      // seconds; GitHub's own floor
+export const MIN_WATCH_SECONDS = 120;   // keep watching this long even if told otherwise
+export const MAX_TRANSIENT_ERRORS = 3;  // consecutive network/5xx failures before giving up
+
+/**
+ * Drives the "waiting for authorization" wait so the user never has to press
+ * "check now". Three things a naive setInterval gets wrong:
+ *
+ *   - The user authorizes on github.com in ANOTHER tab, so this one is
+ *     backgrounded and its timers are throttled to roughly once a minute. We
+ *     re-check the moment the tab is looked at again (visibility/focus/online).
+ *   - The successful poll installs the token on the host (gh auth login +
+ *     docker cp), which can take tens of seconds. A timer firing underneath it
+ *     would ask GitHub about an already-redeemed device code and paint an error
+ *     over the success — so only one check is ever in flight.
+ *   - A single transient 5xx must not end the wait.
+ *
+ * Timers, fetch and the clock are injectable so this is testable without
+ * waiting on real time (see app/tests/js/github_device_autopoll.test.mjs).
+ */
+export class DeviceAuthPoller {
+  constructor({
+    deviceCode,
+    interval = DEFAULT_INTERVAL,
+    expiresIn = 900,
+    fetchFn = (...args) => fetch(...args),
+    timers = { setTimeout: (...a) => setTimeout(...a), clearTimeout: (...a) => clearTimeout(...a) },
+    doc = typeof document !== 'undefined' ? document : null,
+    win = typeof window !== 'undefined' ? window : null,
+    now = () => Date.now(),
+    onResult = () => {},
+    onCheckingChange = () => {},
+  } = {}) {
+    this.deviceCode = deviceCode;
+    this.intervalSeconds = Math.max(interval || DEFAULT_INTERVAL, DEFAULT_INTERVAL);
+    this.expiresIn = expiresIn;
+    this.fetchFn = fetchFn;
+    this.timers = timers;
+    this.doc = doc;
+    this.win = win;
+    this.now = now;
+    this.onResult = onResult;
+    this.onCheckingChange = onCheckingChange;
+
+    this.stopped = false;
+    this.inFlight = false;
+    this.timer = null;
+    this.deadline = null;
+    this.lastCheckAt = null;
+    this.transientErrors = 0;
+    this.wakeEvents = [];
+    this._onWake = () => { this.wake(); };
+  }
+
+  /** Begin the wait: hook the wake events and schedule the first check. */
+  start() {
+    if (this.stopped) return;
+    this.lastCheckAt = this.now();
+    this.deadline = this.now() + Math.max(this.expiresIn || 0, MIN_WATCH_SECONDS) * 1000;
+    this._listen();
+    this._schedule();
+  }
+
+  /**
+   * The tab came back (or the network did). Check right away if GitHub's
+   * interval floor has elapsed; otherwise leave the pending timer alone.
+   */
+  wake() {
+    if (this.stopped || this.inFlight) return;
+    const since = this.now() - (this.lastCheckAt ?? 0);
+    if (since >= this.intervalSeconds * 1000) {
+      this.timers.clearTimeout(this.timer);
+      this.timer = null;
+      this.check();
+    }
+  }
+
+  /**
+   * One poll. Safe to call from the timer, a wake, or the manual button — a
+   * check already in flight simply wins.
+   */
+  async check() {
+    if (this.stopped || this.inFlight) return null;
+    this.inFlight = true;
+    this.lastCheckAt = this.now();
+    this.onCheckingChange(true);
+
+    let status = null;
+    try {
+      const resp = await this.fetchFn(POLL_ENDPOINT, {
+        method: 'POST',
+        credentials: 'same-origin',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ device_code: this.deviceCode }),
+      });
+
+      if (!resp.ok) {
+        status = this._transient('Server error while checking GitHub');
+      } else {
+        const data = await resp.json();
+        this.transientErrors = 0;
+        status = data.status || 'error';
+        this._handle(status, data);
+      }
+    } catch (e) {
+      status = this._transient(e?.message || 'Network error while checking GitHub');
+    } finally {
+      this.inFlight = false;
+      this.onCheckingChange(false);
+      if (!this.stopped) this._schedule();
+    }
+    return status;
+  }
+
+  /** Stop polling and unhook the wake listeners. Idempotent. */
+  stop() {
+    this.stopped = true;
+    this.timers.clearTimeout(this.timer);
+    this.timer = null;
+    this._unlisten();
+  }
+
+  _handle(status, data) {
+    switch (status) {
+      case 'pending':
+        this.onResult('pending', data);
+        break;
+      case 'slow_down':
+        // GitHub asks for more room between polls; take it and keep waiting.
+        this.intervalSeconds = Math.max(data.interval || this.intervalSeconds + 5, this.intervalSeconds + 5);
+        this.onResult('slow_down', data);
+        break;
+      case 'success':
+      case 'expired':
+      case 'denied':
+        this.stop();
+        this.onResult(status, data);
+        break;
+      default:
+        this.stop();
+        this.onResult('error', data);
+    }
+  }
+
+  /** Ride out the odd network blip; give up only if they keep coming. */
+  _transient(message) {
+    this.transientErrors += 1;
+    if (this.transientErrors > MAX_TRANSIENT_ERRORS) {
+      this.stop();
+      this.onResult('error', { message });
+      return 'error';
+    }
+    console.warn('GitHub poll error:', message);
+    return 'retry';
+  }
+
+  _schedule() {
+    if (this.stopped) return;
+    if (this.deadline !== null && this.now() >= this.deadline) {
+      this.stop();
+      this.onResult('expired', { message: 'Authorization code expired. Please try again.' });
+      return;
+    }
+    this.timers.clearTimeout(this.timer);
+    this.timer = this.timers.setTimeout(() => { this.timer = null; return this.check(); }, this.intervalSeconds * 1000);
+  }
+
+  _listen() {
+    this._unlisten();
+    if (this.doc?.addEventListener) {
+      this.doc.addEventListener('visibilitychange', this._onWake);
+      this.wakeEvents.push([this.doc, 'visibilitychange']);
+    }
+    if (this.win?.addEventListener) {
+      this.win.addEventListener('focus', this._onWake);
+      this.win.addEventListener('online', this._onWake);
+      this.wakeEvents.push([this.win, 'focus'], [this.win, 'online']);
+    }
+  }
+
+  _unlisten() {
+    this.wakeEvents.forEach(([target, name]) => target.removeEventListener(name, this._onWake));
+    this.wakeEvents = [];
+  }
+}
+
 export class GitHubAuthModal {
-  constructor() {
+  constructor(options = {}) {
     this.modal = null;
-    this.pollInterval = null;
+    this.poller = null;
     this.deviceCode = null;
     this.aborted = false;
+    // Injection seam for tests; the browser gets the real globals.
+    this.pollerOptions = options.pollerOptions || {};
   }
 
   /**
@@ -49,7 +239,7 @@ export class GitHubAuthModal {
       const data = await resp.json();
       this.deviceCode = data.device_code;
       this.showModal(data.user_code, data.verification_uri, data.interval);
-      this.startPolling(data.device_code, data.interval);
+      this.startPolling(data.device_code, data.interval, data.expires_in);
     } catch (e) {
       this.showError('Failed to connect to server: ' + e.message);
     }
@@ -108,7 +298,7 @@ export class GitHubAuthModal {
         </div>
         <div class="gh-auth-waiting">
           <i class="fa-solid fa-spinner fa-spin"></i>
-          <span>Waiting for authorization...</span>
+          <span class="gh-auth-waiting-text">Waiting for authorization — this checks itself, no need to refresh.</span>
           <button class="gh-auth-check-btn" title="Check now">
             <i class="fa-solid fa-rotate"></i>
           </button>
@@ -136,9 +326,9 @@ export class GitHubAuthModal {
       }
     };
 
-    // Check now button - manual poll trigger
+    // Check now button — the flow polls itself; this is just an impatience valve.
     this.modal.querySelector('.gh-auth-check-btn').onclick = () => {
-      this.pollOnce(this.deviceCode);
+      this.poller?.wake();
     };
 
     // Cancel button
@@ -216,117 +406,57 @@ export class GitHubAuthModal {
     document.body.appendChild(this.modal);
   }
 
-  startPolling(deviceCode, interval) {
-    const pollMs = (interval || 5) * 1000;
-
-    this.pollInterval = setInterval(async () => {
-      if (this.aborted) {
-        this.stopPolling();
-        return;
-      }
-
-      try {
-        const resp = await fetch('/api/github/poll-auth', {
-          method: 'POST',
-          credentials: 'same-origin',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ device_code: deviceCode }),
-        });
-
-        if (!resp.ok) {
-          this.showError('Server error while polling');
-          this.stopPolling();
-          return;
-        }
-
-        const data = await resp.json();
-
-        switch (data.status) {
+  /**
+   * Wait for the user to finish on github.com. DeviceAuthPoller keeps checking
+   * on its own — including the instant the user switches back to this tab,
+   * which is when a plain interval would still be throttled — so the "check
+   * now" button is optional rather than the way the flow completes.
+   */
+  startPolling(deviceCode, interval, expiresIn) {
+    this.stopPolling();
+    this.deviceCode = deviceCode;
+    this.poller = new DeviceAuthPoller({
+      deviceCode,
+      interval,
+      expiresIn,
+      onCheckingChange: (checking) => this.setChecking(checking),
+      onResult: (status, data = {}) => {
+        switch (status) {
           case 'success':
-            this.stopPolling();
             this.showSuccess(data.message || 'GitHub connected!');
             break;
-          case 'pending':
-            // Keep polling
-            break;
-          case 'slow_down':
-            // GitHub wants us to slow down - restart with longer interval
-            this.stopPolling();
-            this.startPolling(deviceCode, data.interval || 10);
-            break;
           case 'expired':
-            this.stopPolling();
-            this.showError('Authorization code expired. Please try again.');
+            this.showError(data.message || 'Authorization code expired. Please try again.');
             break;
           case 'denied':
-            this.stopPolling();
             this.showError('Authorization was denied.');
             break;
-          default:
-            this.stopPolling();
+          case 'error':
             this.showError(data.message || 'Unexpected error');
+            break;
+          default:
+            break;  // pending / slow_down — keep waiting
         }
-      } catch (e) {
-        // Network error - keep trying
-        console.warn('GitHub poll error:', e);
-      }
-    }, pollMs);
+      },
+      ...this.pollerOptions,
+    });
+    this.poller.start();
   }
 
-  async pollOnce(deviceCode) {
-    const checkBtn = this.modal?.querySelector('.gh-auth-check-btn');
-    if (checkBtn) {
-      checkBtn.innerHTML = '<i class="fa-solid fa-rotate fa-spin"></i>';
-      checkBtn.disabled = true;
-    }
-
-    try {
-      const resp = await fetch('/api/github/poll-auth', {
-        method: 'POST',
-        credentials: 'same-origin',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ device_code: deviceCode }),
-      });
-
-      if (!resp.ok) {
-        this.showError('Server error while checking');
-        this.stopPolling();
-        return;
-      }
-
-      const data = await resp.json();
-
-      if (data.status === 'success') {
-        this.stopPolling();
-        this.showSuccess(data.message || 'GitHub connected!');
-      } else if (data.status === 'pending') {
-        // Still waiting - restore button
-        if (checkBtn) {
-          checkBtn.innerHTML = '<i class="fa-solid fa-rotate"></i>';
-          checkBtn.disabled = false;
-        }
-      } else if (data.status === 'expired') {
-        this.stopPolling();
-        this.showError('Authorization code expired. Please try again.');
-      } else if (data.status === 'denied') {
-        this.stopPolling();
-        this.showError('Authorization was denied.');
-      } else {
-        this.stopPolling();
-        this.showError(data.message || 'Unexpected error');
-      }
-    } catch (e) {
-      if (checkBtn) {
-        checkBtn.innerHTML = '<i class="fa-solid fa-rotate"></i>';
-        checkBtn.disabled = false;
-      }
-    }
+  /** Spin the check button while a poll is in flight. */
+  setChecking(checking) {
+    const btn = this.modal?.querySelector('.gh-auth-check-btn');
+    if (!btn) return;
+    btn.innerHTML = checking
+      ? '<i class="fa-solid fa-rotate fa-spin"></i>'
+      : '<i class="fa-solid fa-rotate"></i>';
+    btn.disabled = checking;
   }
 
   stopPolling() {
-    if (this.pollInterval) {
-      clearInterval(this.pollInterval);
-      this.pollInterval = null;
+    if (this.poller) {
+      this.poller.stop();
+      this.poller = null;
     }
   }
 

--- a/app/frontend/chat/config.js
+++ b/app/frontend/chat/config.js
@@ -92,6 +92,16 @@ export const DEFAULT_CONFIG = {
 };
 
 /**
+ * Inactivity warning banner ("Session expiring soon due to inactivity.").
+ *
+ * Temporarily OFF (0.7.4). The lease itself and the activity sync behind it are
+ * untouched — this only suppresses the yellow banner, which we don't need in
+ * front of users right now. Flip to true to bring it back; no other code
+ * changes are needed.
+ */
+export const INACTIVITY_WARNING_BANNER_ENABLED = false;
+
+/**
  * Resolve the active agent-mode -> agent_name map.
  *
  * Built-in modes (DEFAULT_CONFIG.agentModes) are always present and always win.

--- a/app/frontend/chat/index.js
+++ b/app/frontend/chat/index.js
@@ -3,7 +3,7 @@
  * Initializes and coordinates all modules
  */
 
-import { DEFAULT_CONFIG, getRailsUrl } from './config.js';
+import { DEFAULT_CONFIG, getRailsUrl, INACTIVITY_WARNING_BANNER_ENABLED } from './config.js';
 import { setCookie, getCookie } from './utils/cookies.js';
 import { errorReporter } from './utils/ErrorReporter.js';
 import { leoDiagnostics } from './utils/LeoDiagnostics.js';
@@ -23,6 +23,7 @@ import { PromptManager } from './ui/PromptManager.js';
 import { BrandGuide } from './ui/BrandGuide.js';
 import { ColorAttach } from './ui/ColorAttach.js';
 import { ErrorAttach } from './ui/ErrorAttach.js';
+import { RailsErrorPoll } from './ui/RailsErrorPoll.js';
 import { FileAttachmentManager } from './ui/FileAttachmentManager.js';
 import { ScreenRecorder } from './ui/ScreenRecorder.js';
 import { ScreenshotAnnotator } from './ui/ScreenshotAnnotator.js';
@@ -322,16 +323,18 @@ class ChatApp {
     // NOT re-send the user message (that's what caused the duplicate-restart
     // bug). The client_message_id idempotency guard remains a backstop. The
     // small delay lets the auth message go first (sendAuthMessage is async).
-    window.addEventListener('websocketConnected', () => {
+    // `websocketReady`, not `websocketConnected`: the server refuses `attach`
+    // until the socket has authenticated, and the token fetch is async. This
+    // used to be a 300ms timer racing that handshake — losing the race now
+    // costs the run its live output, so wait for the real signal instead.
+    window.addEventListener('websocketReady', () => {
       if (!this.isAgentRunning) return;
       const threadId = this.appState.getThreadId?.();
       if (!threadId) return;
       const lastSeq = this.messageHandler?.getLastSeq?.(threadId) || 0;
-      setTimeout(() => {
-        if (this.webSocketManager?.send({ type: 'attach', thread_id: threadId, last_seq: lastSeq })) {
-          console.log(`Resumed: attached to background run (thread=${threadId}, last_seq=${lastSeq})`);
-        }
-      }, 300);
+      if (this.webSocketManager?.send({ type: 'attach', thread_id: threadId, last_seq: lastSeq })) {
+        console.log(`Resumed: attached to background run (thread=${threadId}, last_seq=${lastSeq})`);
+      }
     });
 
     // Layer 2: the background run for this thread is gone (server restarted, or
@@ -489,6 +492,29 @@ class ChatApp {
         this.elements.jsErrorBanner,
         this.elements.messageInput
       );
+    });
+
+    safeInit('rails error poll', () => {
+      // The other half of the tray: crashes from the Rails app itself. They
+      // cannot be pushed the way the preview's JS errors are — the app has no
+      // handle on this page — so we poll LlamaBot's proxy of the crash feed.
+      // Own safeInit for the same reason as the tray above.
+      this.railsErrorPoll = new RailsErrorPoll({
+        getToken: () => this.getRailsApiToken(),
+        // Mid-turn crashes belong to Leo's auto-recovery, which is already
+        // fixing them without showing the user a broken page.
+        isAgentRunning: () => this.isAgentRunning,
+        onErrors: (errors) => errors.forEach((e) => this.errorAttach?.record(e)),
+      });
+      this.railsErrorPoll.start();
+
+      // A 500 usually arrives as a page the preview just navigated to, and by
+      // the time it has loaded the crash is already in the feed. Asking now
+      // instead of on the next tick is the difference between the notice
+      // appearing with the broken page and appearing a few seconds later.
+      this.elements.liveSiteFrame?.addEventListener('load', () => {
+        this.railsErrorPoll.nudge();
+      });
     });
 
     // The step that failed on leo-tama (initAssetModal). Attaching, uploads and
@@ -2319,6 +2345,8 @@ class ChatApp {
    * Start periodic inactivity check
    */
   startInactivityCheck() {
+    // Banner is disabled for now — don't burn a timer on a check that can't fire.
+    if (!INACTIVITY_WARNING_BANNER_ENABLED) return;
     // Check every 30 seconds if we should show warning
     this.inactivityCheckInterval = setInterval(() => this.checkInactivityWarning(), 30000);
   }
@@ -2346,6 +2374,9 @@ class ChatApp {
    * Show the timeout warning banner
    */
   showTimeoutWarning() {
+    // Single choke point for the banner: with the flag off it never appears,
+    // whoever calls this.
+    if (!INACTIVITY_WARNING_BANNER_ENABLED) return;
     const banner = this.container.querySelector('[data-llamabot="timeout-warning"]');
     if (banner && banner.classList.contains('hidden')) {
       banner.classList.remove('hidden');

--- a/app/frontend/chat/messages/QuestionCard.js
+++ b/app/frontend/chat/messages/QuestionCard.js
@@ -1,0 +1,206 @@
+/**
+ * Question card markup + answer formatting for `ask_user_question`.
+ *
+ * Leo can ask 1-4 questions in a single interrupt. The card renders one block per
+ * question; the user answers them all and submits once, which is a whole round-trip
+ * saved per extra question.
+ *
+ * The pieces that matter live here (pure, no DOM) rather than in MessageHandler so the
+ * answer format — the actual contract with the agent — can be tested without a browser.
+ * MessageHandler keeps the event wiring.
+ */
+
+/**
+ * Submitted for a question when the user picks "See visual options" instead of
+ * answering. It is a directive, not an answer: it asks Leo to re-ask THIS question
+ * visually via ask_user_uiux_question. In a batch it must name the question, or Leo
+ * can't tell which one to draw — and must say the other answers still stand, or Leo
+ * re-asks everything.
+ */
+export function uiuxRequestDirective(questionText, { batched = false } = {}) {
+  const target = questionText ? ` for this question ("${questionText}")` : ' for this';
+  return (
+    `The user would like to see visual UI/UX options${target}. Please call the ` +
+    'ask_user_uiux_question tool with 2-4 concrete example designs (live HTML previews) ' +
+    'for it instead of answering in text.' +
+    (batched ? ' Keep the answers given to the other questions — do not re-ask those.' : '')
+  );
+}
+
+/**
+ * Normalize a `question_request` frame into a list of questions.
+ *
+ * The backend sends `questions` (the batch) and also mirrors the first one into the
+ * legacy top-level `question`/`options`/`ui_related` fields, so an older cached
+ * frontend still renders something. Read the batch when it's there, fall back otherwise.
+ */
+export function normalizeQuestions(data) {
+  const batch = Array.isArray(data?.questions) ? data.questions : [];
+  const source = batch.length
+    ? batch
+    : [{ question: data?.question, options: data?.options, ui_related: data?.ui_related }];
+
+  return source
+    .map(q => ({
+      question: String(q?.question ?? '').trim(),
+      options: Array.isArray(q?.options) ? q.options.map(String) : [],
+      ui_related: !!q?.ui_related,
+    }))
+    .filter(q => q.question.length > 0);
+}
+
+/** Escape for use inside a double-quoted HTML attribute. */
+function escapeAttr(value) {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+const EYE_ICON =
+  '<svg viewBox="0 0 24 24" width="13" height="13" fill="currentColor" aria-hidden="true">' +
+  '<path d="M12 2C6.49 2 2 6.49 2 12s4.49 10 10 10c1.38 0 2.5-1.12 2.5-2.5 0-.61-.23-1.2-.64-1.67-.08-.1-.13-.21-.13-.33 0-.28.22-.5.5-.5H16c3.31 0 6-2.69 6-6 0-4.96-4.49-9-10-9zm-5.5 9c-.83 0-1.5-.67-1.5-1.5S5.67 8 6.5 8 8 8.67 8 9.5 7.33 11 6.5 11zm3-4C8.67 7 8 6.33 8 5.5S8.67 4 9.5 4s1.5.67 1.5 1.5S10.33 7 9.5 7zm5 0c-.83 0-1.5-.67-1.5-1.5S13.67 4 14.5 4s1.5.67 1.5 1.5S15.33 7 14.5 7zm3 4c-.83 0-1.5-.67-1.5-1.5S16.67 8 17.5 8s1.5.67 1.5 1.5-.67 1.5-1.5 1.5z"/></svg>';
+
+/**
+ * Build the card markup.
+ *
+ * A single question renders exactly as it always has (options row with Skip, hidden
+ * Continue, free-text row with a send arrow). Two or more switch to the batched
+ * layout: one block per question, a per-question Skip, and one footer Continue that
+ * stays disabled until every question is answered or skipped.
+ *
+ * `escapeHtml` and `parseMarkdown` are injected so this module stays DOM-free.
+ */
+export function buildQuestionCardHtml({
+  questionId,
+  questions,
+  context = '',
+  threadId,
+  agentName,
+  escapeHtml,
+  parseMarkdown,
+}) {
+  const batched = questions.length > 1;
+
+  const blocks = questions.map((q, i) => {
+    const optionButtons = q.options.map(opt =>
+      `<button class="plan-option-btn" data-qi="${i}" data-option="${escapeAttr(opt)}">${escapeHtml(opt)}</button>`
+    ).join('');
+
+    // Only on questions the agent flagged as visual. Kept per-question in a batch:
+    // the user can ask for previews on question 2 while answering 1 and 3 in text.
+    const uiuxBtn = q.ui_related ? `
+        <button class="plan-option-btn plan-uiux-request-btn" data-qi="${i}" data-uiux-request="true"
+                title="Have Leo show you visual UI/UX options to pick from">
+          ${EYE_ICON}See visual options
+        </button>` : '';
+
+    // Batched: Skip marks just this question and waits for Continue.
+    // Single: Skip submits the whole card immediately (unchanged behaviour).
+    const skipBtn = `<button class="plan-skip-btn" data-qi="${i}">Skip</button>`;
+    const hasOptionRow = q.options.length > 0 || q.ui_related || batched;
+
+    const sendBtn = batched ? '' : `<button class="plan-send-btn"><i class="fa-solid fa-arrow-up"></i></button>`;
+
+    return `
+      <div class="plan-question-item" data-qi="${i}" data-question-text="${escapeAttr(q.question)}">
+        ${batched ? `<span class="plan-question-num">${i + 1}</span>` : ''}
+        <div class="plan-question-text">${parseMarkdown(q.question)}</div>
+        ${hasOptionRow ? `<div class="plan-question-options">${optionButtons}${uiuxBtn}${skipBtn}</div>` : ''}
+        <div class="plan-question-input-row">
+          <textarea class="plan-question-input" data-qi="${i}" rows="${batched ? 1 : 2}" placeholder="${batched ? 'Or type your own…' : 'Add to your answer...'}"></textarea>
+          ${sendBtn}
+        </div>
+      </div>`;
+  }).join('');
+
+  const foot = batched ? `
+      <div class="plan-question-foot">
+        <span class="plan-question-progress">0 of ${questions.length} answered</span>
+        <div class="plan-question-foot-actions">
+          <button class="plan-skip-all-btn">Skip all</button>
+          <button class="plan-continue-btn" disabled>Continue</button>
+        </div>
+      </div>`
+    : `<button class="plan-continue-btn" style="display: none;">Continue</button>`;
+
+  return `
+      <div class="plan-question-card${batched ? ' batched' : ''}" data-question-id="${questionId}"
+           data-thread-id="${escapeAttr(threadId)}" data-agent-name="${escapeAttr(agentName)}"
+           data-count="${questions.length}">
+        ${context ? `<div class="plan-question-context">${escapeHtml(context)}</div>` : ''}
+        ${blocks}
+        ${foot}
+      </div>
+    `;
+}
+
+/**
+ * True once this question has something to send.
+ * A blank question is what keeps Continue disabled in a batch.
+ */
+export function isAnswered(state) {
+  return !!(state && (state.skipped || state.uiux || state.options.length > 0 || (state.text || '').trim()));
+}
+
+/**
+ * Turn the per-question UI state into what resumes the agent (`answer`) and what the
+ * user sees in their own chat bubble (`display`).
+ *
+ * A single question keeps the original flat format so nothing about existing
+ * one-at-a-time behaviour changes. A batch is numbered and pairs each question with
+ * its answer, because the agent has no other way to map answers back to questions.
+ *
+ * `states[i]` is `{ options: string[], text: string, uiux: bool, skipped: bool }`.
+ */
+export function buildSubmission(questions, states) {
+  const batched = questions.length > 1;
+
+  if (!batched) {
+    const s = states[0] || { options: [], text: '', uiux: false, skipped: false };
+    const freeText = (s.text || '').trim();
+    const parts = [...s.options];
+    const displayParts = [...s.options];
+    if (freeText) { parts.push(freeText); displayParts.push(freeText); }
+    if (s.uiux) {
+      parts.push(uiuxRequestDirective(questions[0]?.question));
+      displayParts.push('See visual options');
+    }
+    return { answer: parts.join(', '), display: displayParts.join(', ') };
+  }
+
+  const answerBlocks = [];
+  const displayLines = [];
+
+  questions.forEach((q, i) => {
+    const s = states[i] || { options: [], text: '', uiux: false, skipped: false };
+    const freeText = (s.text || '').trim();
+
+    let answer;
+    let shown;
+    if (s.uiux) {
+      answer = uiuxRequestDirective(q.question, { batched: true });
+      shown = 'See visual options';
+      // Anything typed alongside the request is still useful context for the previews.
+      if (freeText) { answer += ` The user added: "${freeText}"`; shown += `, ${freeText}`; }
+    } else if (s.skipped || (!s.options.length && !freeText)) {
+      answer = '(skipped — no preference)';
+      shown = '(skipped)';
+    } else {
+      const parts = [...s.options];
+      if (freeText) parts.push(freeText);
+      answer = parts.join(', ');
+      shown = answer;
+    }
+
+    answerBlocks.push(`${i + 1}. ${q.question}\n→ ${answer}`);
+    displayLines.push(`${q.question} → ${shown}`);
+  });
+
+  return {
+    answer: `The user answered all ${questions.length} questions:\n\n${answerBlocks.join('\n\n')}`,
+    display: displayLines.join('\n'),
+  };
+}

--- a/app/frontend/chat/ui/ErrorAttach.js
+++ b/app/frontend/chat/ui/ErrorAttach.js
@@ -88,12 +88,19 @@ export class ErrorAttach {
       stack: raw.stack ? String(raw.stack).slice(0, 4000) : null,
       path: String(raw.path || ''),
       timestamp: Number(raw.timestamp) || Date.now(),
-      count: 1
+      // Server errors arrive with a total already on them: the Rails feed
+      // collapses a render loop into a count rather than 200 entries, so this is
+      // the only place that number exists. Pushed JS errors carry no count and
+      // are tallied here instead.
+      count: Math.max(1, Number(raw.count) || 1),
+      counted: Number(raw.count) > 0
     };
 
     const dupe = this.errors.find((e) => e.message === entry.message && e.path === entry.path);
     if (dupe) {
-      dupe.count += 1;
+      // A source that counts for itself re-reports its running total, so taking
+      // the larger is right and incrementing would double-count it.
+      dupe.count = entry.counted ? Math.max(dupe.count, entry.count) : dupe.count + 1;
       dupe.timestamp = entry.timestamp;
     } else {
       this.errors.push(entry);
@@ -136,15 +143,29 @@ export class ErrorAttach {
    */
   buildMessageBlock() {
     if (!this.sending()) return '';
-    const body = this.errors.map((e) => {
-      const times = e.count > 1 ? ` (x${e.count})` : '';
-      const where = e.path ? ` on ${e.path}` : '';
-      const stack = e.stack ? `\n${e.stack}` : '';
-      return `[${e.kind}]${where}${times}: ${e.message}${stack}`;
-    }).join('\n\n');
-    const plural = this.errors.length > 1 ? 's' : '';
-    return `<PAGE_JS_ERRORS>\nThe user attached the following JavaScript error${plural} `
-      + `from their app preview:\n\n${body}\n</PAGE_JS_ERRORS>`;
+
+    // Two tags, because they are two different jobs. A Ruby backtrace described
+    // as "a JavaScript error from their app preview" would send Leo looking in
+    // the wrong half of the app — and a 500 is fixed in a controller or a view,
+    // not in the page's script.
+    const blocks = [];
+
+    const js = this.errors.filter((e) => e.kind !== 'rails');
+    if (js.length > 0) {
+      const plural = js.length > 1 ? 's' : '';
+      blocks.push(`<PAGE_JS_ERRORS>\nThe user attached the following JavaScript error${plural} `
+        + `from their app preview:\n\n${formatErrors(js)}\n</PAGE_JS_ERRORS>`);
+    }
+
+    const rails = this.errors.filter((e) => e.kind === 'rails');
+    if (rails.length > 0) {
+      const plural = rails.length > 1 ? 's' : '';
+      blocks.push(`<RAILS_SERVER_ERRORS>\nThe user attached the following error${plural} `
+        + `their Rails app raised while they were using it:\n\n${formatErrors(rails)}\n`
+        + `</RAILS_SERVER_ERRORS>`);
+    }
+
+    return blocks.join('\n\n');
   }
 
   /** True when the current errors would ride along with a send. */
@@ -177,13 +198,15 @@ export class ErrorAttach {
       return;
     }
 
-    const total = this.errors.reduce((n, e) => n + e.count, 0);
-    const plural = total === 1 ? '' : 's';
-
+    // Distinct problems, not total occurrences. One broken page that raises the
+    // same error on every render is one thing to fix, and Rails counts those in
+    // the dozens — "50 errors detected" would be alarming and wrong. How many
+    // times each one fired is in the popup, on the entry it belongs to, which is
+    // also the only place it means anything.
     this.banner.classList.remove('hidden');
     this.banner.innerHTML = `
       <span class="js-error-dot"></span>
-      <span class="js-error-count">${total} error${plural} detected</span>
+      <span class="js-error-count">${this._countLabel()}</span>
       <button type="button" class="js-error-more" data-act="details">Read more</button>
       <label class="js-error-show">
         <input type="checkbox" data-act="show" ${this.showLeo ? 'checked' : ''} />
@@ -211,6 +234,26 @@ export class ErrorAttach {
    * Open the details popup. Built on demand and thrown away on close — it is
    * describing a list that changes, so there is nothing worth keeping around.
    */
+  /**
+   * "1 Rails error, 2 JavaScript errors detected".
+   *
+   * Naming the kind is the whole point of the line. The two mean different
+   * things to whoever is looking: a JavaScript error means the page loaded and
+   * something on it misbehaved; a Rails error means the request never made it
+   * out of the server — and those happen on screens that look completely fine,
+   * which is exactly when nobody would think to look.
+   */
+  _countLabel() {
+    const rails = this.errors.filter((e) => e.kind === 'rails').length;
+    const js = this.errors.length - rails;
+    const part = (n, name) => `${n} ${name} error${n === 1 ? '' : 's'}`;
+
+    const parts = [];
+    if (rails) parts.push(part(rails, 'Rails'));
+    if (js) parts.push(part(js, 'JavaScript'));
+    return `${parts.join(', ')} detected`;
+  }
+
   openDetails() {
     if (this.modal) return;              // already open; don't stack a second one
     if (this.errors.length === 0) return;
@@ -252,7 +295,8 @@ export class ErrorAttach {
       : `These aren't being sent right now — tick <strong>Show Leo</strong> on the notice to include them with your next message.`;
 
     const items = this.errors.map((e) => `
-      <li class="js-error-item">
+      <li class="js-error-item${e.kind === 'rails' ? ' js-error-item--rails' : ''}">
+        <span class="js-error-kind">${kindLabel(e)}</span>
         <div class="js-error-item-plain">${escapeHtml(friendlySummary(e))}</div>
         <div class="js-error-item-tech">${escapeHtml(e.message)}</div>
         <div class="js-error-item-meta">
@@ -292,6 +336,10 @@ export function friendlySummary(e) {
   const message = String((e && e.message) || '');
   const kind = (e && e.kind) || '';
 
+  // Server errors first: a Ruby NoMethodError would otherwise be described in
+  // the language of the browser, which is both wrong and unhelpful.
+  if (kind === 'rails') return serverSummary(message);
+
   if (/NetworkError|Failed to fetch|fetch failed|ERR_|status (4|5)\d\d/i.test(message)) {
     return "A request to the server didn't go through.";
   }
@@ -311,6 +359,46 @@ export function friendlySummary(e) {
     return 'A background task failed and nothing caught it.';
   }
   return 'The page hit an unexpected error.';
+}
+
+/**
+ * Which half of the stack this came from, as a word the user can act on.
+ *
+ * Derived from a fixed two-way mapping rather than echoing `e.kind`, so an
+ * app-controlled value can never reach the markup.
+ */
+export function kindLabel(e) {
+  return (e && e.kind) === 'rails' ? 'Rails' : 'JavaScript';
+}
+
+/** The same job as friendlySummary, for the exceptions Rails raises. */
+function serverSummary(message) {
+  if (/PendingMigration/.test(message)) {
+    return 'The database is missing a change the app expects.';
+  }
+  if (/RecordNotFound/.test(message)) {
+    return "The app asked for something in the database that doesn't exist.";
+  }
+  if (/StatementInvalid|PG::|ActiveRecord::/.test(message)) {
+    return "The database couldn't do what the app asked.";
+  }
+  if (/MissingTemplate|ActionView::/.test(message)) {
+    return 'The server hit an error while building this page.';
+  }
+  if (/RoutingError|ActionController::/.test(message)) {
+    return "The server didn't know how to handle that request.";
+  }
+  return 'The server hit an error handling that request.';
+}
+
+/** One line per error, shared by both blocks sent to Leo. */
+function formatErrors(errors) {
+  return errors.map((e) => {
+    const times = e.count > 1 ? ` (x${e.count})` : '';
+    const where = e.path ? ` on ${e.path}` : '';
+    const stack = e.stack ? `\n${e.stack}` : '';
+    return `[${e.kind}]${where}${times}: ${e.message}${stack}`;
+  }).join('\n\n');
 }
 
 function truncate(s, n) {

--- a/app/frontend/chat/ui/FileAttachmentManager.js
+++ b/app/frontend/chat/ui/FileAttachmentManager.js
@@ -136,10 +136,14 @@ export class FileAttachmentManager {
 
     if (!browseBtn || !panel || !listEl) return;
 
+    // "My Uploads" goes straight to the full Asset Library modal. The small
+    // panel below used to be an intermediate step — one extra click to see the
+    // same list with no previews — so the menu item skips it entirely.
     browseBtn.addEventListener('click', (e) => {
       e.stopPropagation();
       this.hideMenu();
-      this.toggleFileBrowser();
+      this.hideFileBrowser();
+      this.openAssetModal();
     });
 
     if (closeBtn) {
@@ -317,6 +321,11 @@ export class FileAttachmentManager {
 
     const closeBtn = modal.querySelector('[data-llamabot="asset-modal-close"]');
     const refreshBtn = modal.querySelector('[data-llamabot="asset-modal-refresh"]');
+    this.assetModalExpandBtn = modal.querySelector('[data-llamabot="asset-modal-expand"]');
+
+    if (this.assetModalExpandBtn) {
+      this.assetModalExpandBtn.addEventListener('click', () => this.toggleAssetModalExpanded());
+    }
 
     if (expandBtn) {
       expandBtn.addEventListener('click', (e) => {
@@ -334,16 +343,45 @@ export class FileAttachmentManager {
       if (e.target === modal) this.hideAssetModal();
     });
 
-    // Escape closes the modal
+    // Escape steps back one level: out of full screen first, then out of the modal.
     document.addEventListener('keydown', (e) => {
-      if (e.key === 'Escape' && this.assetModal && !this.assetModal.classList.contains('hidden')) {
+      if (e.key !== 'Escape') return;
+      if (!this.assetModal || this.assetModal.classList.contains('hidden')) return;
+      if (this.assetModal.classList.contains('asset-modal--expanded')) {
+        this.setAssetModalExpanded(false);
+      } else {
         this.hideAssetModal();
       }
     });
   }
 
+  /**
+   * Full-screen the asset library: the modal grows to fill the viewport and the
+   * file list gets out of the way, so a spreadsheet gets the whole width instead
+   * of the ~800px left over in the default layout.
+   */
+  toggleAssetModalExpanded() {
+    if (!this.assetModal) return;
+    this.setAssetModalExpanded(!this.assetModal.classList.contains('asset-modal--expanded'));
+  }
+
+  setAssetModalExpanded(expanded) {
+    if (!this.assetModal) return;
+    this.assetModal.classList.toggle('asset-modal--expanded', expanded);
+    const btn = this.assetModalExpandBtn;
+    if (!btn) return;
+    btn.setAttribute('aria-pressed', expanded ? 'true' : 'false');
+    btn.setAttribute('data-tooltip', expanded ? 'Back to the file list' : 'Expand to full screen');
+    btn.innerHTML = expanded
+      ? '<i class="fa-solid fa-down-left-and-up-right-to-center"></i>'
+      : '<i class="fa-solid fa-up-right-and-down-left-from-center"></i>';
+  }
+
   hideAssetModal() {
-    if (this.assetModal) this.assetModal.classList.add('hidden');
+    if (!this.assetModal) return;
+    // Reset to the two-pane layout so the next open always shows the file list.
+    this.setAssetModalExpanded(false);
+    this.assetModal.classList.add('hidden');
   }
 
   async openAssetModal() {
@@ -420,8 +458,8 @@ export class FileAttachmentManager {
 
   /**
    * Render the right-hand preview pane for the selected asset. Images and PDFs
-   * render natively; spreadsheets render via lazily-loaded SheetJS; everything
-   * else offers a download plus an optional Microsoft Office Online preview.
+   * render natively; spreadsheets render as a cell grid parsed on the box;
+   * everything else is download-only.
    */
   renderAssetPreview(dataset) {
     const { path, filename, size, folder } = dataset;
@@ -455,10 +493,7 @@ export class FileAttachmentManager {
         <div class="asset-preview-placeholder">
           <i class="fa-solid ${this.iconForFile(filename, false)}"></i>
           <span>No inline preview for .${ext} files</span>
-          <button class="asset-office-btn" data-llamabot="asset-office-btn">
-            <i class="fa-solid fa-cloud"></i> Preview with Microsoft Office Online
-          </button>
-          <span class="asset-office-note">Opens an external viewer — requires this instance to be publicly reachable.</span>
+          <span class="asset-office-note">Download it to open in the app it belongs to.</span>
         </div>`;
     }
 
@@ -513,24 +548,13 @@ export class FileAttachmentManager {
     // Lazy spreadsheet rendering
     if (isSheet) {
       const stage = this.assetModalPreview.querySelector('[data-llamabot="asset-sheet-stage"]');
-      this.renderSpreadsheetPreview(previewUrl, stage);
+      this.renderSpreadsheetPreview(path, previewUrl, stage);
     }
 
     // Lazy text rendering
     if (isText) {
       const stage = this.assetModalPreview.querySelector('[data-llamabot="asset-text-stage"]');
       this.renderTextPreview(previewUrl, filename, stage);
-    }
-
-    // Office Online viewer (lazy iframe, only on click)
-    const officeBtn = this.assetModalPreview.querySelector('[data-llamabot="asset-office-btn"]');
-    if (officeBtn) {
-      officeBtn.addEventListener('click', () => {
-        const publicUrl = `${window.location.origin}${downloadUrl}`;
-        const viewer = `https://view.officeapps.live.com/op/embed.aspx?src=${encodeURIComponent(publicUrl)}`;
-        const body = this.assetModalPreview.querySelector('[data-llamabot="asset-preview-body"]');
-        body.innerHTML = `<iframe class="asset-preview-frame" src="${viewer}" title="${filename}"></iframe>`;
-      });
     }
   }
 
@@ -559,11 +583,61 @@ export class FileAttachmentManager {
   }
 
   /**
-   * Render a spreadsheet/CSV inline by lazily loading SheetJS from a CDN, fetching
-   * the file through the authenticated preview endpoint (the browser sends the
-   * session cookie), and converting the first sheet to an HTML table.
+   * Render a spreadsheet/CSV inline as a cell grid.
+   *
+   * The workbook is parsed on the box by /api/uploaded-files/sheet (openpyxl),
+   * so nothing leaves the instance and no third-party viewer is involved. Legacy
+   * binary formats openpyxl can't read (.xls, .xlsb) come back 415 and fall back
+   * to the client-side SheetJS reader.
    */
-  async renderSpreadsheetPreview(previewUrl, stage) {
+  async renderSpreadsheetPreview(path, previewUrl, stage) {
+    if (!stage) return;
+    try {
+      const resp = await fetch(`/api/uploaded-files/sheet?path=${encodeURIComponent(path)}`);
+      if (resp.status === 415) return this.renderSpreadsheetPreviewClientSide(previewUrl, stage);
+      if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+      const data = await resp.json();
+      const names = data.sheets || [];
+
+      const tabs = names.map((name, i) =>
+        `<button class="asset-sheet-tab ${i === (data.active || 0) ? 'asset-sheet-tab--active' : ''}" data-sheet="${i}">${this.escapeHtml(name)}</button>`
+      ).join('');
+
+      stage.innerHTML = `
+        ${names.length > 1 ? `<div class="asset-sheet-tabs">${tabs}</div>` : ''}
+        <div class="asset-sheet-scroll" data-llamabot="asset-sheet-scroll"></div>
+      `;
+
+      const scroll = stage.querySelector('[data-llamabot="asset-sheet-scroll"]');
+      this.renderSheetGrid(data.rows || [], scroll, data.total_rows);
+
+      stage.querySelectorAll('.asset-sheet-tab').forEach(tab => {
+        tab.addEventListener('click', async () => {
+          stage.querySelectorAll('.asset-sheet-tab').forEach(t => t.classList.remove('asset-sheet-tab--active'));
+          tab.classList.add('asset-sheet-tab--active');
+          scroll.innerHTML = '<div class="asset-preview-loading"><i class="fa-solid fa-spinner fa-spin"></i> Loading sheet…</div>';
+          try {
+            const r = await fetch(`/api/uploaded-files/sheet?path=${encodeURIComponent(path)}&sheet=${tab.dataset.sheet}`);
+            if (!r.ok) throw new Error(`HTTP ${r.status}`);
+            const d = await r.json();
+            this.renderSheetGrid(d.rows || [], scroll, d.total_rows);
+          } catch (err) {
+            console.error('Sheet load failed:', err);
+            scroll.innerHTML = `<div class="asset-preview-placeholder"><i class="fa-solid fa-triangle-exclamation"></i><span>Couldn't load that sheet.</span></div>`;
+          }
+        });
+      });
+    } catch (err) {
+      console.error('Spreadsheet preview failed:', err);
+      stage.innerHTML = `<div class="asset-preview-placeholder"><i class="fa-solid fa-triangle-exclamation"></i><span>Couldn't render this spreadsheet. Try downloading it instead.</span></div>`;
+    }
+  }
+
+  /**
+   * Fallback reader for legacy binary workbooks (.xls, .xlsb) that openpyxl
+   * can't open: lazily load SheetJS and parse the bytes in the browser.
+   */
+  async renderSpreadsheetPreviewClientSide(previewUrl, stage) {
     if (!stage) return;
     try {
       const XLSX = await this.loadSheetJs();
@@ -571,6 +645,8 @@ export class FileAttachmentManager {
       if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
       const buf = await resp.arrayBuffer();
       const wb = XLSX.read(buf, { type: 'array' });
+
+      const toRows = (ws) => XLSX.utils.sheet_to_json(ws, { header: 1, defval: '', blankrows: false });
 
       const tabs = wb.SheetNames.map((name, i) =>
         `<button class="asset-sheet-tab ${i === 0 ? 'asset-sheet-tab--active' : ''}" data-sheet="${i}">${this.escapeHtml(name)}</button>`
@@ -582,14 +658,14 @@ export class FileAttachmentManager {
       `;
 
       const scroll = stage.querySelector('[data-llamabot="asset-sheet-scroll"]');
-      this.renderSheetGrid(XLSX, wb.Sheets[wb.SheetNames[0]], scroll);
+      this.renderSheetGrid(toRows(wb.Sheets[wb.SheetNames[0]]), scroll);
 
       stage.querySelectorAll('.asset-sheet-tab').forEach(tab => {
         tab.addEventListener('click', () => {
           stage.querySelectorAll('.asset-sheet-tab').forEach(t => t.classList.remove('asset-sheet-tab--active'));
           tab.classList.add('asset-sheet-tab--active');
           const idx = parseInt(tab.dataset.sheet, 10);
-          this.renderSheetGrid(XLSX, wb.Sheets[wb.SheetNames[idx]], scroll);
+          this.renderSheetGrid(toRows(wb.Sheets[wb.SheetNames[idx]]), scroll);
         });
       });
     } catch (err) {
@@ -599,20 +675,25 @@ export class FileAttachmentManager {
   }
 
   /**
-   * Render a worksheet as a spreadsheet-style grid: A/B/C column headers, row
-   * numbers, sticky headers, zebra striping, right-aligned numerics. Capped to a
-   * sane number of rows so huge sheets don't lock up the DOM.
+   * Render rows of cell values as a spreadsheet-style grid: A/B/C column headers,
+   * row numbers, sticky headers, zebra striping, right-aligned numerics. Capped
+   * to a sane number of rows so huge sheets don't lock up the DOM.
+   *
+   * @param {Array<Array>} rows - already-parsed cell values, row-major
+   * @param {HTMLElement} scroll - container to render into
+   * @param {number} [totalRows] - row count in the full sheet, when the caller
+   *   (the server parser) already truncated `rows`
    */
-  renderSheetGrid(XLSX, ws, scroll) {
+  renderSheetGrid(rows, scroll, totalRows) {
     const MAX_ROWS = 500;
-    const rows = XLSX.utils.sheet_to_json(ws, { header: 1, defval: '', blankrows: false });
     if (!rows.length) {
       scroll.innerHTML = `<div class="asset-preview-placeholder"><i class="fa-solid fa-table-cells"></i><span>This sheet is empty</span></div>`;
       return;
     }
 
-    const truncated = rows.length > MAX_ROWS;
-    const view = truncated ? rows.slice(0, MAX_ROWS) : rows;
+    const fullCount = Number.isFinite(totalRows) ? totalRows : rows.length;
+    const truncated = fullCount > MAX_ROWS;
+    const view = rows.length > MAX_ROWS ? rows.slice(0, MAX_ROWS) : rows;
     const colCount = view.reduce((m, r) => Math.max(m, r.length), 0);
 
     const colLabel = (n) => {
@@ -633,7 +714,9 @@ export class FileAttachmentManager {
       for (let c = 0; c < colCount; c++) {
         const v = r[c];
         const empty = v === '' || v === null || v === undefined;
-        const num = typeof v === 'number';
+        // The server parser hands back strings, so right-align anything that
+        // reads as a number too — otherwise every numeric column looks like text.
+        const num = typeof v === 'number' || (!empty && typeof v === 'string' && /^-?[\d,]*\.?\d+%?$/.test(v.trim()));
         body += `<td class="${num ? 'asset-sheet-num' : ''}">${empty ? '' : this.escapeHtml(String(v))}</td>`;
       }
       body += '</tr>';
@@ -642,7 +725,7 @@ export class FileAttachmentManager {
 
     scroll.innerHTML =
       `<table class="asset-sheet-grid">${head}${body}</table>` +
-      (truncated ? `<div class="asset-sheet-truncated"><i class="fa-solid fa-circle-info"></i> Showing first ${MAX_ROWS} of ${rows.length} rows — download for the full file.</div>` : '');
+      (truncated ? `<div class="asset-sheet-truncated"><i class="fa-solid fa-circle-info"></i> Showing first ${view.length} of ${fullCount} rows — download for the full file.</div>` : '');
   }
 
   /** Escape a string for safe insertion into HTML. */

--- a/app/frontend/chat/ui/IframeManager.js
+++ b/app/frontend/chat/ui/IframeManager.js
@@ -15,6 +15,8 @@
 
 import { getRailsUrl, getVSCodeUrl, getInboxUrl, getActivityUrl, DEFAULT_CONFIG } from '../config.js';
 import { isTabVisible } from '../utils/tabVisibility.js';
+import { loadOverlayAds, OverlayAdRotator, evaluatePolicy, policyAllowsMode, recordShown } from './OverlayAds.js';
+import { installOverlayDevtools } from './OverlayDevtools.js';
 
 /**
  * data-target name → data-llamabot attribute, for every tab in the browser pane.
@@ -69,6 +71,11 @@ export class IframeManager {
 
     // Navigation history stack for back button (since we can't access cross-origin iframe history)
     this.navigationHistory = [];
+
+    // window.leoAds — console handle for driving the overlay without an agent turn.
+    // Installed here (rather than off window.chatApp) so it binds to this manager
+    // directly and doesn't care when/whether chatApp gets assigned.
+    installOverlayDevtools(this);
 
     // Track current path for reliable refresh (fallback when iframe query fails).
     // Seeded from the last page this browser was on so a full page refresh puts
@@ -349,6 +356,8 @@ export class IframeManager {
     const browserContent = document.querySelector('.browser-content');
     if (!browserContent) return;
 
+    this._stopOverlayAds();   // belt-and-braces: never inherit a previous overlay's rotator
+
     // Create overlay div
     const overlay = document.createElement('div');
     overlay.id = 'streamingOverlay';
@@ -365,7 +374,9 @@ export class IframeManager {
     overlay.style.zIndex = '10';
     overlay.style.borderRadius = '8px';
     overlay.style.overflow = 'hidden';
-    overlay.style.paddingTop = '24px';
+    overlay.style.boxSizing = 'border-box';
+    overlay.style.padding = '16px';
+    overlay.style.gap = '12px';
 
     // Add close control if requested. A bare "×" reads as "cancel", which made
     // users unsure whether hitting it would stop Leo. Instead we show a labeled
@@ -462,7 +473,7 @@ export class IframeManager {
 
     const textContainer = document.createElement('div');
     textContainer.style.width = 'auto';
-    textContainer.style.textAlign = 'center';
+    textContainer.style.textAlign = 'left';
     textContainer.style.overflow = 'hidden';
     textContainer.appendChild(overlayText);
 
@@ -497,11 +508,11 @@ export class IframeManager {
     const tipsContainer = document.createElement('div');
     tipsContainer.style.width = 'auto';
     tipsContainer.style.maxWidth = '100%';
-    tipsContainer.style.textAlign = 'center';
-    // Extra breathing room below the title so the tip reads as its own thing, not
-    // a subtitle. The title is big+bold+white; the tip is a lighter, amber-accented
-    // hint in its own pill below, so the two clearly separate.
-    tipsContainer.style.padding = '18px 0 0';
+    tipsContainer.style.textAlign = 'left';
+    // The status block is deliberately quiet now — it shares one compact top-left
+    // row with the animation so the promo below it owns the pane. A little space
+    // under the title still keeps the tip reading as its own thing.
+    tipsContainer.style.padding = '6px 0 0';
     tipsContainer.style.boxSizing = 'border-box';
     tipsContainer.style.color = 'rgba(255, 255, 255, 0.85)';
     tipsContainer.style.fontFamily = 'Arial, sans-serif';
@@ -639,11 +650,144 @@ export class IframeManager {
     questionContainer.style.padding = '16px 20px';
     questionContainer.style.display = 'none';
 
+    // Full-width rail that carries the status pill. It's what keeps the pill's
+    // left edge flush with the promo below it: the rail is the same width as the
+    // content column and centered like it, while the pill itself hugs its content
+    // at the rail's left edge.
+    const headerRow = document.createElement('div');
+    headerRow.style.flex = '0 0 auto';
+    headerRow.style.alignSelf = 'center';
+    headerRow.style.width = '100%';
+    headerRow.style.display = 'flex';
+    headerRow.style.justifyContent = 'flex-start';
+
+    // Jumbotron promo slot. The creative is mothership-owned HTML rendered in a
+    // sandboxed iframe (see OverlayAds.js) — this is only the frame it sits in.
+    // Stays hidden unless the mothership actually returns a promo, so an
+    // unconfigured box looks exactly like it did before this shipped.
+    const adContainer = document.createElement('div');
+    adContainer.id = 'overlayAdSlot';
+    adContainer.style.flex = '0 0 auto';
+    adContainer.style.width = '100%';
+    adContainer.style.maxWidth = '480px';
+    adContainer.style.height = '140px';
+    adContainer.style.marginBottom = '16px';
+    adContainer.style.boxSizing = 'border-box';
+    adContainer.style.background = 'rgba(13, 13, 26, 0.85)';
+    adContainer.style.borderRadius = '10px';
+    adContainer.style.border = '1px solid rgba(255, 255, 255, 0.08)';
+    adContainer.style.overflow = 'hidden';
+    adContainer.style.display = 'none';
+
+    // Is a promo actually on screen right now? Everything about the overlay's
+    // proportions hangs off this: with no promo the overlay must look EXACTLY
+    // like it did before the jumbotron shipped (big centered animation under a
+    // 2.5rem title), and it only shrinks into the compact top-left status pill
+    // when there's a promo to make room for. A mothership that's down, empty, or
+    // hasn't been configured yet is therefore invisible to the user.
+    const adsVisible = () => {
+      const mode = this._overlayMode;
+      return !!this._overlayAdRotator
+        && mode !== 'question'
+        && policyAllowsMode(this._overlayAdPolicy, mode);
+    };
+
+    // The todo/question boxes are 480 wide; only the jumbotron gets the full 900.
+    const columnWidth = () => (
+      (this._overlayMode !== 'plan' && this._overlayMode !== 'question') ? '900px' : '480px'
+    );
+
+    // Sizes the promo slot for the current mode.
+    //
+    //   building → ALL of it. Nothing else is competing, and an ad that fills the
+    //              pane is the whole point of the jumbotron.
+    //   plan     → the payload's own `height` (default 140), so the todo list —
+    //              which is what the user actually wants to watch — keeps the rest.
+    //
+    // Called from setOverlayMode (layout changed) and from the rotator's
+    // onAdChange (a promo with a different height just came up).
+    const applyAdSizing = this._applyOverlayAdSizing = () => {
+      adContainer.style.maxWidth = columnWidth();
+      if (this._overlayMode === 'plan') {
+        const height = this._overlayAdRotator?.currentAd?.height || 140;
+        adContainer.style.flex = `0 0 ${height}px`;
+      } else {
+        adContainer.style.flex = '1 1 auto';
+      }
+    };
+
+    // Switches the whole status block between its two chromes:
+    //
+    //   classic (no promo) → the pre-jumbotron look. Title + tip centered in a
+    //                        pill, the big animation centered below it, nothing
+    //                        else on the pane.
+    //   compact (promo up) → title + tip + a small ball in one quiet top-left
+    //                        row, left-aligned to the promo's column, so the eye
+    //                        goes to the promo instead.
+    //
+    // The animation actually moves between the two: a row item inside the pill in
+    // compact chrome, its own full-width block under the pill in classic.
+    const applyChrome = (withAd, { isPlan, isQuestion }) => {
+      if (withAd) {
+        overlay.style.padding = '16px';
+        overlay.style.gap = '12px';
+        headerRow.style.maxWidth = columnWidth();
+        headerRow.style.justifyContent = 'flex-start';
+        headerBox.style.flexDirection = 'row';
+        headerBox.style.gap = '10px';
+        headerBox.style.maxWidth = '100%';
+        headerBox.style.padding = '8px 16px 8px 10px';
+        textContainer.style.textAlign = 'left';
+        tipsContainer.style.textAlign = 'left';
+        tipsContainer.style.padding = '6px 0 0';
+        lottieContainer.style.width = 'auto';
+        // A row item inside the pill, ahead of the title/tip stack.
+        if (headerBox.firstChild !== lottieContainer) headerBox.insertBefore(lottieContainer, headerText);
+        // Deliberately quiet: a 1.15rem title over a 58px ball.
+        overlayText.style.fontSize = isQuestion ? '1.6rem' : '1.15rem';
+        tipsContainer.style.fontSize = '0.68rem';
+        const ballPx = isQuestion ? '0px' : '58px';
+        lottiePlayer.style.width = ballPx;
+        lottiePlayer.style.height = ballPx;
+        // The title shares its row with the animation and the pill's padding, so
+        // it has meaningfully less room than when it was centered on its own.
+        this._overlayTitleReserve = 150;
+      } else {
+        overlay.style.padding = '24px 0 0';
+        overlay.style.gap = '0px';
+        headerRow.style.maxWidth = 'none';
+        headerRow.style.justifyContent = 'center';
+        headerBox.style.flexDirection = 'column';
+        headerBox.style.gap = '0px';
+        headerBox.style.maxWidth = '92%';
+        headerBox.style.padding = '12px 26px';
+        textContainer.style.textAlign = 'center';
+        tipsContainer.style.textAlign = 'center';
+        // Extra breathing room below the title so the tip reads as its own thing,
+        // not a subtitle.
+        tipsContainer.style.padding = '18px 0 0';
+        lottieContainer.style.width = '100%';
+        // Big animation on its own line, directly under the pill.
+        if (lottieContainer.parentNode !== overlay) overlay.insertBefore(lottieContainer, todoContainer);
+        // Title is large while building, then shrinks once the todo list takes over.
+        overlayText.style.fontSize = isPlan ? '1.8rem' : '2.5rem';
+        // Tips track ~35% of the current title size.
+        tipsContainer.style.fontSize = isPlan ? '0.63rem' : '0.875rem';
+        const ballPx = isPlan ? '140px' : '240px';
+        lottiePlayer.style.width = ballPx;
+        lottiePlayer.style.height = ballPx;
+        this._overlayTitleReserve = 70;
+      }
+    };
+
     // Toggle the overlay layouts:
     //   building → big centered animation + cycling tips, no box
     //   plan     → small animation up top + the cloned todo list box
     //   question → animation/tips stopped; the cloned question card takes the pane
+    // Orthogonal to all three: whether a promo is on screen, which is what
+    // applyChrome switches the status block's proportions on.
     const setOverlayMode = (mode) => {
+      this._overlayMode = mode;
       const isPlan = mode === 'plan';
       const isQuestion = mode === 'question';
       // Building: title + tips + ball are centered as a group (animation doesn't
@@ -653,44 +797,61 @@ export class IframeManager {
       // Stop the animation entirely while a question is up — it's the cue that Leo
       // has paused and needs an answer (rather than still working).
       lottieContainer.style.display = isQuestion ? 'none' : 'flex';
-      // Title is large while building, then shrinks once the todo list takes over.
-      overlayText.style.fontSize = isPlan ? '1.8rem' : '2.5rem';
-      // Tips track ~35% of the current title size (bigger pre-plan, smaller after).
-      tipsContainer.style.fontSize = isPlan ? '0.63rem' : '0.875rem';
-      lottiePlayer.style.width = isPlan ? '140px' : '240px';
-      lottiePlayer.style.height = isPlan ? '140px' : '240px';
       // Tips keep cycling in building/plan, but are hidden while a question is up.
       tipsContainer.style.display = isQuestion ? 'none' : 'block';
       todoContainer.style.display = isPlan ? 'block' : 'none';
       questionContainer.style.display = isQuestion ? 'block' : 'none';
+      // Whether a promo may appear in THIS layout is the mothership's call
+      // (policy.modes), with one guarantee it can't override: never during a
+      // question — Leo is blocked on the user, nothing competes with that.
+      const withAd = adsVisible();
+      adContainer.style.display = withAd ? 'block' : 'none';
+      applyAdSizing();
+      applyChrome(withAd, { isPlan, isQuestion });
       // Re-evaluate the "Your " drop since the title size just changed.
       this._fitOverlayTitle?.();
     };
     this._setOverlayMode = setOverlayMode;
-    setOverlayMode('building'); // start in the building state
 
-    // Wrap the title + tips in a semi-opaque "pill" so the white text reads
-    // clearly over the live site behind the overlay, without darkening the rest.
+    // The status block: animation on the left, title + tip stacked to its right,
+    // the whole thing a compact pill pinned to the TOP-LEFT of the pane. The pill
+    // background keeps the white text readable over the live site behind it.
+    //
+    // This used to be a centered column with a 240px animation under a 2.5rem
+    // title, which is what the promo slot below now claims — see setOverlayMode.
+    const headerText = document.createElement('div');
+    headerText.style.display = 'flex';
+    headerText.style.flexDirection = 'column';
+    headerText.style.alignItems = 'flex-start';
+    headerText.style.minWidth = '0';
+    headerText.appendChild(textContainer);
+    headerText.appendChild(tipsContainer);
+
+    // Direction, gap, padding and max-width are chrome-dependent — applyChrome
+    // owns them, along with where the animation lives.
     const headerBox = document.createElement('div');
     headerBox.style.flex = '0 0 auto';
     headerBox.style.display = 'flex';
-    headerBox.style.flexDirection = 'column';
     headerBox.style.alignItems = 'center';
-    headerBox.style.maxWidth = '92%';
     headerBox.style.boxSizing = 'border-box';
-    headerBox.style.padding = '12px 26px';
     headerBox.style.borderRadius = '14px';
     headerBox.style.background = 'rgba(0, 0, 0, 0.45)';
-    headerBox.appendChild(textContainer);
-    headerBox.appendChild(tipsContainer);
+    headerBox.appendChild(headerText);
 
-    overlay.appendChild(headerBox);
-    overlay.appendChild(lottieContainer);
+    headerRow.appendChild(headerBox);
+
+    overlay.appendChild(headerRow);
     overlay.appendChild(todoContainer);
     overlay.appendChild(questionContainer);
+    overlay.appendChild(adContainer);
+
+    // Now that every node applyChrome touches exists, paint the initial layout.
+    setOverlayMode('building');
+
     browserContent.appendChild(overlay);
 
     this.overlayElement = overlay;
+    this._startOverlayAds(overlay, adContainer);
 
     // Keep the title on one line: drop the "Your " prefix when the pane is too
     // narrow to fit the full title, and restore it when there's room again. The
@@ -700,8 +861,10 @@ export class IframeManager {
       if (!prefixSpan) return;                          // current title has no "Your "
       prefixSpan.style.display = 'inline';              // try the full title first
       // Measure against the pane width (minus the pill's padding/margins), not
-      // the now content-hugging title container.
-      const available = browserContent.clientWidth - 70;
+      // the now content-hugging title container. How much to reserve depends on
+      // the chrome (compact shares the row with the animation), so applyChrome
+      // sets it.
+      const available = browserContent.clientWidth - (this._overlayTitleReserve || 70);
       if (overlayText.scrollWidth > available) {
         prefixSpan.style.display = 'none';              // too tight — drop "Your"
       }
@@ -788,6 +951,70 @@ export class IframeManager {
   }
 
   /**
+   * Fetch and mount the overlay's promo slot.
+   *
+   * Fire-and-forget by design: the overlay is already on screen and useful
+   * without it, so nothing here is awaited and every failure path is "no slot".
+   * `loadOverlayAds` never rejects; the only thing to guard is the race where
+   * the user hides the overlay (or a new build starts) while the request is in
+   * flight — hence the identity check against the overlay we were called for.
+   */
+  _startOverlayAds(overlay, slotEl) {
+    loadOverlayAds().then(({ ads, rotateSeconds, policy, variant }) => {
+      if (this.overlayElement !== overlay) return;   // overlay died mid-fetch
+
+      this._overlayAdPolicy = policy;
+      this._overlayAdVariant = variant;
+
+      // WHEN a promo shows is the mothership's decision, not ours — see
+      // evaluatePolicy. We only carry out the verdict and record why, so
+      // leoAds.status() can answer "where's my ad?" without a code read.
+      const verdict = evaluatePolicy({ ads, policy });
+      this._overlayAdVerdict = verdict.reason;
+      if (!verdict.show) return;
+
+      const mount = () => {
+        // The delay means the overlay may be long gone by the time we fire.
+        if (this.overlayElement !== overlay) return;
+        const rotator = new OverlayAdRotator({
+          ads,
+          rotateSeconds,
+          // Promos can declare different heights; re-apply sizing whenever one
+          // comes up (only actually changes anything in plan mode).
+          onAdChange: () => this._applyOverlayAdSizing?.(),
+        });
+        if (!rotator.mount(slotEl)) return;
+        this._overlayAdRotator = rotator;
+        recordShown();                                // starts the cooldown clock
+        // Re-run the current layout now that there IS a slot to show.
+        this._setOverlayMode?.(this._overlayMode || 'building');
+      };
+
+      // Hold the promo back for the first few seconds so a short build doesn't
+      // flash an ad and yank it away.
+      if (verdict.delayMs > 0) {
+        this._overlayAdDelayTimer = setTimeout(mount, verdict.delayMs);
+      } else {
+        mount();
+      }
+    });
+  }
+
+  /**
+   * Tear the promo slot down (kills its rotation timer). Safe when none exists.
+   */
+  _stopOverlayAds() {
+    if (this._overlayAdDelayTimer) {
+      clearTimeout(this._overlayAdDelayTimer);
+      this._overlayAdDelayTimer = null;
+    }
+    if (this._overlayAdRotator) {
+      this._overlayAdRotator.stop();
+      this._overlayAdRotator = null;
+    }
+  }
+
+  /**
    * Stop mirroring the chat into the overlay.
    */
   _stopOverlayPlanMirror() {
@@ -810,7 +1037,9 @@ export class IframeManager {
     container.innerHTML = '';
     container.appendChild(cloneEl);
     this._overlayQuestionActive = true;
-    this._setOverlayTitle?.('Question from Leo');
+    // Leo can ask 1-4 questions on one card.
+    const asked = Number(cloneEl.dataset?.count || 1);
+    this._setOverlayTitle?.(asked > 1 ? `${asked} questions from Leo` : 'Question from Leo');
     this._setOverlayMode?.('question');
     return true;
   }
@@ -858,6 +1087,7 @@ export class IframeManager {
    */
   removeStreamingOverlay() {
     this._stopOverlayPlanMirror();
+    this._stopOverlayAds();
     if (this._overlayTitleObserver) {
       this._overlayTitleObserver.disconnect();
       this._overlayTitleObserver = null;
@@ -868,6 +1098,11 @@ export class IframeManager {
       this._overlayTipInterval = null;
     }
     this._setOverlayMode = null;
+    this._overlayMode = null;
+    this._applyOverlayAdSizing = null;
+    this._overlayAdPolicy = null;
+    this._overlayAdVariant = null;
+    this._overlayAdVerdict = null;
     // Drop the question state too — the real card still lives in the chat; only the
     // throwaway overlay clone dies with the overlay, so nothing needs rescuing.
     this._overlayQuestionActive = false;

--- a/app/frontend/chat/ui/OverlayAds.js
+++ b/app/frontend/chat/ui/OverlayAds.js
@@ -1,0 +1,249 @@
+/**
+ * Overlay Ads — the "jumbotron" promo slot in the building overlay.
+ *
+ * The creative lives on the mothership (`GET /api/overlay-ads` proxies it), so a
+ * promo can be written/edited there and picked up on the next build with no
+ * instance deploy. This module owns three things and nothing else:
+ *
+ *   1. Fetching the slot's payload, fail-open (any error → no slot at all).
+ *   2. Rendering each snippet inside a SANDBOXED iframe.
+ *   3. Rotating between snippets on the mothership's cadence.
+ *
+ * ## Why an iframe and not innerHTML
+ *
+ * The snippet is remote HTML rendered inside the signed-in chat page. Dropping it
+ * into the chat DOM would be self-inflicted XSS — one bad or compromised promo
+ * would own the user's session. Each snippet instead goes into an iframe with
+ * `sandbox="allow-scripts allow-popups allow-popups-to-escape-sandbox"`:
+ * `allow-scripts` WITHOUT `allow-same-origin` puts the frame in an opaque origin,
+ * so a promo can animate itself but cannot read the parent DOM, cookies, or
+ * localStorage. `allow-popups*` is what lets a promo's link actually open a tab.
+ * **Never add `allow-same-origin` here** — with `allow-scripts` it cancels the
+ * sandbox entirely.
+ */
+
+/** Sandbox flags for the ad frame. See the module header before changing these. */
+export const AD_SANDBOX = 'allow-scripts allow-popups allow-popups-to-escape-sandbox';
+
+/** Fallback cadence if the payload omits one; the backend clamps the real value. */
+export const DEFAULT_ROTATE_SECONDS = 180;
+
+/**
+ * Fallback display policy, mirroring the backend's `DEFAULT_POLICY`. Only used
+ * when the endpoint is unreachable — a served payload always carries a policy,
+ * already merged and clamped server-side.
+ */
+export const DEFAULT_POLICY = Object.freeze({
+  enabled: true,
+  show_after_seconds: 5,
+  modes: ['building', 'plan'],
+  min_interval_seconds: 0,
+});
+
+/** Where the per-browser cooldown timestamp lives. */
+export const LAST_SHOWN_KEY = 'llamabot.overlayAds.lastShownAt';
+
+/** Cross-fade duration, matched by the CSS transition on the frame. */
+const FADE_MS = 400;
+
+/**
+ * Wrap a promo snippet in a full document.
+ *
+ * `<base target="_blank">` is the important part: the frame is sandboxed, so a
+ * link that tried to navigate in place would go nowhere useful — every promo
+ * link should leave for a real tab instead. The reset keeps a snippet from
+ * inheriting nothing and rendering with the UA's default 8px body margin.
+ */
+export function adDocument(html) {
+  return `<!doctype html><html><head><meta charset="utf-8">`
+    + `<base target="_blank" rel="noopener noreferrer">`
+    + `<style>html,body{margin:0;padding:0;height:100%;`
+    + `font-family:Arial,Helvetica,sans-serif;color:#fff;background:transparent;}`
+    // The slot is short beside a todo list but fills the whole pane while Leo is
+    // starting up, so the same snippet has to look right at 140px AND at ~500px.
+    // Stretching the body's top-level element(s) to the frame means creative
+    // authored as a fixed-height banner just grows its background instead of
+    // floating in dead space. An author who wants natural height opts out with
+    // `flex:none` on their root element.
+    + `body{display:flex;flex-direction:column;}body>*{flex:1 1 auto;min-height:0;}`
+    + `*{box-sizing:border-box;}a{color:inherit;}</style></head>`
+    + `<body>${html}</body></html>`;
+}
+
+/**
+ * Fetch the promo payload. Always resolves — never rejects — to
+ * `{ ads: [], rotateSeconds }` on any failure, so a dead endpoint just means the
+ * overlay looks exactly like it did before this feature existed.
+ */
+export async function loadOverlayAds(fetchImpl = globalThis.fetch) {
+  const empty = { ads: [], rotateSeconds: DEFAULT_ROTATE_SECONDS, policy: { ...DEFAULT_POLICY }, variant: null };
+  try {
+    const response = await fetchImpl('/api/overlay-ads', { credentials: 'same-origin' });
+    if (!response || !response.ok) return empty;
+    const body = await response.json();
+    const ads = Array.isArray(body?.ads)
+      ? body.ads.filter((ad) => ad && typeof ad.html === 'string' && ad.html.trim())
+      : [];
+    const rotate = Number(body?.rotate_seconds);
+    return {
+      ads,
+      rotateSeconds: Number.isFinite(rotate) && rotate > 0 ? rotate : DEFAULT_ROTATE_SECONDS,
+      // Server-merged and clamped; only fall back if the field is missing entirely.
+      policy: { ...DEFAULT_POLICY, ...(body?.policy || {}) },
+      variant: body?.variant || null,
+    };
+  } catch (e) {
+    return empty;
+  }
+}
+
+/**
+ * Decide whether this build gets a promo at all, and after how long.
+ *
+ * All of the actual product judgement here is the mothership's — this only
+ * applies what it sent. Returns `{ show, delayMs, reason }`; `reason` is what
+ * `leoAds.status()` surfaces so "why is there no ad?" is answerable without
+ * reading code.
+ *
+ * `now` and `storage` are injected so the cooldown is testable without waiting
+ * and without a real localStorage.
+ */
+export function evaluatePolicy({
+  ads = [],
+  policy = DEFAULT_POLICY,
+  now = Date.now(),
+  storage = globalThis.localStorage,
+} = {}) {
+  if (!ads.length) return { show: false, delayMs: 0, reason: 'no-ads' };
+  if (policy.enabled === false) return { show: false, delayMs: 0, reason: 'disabled-by-policy' };
+
+  const cooldown = Number(policy.min_interval_seconds) || 0;
+  if (cooldown > 0) {
+    // localStorage throws in some embedded/private contexts — a cooldown we
+    // can't read is not a reason to suppress the promo, so fail open.
+    let lastShown = 0;
+    try { lastShown = Number(storage?.getItem(LAST_SHOWN_KEY)) || 0; } catch (e) { lastShown = 0; }
+    const elapsed = (now - lastShown) / 1000;
+    if (lastShown && elapsed < cooldown) {
+      return { show: false, delayMs: 0, reason: `cooldown:${Math.ceil(cooldown - elapsed)}s-left` };
+    }
+  }
+
+  const delaySeconds = Math.max(0, Number(policy.show_after_seconds) || 0);
+  return { show: true, delayMs: delaySeconds * 1000, reason: 'ok' };
+}
+
+/** Stamp "a promo was shown just now" for the cooldown. Never throws. */
+export function recordShown(now = Date.now(), storage = globalThis.localStorage) {
+  try { storage?.setItem(LAST_SHOWN_KEY, String(now)); } catch (e) { /* private mode */ }
+}
+
+/** Is `mode` one the policy allows a promo in? */
+export function policyAllowsMode(policy, mode) {
+  const modes = Array.isArray(policy?.modes) ? policy.modes : DEFAULT_POLICY.modes;
+  return modes.includes(mode);
+}
+
+/**
+ * Renders one promo at a time into `slotEl` and cycles through the rest.
+ *
+ * Timers are injected so the rotation is testable without waiting three minutes.
+ */
+export class OverlayAdRotator {
+  constructor({
+    ads = [],
+    rotateSeconds = DEFAULT_ROTATE_SECONDS,
+    doc = globalThis.document,
+    timers = globalThis,
+    onAdChange = null,
+  } = {}) {
+    this.ads = ads;
+    this.rotateSeconds = rotateSeconds;
+    this.doc = doc;
+    this.timers = timers;
+    // Fired with the ad that just became visible. The rotator deliberately does
+    // NOT size its own slot: how much room a promo gets is the overlay's call
+    // (it fills the pane while Leo is starting up, but yields to the todo list
+    // once there's a plan), so the payload's `height` is a hint the overlay
+    // applies, not something this class imposes.
+    this.onAdChange = onAdChange;
+    this.currentAd = null;
+    this.index = 0;
+    this.frame = null;
+    this.slot = null;
+    this._interval = null;
+    this._fadeTimeout = null;
+  }
+
+  /**
+   * Build the frame, show the first promo, and start rotating.
+   * No-op (returns false) with no ads or no slot — the caller keeps the slot
+   * hidden in that case, which is the normal state on an unconfigured box.
+   */
+  mount(slotEl) {
+    if (!slotEl || !this.ads.length) return false;
+    this.slot = slotEl;
+
+    const frame = this.doc.createElement('iframe');
+    frame.setAttribute('sandbox', AD_SANDBOX);
+    frame.setAttribute('referrerpolicy', 'no-referrer');
+    frame.setAttribute('title', 'LlamaPress promo');
+    frame.style.width = '100%';
+    frame.style.height = '100%';
+    frame.style.border = 'none';
+    frame.style.display = 'block';
+    frame.style.opacity = '1';
+    frame.style.transition = `opacity ${FADE_MS}ms ease`;
+    this.frame = frame;
+
+    slotEl.innerHTML = '';
+    slotEl.appendChild(frame);
+    this._render(0);
+
+    // A single promo is a static banner, not a carousel — don't burn a timer.
+    if (this.ads.length > 1) {
+      this._interval = this.timers.setInterval(
+        () => this.next(),
+        this.rotateSeconds * 1000,
+      );
+    }
+    return true;
+  }
+
+  /** Advance to the next promo, wrapping around, with a cross-fade. */
+  next() {
+    if (!this.frame || this.ads.length < 2) return;
+    const nextIndex = (this.index + 1) % this.ads.length;
+    this.frame.style.opacity = '0';
+    this._fadeTimeout = this.timers.setTimeout(() => {
+      this._render(nextIndex);
+      if (this.frame) this.frame.style.opacity = '1';
+    }, FADE_MS);
+  }
+
+  /** Point the frame at ad `i` and tell the overlay which ad is now showing. */
+  _render(i) {
+    const ad = this.ads[i];
+    if (!ad || !this.frame) return;
+    this.index = i;
+    this.currentAd = ad;
+    this.frame.srcdoc = adDocument(ad.html);
+    this.onAdChange?.(ad);
+  }
+
+  /** Stop rotating and drop the frame. Safe to call more than once. */
+  stop() {
+    if (this._interval) {
+      this.timers.clearInterval(this._interval);
+      this._interval = null;
+    }
+    if (this._fadeTimeout) {
+      this.timers.clearTimeout(this._fadeTimeout);
+      this._fadeTimeout = null;
+    }
+    if (this.slot) this.slot.innerHTML = '';
+    this.frame = null;
+    this.slot = null;
+    this.currentAd = null;
+  }
+}

--- a/app/frontend/chat/ui/OverlayDevtools.js
+++ b/app/frontend/chat/ui/OverlayDevtools.js
@@ -1,0 +1,108 @@
+/**
+ * `window.leoAds` — console handle for the building overlay + its promo slot.
+ *
+ * Exercising the overlay normally means sending Leo a real message and waiting
+ * for a real build, and checking a rotation means waiting out the mothership's
+ * cadence (3 minutes in production). This makes both instant:
+ *
+ *   leoAds.show()      overlay up now, promos load, no agent turn
+ *   leoAds.next()      jump to the next promo instead of waiting
+ *   leoAds.plan()      force the todo-list layout (promo shrinks under the box)
+ *   leoAds.question()  force the question layout (promo must disappear)
+ *   leoAds.ads()       table of what /api/overlay-ads is serving right now
+ *
+ * Grants nothing new: `window.chatApp` is already global, so everything here is
+ * reachable from the console regardless. It exists so nobody has to keep a block
+ * of code on their clipboard.
+ *
+ * `show()`/`hide()`/`toggle()` use public methods and are stable. `next()`,
+ * `plan()`, `question()` and `building()` poke at overlay internals — they're
+ * debug-only, and a chat mutation can flip the forced mode back out from under
+ * you (the plan mirror owns the mode in real use).
+ */
+
+const OVERLAY_TITLE = 'Your App is Building!';
+
+/**
+ * Install the helper on `win`. Called from the IframeManager constructor with
+ * the live manager, so it never depends on `window.chatApp` being assigned yet.
+ */
+export function installOverlayDevtools(iframeManager, win = globalThis) {
+  if (!win) return null;
+
+  const im = () => iframeManager;
+
+  const leoAds = {
+    im,
+
+    /** Put the overlay up on demand. Tears down any existing one first, since
+     *  createStreamingOverlay is a no-op while one is already on screen. */
+    show(text = OVERLAY_TITLE) {
+      im().removeStreamingOverlay();
+      im().createStreamingOverlay({ showCloseButton: true, text });
+      return `overlay up — leoAds.next() to skip ahead, leoAds.hide() to dismiss`;
+    },
+
+    hide() { im().removeStreamingOverlay(); },
+
+    toggle() {
+      return (win.document && win.document.getElementById('streamingOverlay'))
+        ? leoAds.hide()
+        : leoAds.show();
+    },
+
+    /** Skip the rotation wait. No-op when there's one promo or none. */
+    next() { im()._overlayAdRotator?.next(); },
+
+    plan()     { im()._setOverlayMode?.('plan'); },
+    question() { im()._setOverlayMode?.('question'); },
+    building() { im()._setOverlayMode?.('building'); },
+
+    /** Which promo is on screen, why, and where the layout currently stands.
+     *  `verdict` is the reason the policy gave — 'ok', 'no-ads',
+     *  'disabled-by-policy', or 'cooldown:<n>s-left' — so "where's my ad?" is
+     *  answerable without reading code. */
+    status() {
+      const r = im()._overlayAdRotator;
+      return {
+        overlay: !!(win.document && win.document.getElementById('streamingOverlay')),
+        mode: im()._overlayMode || null,
+        ads: r ? r.ads.length : 0,
+        showing: r?.currentAd?.id || null,
+        rotateSeconds: r?.rotateSeconds ?? null,
+        verdict: im()._overlayAdVerdict || null,
+        policy: im()._overlayAdPolicy || null,
+        variant: im()._overlayAdVariant || null,
+        pendingDelay: !!im()._overlayAdDelayTimer,
+      };
+    },
+
+    /** Clear the per-browser cooldown so the next show() isn't suppressed. */
+    resetCooldown() {
+      try { win.localStorage?.removeItem('llamabot.overlayAds.lastShownAt'); } catch (e) { /* private mode */ }
+      return 'cooldown cleared';
+    },
+
+    /** What policy the endpoint is handing this browser right now. */
+    policy() {
+      return win.fetch('/api/overlay-ads')
+        .then((r) => r.json())
+        .then((b) => ({ policy: b.policy, variant: b.variant, ads: b.ads.length }));
+    },
+
+    /** What the endpoint is serving right now (bypasses whatever is on screen). */
+    ads() {
+      return win.fetch('/api/overlay-ads')
+        .then((r) => r.json())
+        .then((body) => {
+          win.console?.table?.(body.ads.map(({ id, height, html }) => ({
+            id, height, bytes: html.length,
+          })));
+          return body;
+        });
+    },
+  };
+
+  win.leoAds = leoAds;
+  return leoAds;
+}

--- a/app/frontend/chat/ui/RailsErrorPoll.js
+++ b/app/frontend/chat/ui/RailsErrorPoll.js
@@ -1,0 +1,183 @@
+/**
+ * RailsErrorPoll — puts the Rails app's crashes in the same tray as the
+ * preview's JavaScript errors.
+ *
+ * The user presses a button in their app, it 500s, and until now the only sign
+ * was a Rails error page inside the preview iframe — with no way to tell whether
+ * Leo could see it. This closes that: the crash shows up in the notice above the
+ * composer, next to the JS errors, and rides along with the next message.
+ *
+ * Why polling, when JavaScript errors are pushed: the Rails app has no handle on
+ * the chat page and cannot postMessage anything. It keeps its last 25 crashes in
+ * memory instead, behind `GET /llama_bot/errors?since=<seq>`, which LlamaBot
+ * proxies at `/api/rails-errors` (the gem sets no CORS headers, so the browser
+ * cannot read it directly). We read that with a cursor.
+ *
+ * Two things make the cursor worth care rather than a `while (true)`:
+ *
+ * 1. **Arming.** The first poll omits `since`, which the feed treats as a probe:
+ *    tell me where you are, give me nothing. Crashes that predate the page are
+ *    not something to greet the user with.
+ * 2. **Rewinds.** The feed lives in Rails' memory, so a restart resets it to
+ *    zero. A cursor left at 10 would ask for "everything after 10" forever and
+ *    the tray would silently go deaf for the rest of the session.
+ *
+ * And one rule about whose problem an error is: while an agent turn is running,
+ * anything that breaks is Leo's to fix — RailsErrorWatchMiddleware is already
+ * polling the same feed and repairing mid-turn, deliberately without the user
+ * seeing the broken page. Surfacing it here at the same moment would hand them a
+ * problem that is already being handled. We advance past those and stay quiet.
+ */
+
+const DEFAULT_INTERVAL_MS = 4000;
+
+// A box whose gem predates the feed answers "unavailable" forever. After a few
+// of those, drop to a slow heartbeat — it still recovers on its own if the box
+// updates mid-session, but it stops being a request every four seconds.
+const QUIET_INTERVAL_MS = 60000;
+const MISSES_BEFORE_QUIET = 3;
+
+export class RailsErrorPoll {
+  constructor({
+    getToken,
+    onErrors,
+    isAgentRunning = () => false,
+    isVisible = () => (typeof document === 'undefined'
+      || document.visibilityState !== 'hidden'),
+    fetchImpl = (...args) => fetch(...args),
+    endpoint = '/api/rails-errors',
+    intervalMs = DEFAULT_INTERVAL_MS,
+    quietIntervalMs = QUIET_INTERVAL_MS,
+  } = {}) {
+    this.getToken = getToken;
+    this.onErrors = onErrors;
+    this.isAgentRunning = isAgentRunning;
+    this.isVisible = isVisible;
+    this.fetchImpl = fetchImpl;
+    this.endpoint = endpoint;
+
+    this.fastIntervalMs = intervalMs;
+    this.quietIntervalMs = quietIntervalMs;
+    this.intervalMs = intervalMs;
+
+    this.cursor = null;   // null until the first answer arms us
+    this.misses = 0;
+    this._inFlight = false;
+    this._timer = null;
+  }
+
+  // ==========================================================================
+  // Lifecycle
+  // ==========================================================================
+
+  start() {
+    if (this._timer) return;
+    this.tick();
+    this._schedule();
+  }
+
+  stop() {
+    if (this._timer) clearTimeout(this._timer);
+    this._timer = null;
+  }
+
+  /**
+   * Poll now rather than waiting for the next interval. Called when the preview
+   * finishes loading a page: if that navigation was the 500, the crash is
+   * already in the feed and the user should not wait four seconds to be told.
+   */
+  nudge() {
+    this.tick();
+  }
+
+  _schedule() {
+    if (this._timer) clearTimeout(this._timer);
+    this._timer = setTimeout(() => {
+      this.tick().finally(() => this._schedule());
+    }, this.intervalMs);
+  }
+
+  // ==========================================================================
+  // One poll
+  // ==========================================================================
+
+  /** Never rejects: a crash reporter that crashes the page helps nobody. */
+  async tick() {
+    if (this._inFlight) return;          // a slow answer must not stack requests
+    if (!this.isVisible()) return;       // nobody is looking at the tray
+
+    this._inFlight = true;
+    try {
+      await this._poll();
+    } catch (e) {
+      // Offline, CORS, a proxy hiccup. Hold the cursor and try again; losing our
+      // place would be worse than missing one round.
+      this._miss();
+    } finally {
+      this._inFlight = false;
+    }
+  }
+
+  async _poll() {
+    const token = await this.getToken();
+    if (!token) {
+      // Signed into LlamaBot but not into the Rails app. Nothing to read, and
+      // no point telling the user about it.
+      return;
+    }
+
+    const url = this.cursor === null
+      ? this.endpoint
+      : `${this.endpoint}?since=${encodeURIComponent(this.cursor)}`;
+
+    const response = await this.fetchImpl(url, {
+      headers: { 'X-Rails-Api-Token': token, Accept: 'application/json' },
+    });
+    if (!response || !response.ok) {
+      this._miss();
+      return;
+    }
+
+    const body = await response.json();
+    if (!body || body.available !== true || typeof body.seq !== 'number') {
+      this._miss();
+      return;
+    }
+
+    this._hit();
+
+    const previous = this.cursor;
+    this.cursor = body.seq;
+
+    if (previous === null) {
+      // The arming probe. We now know where the log stands; that is all we came
+      // for.
+      return;
+    }
+
+    if (body.seq < previous) {
+      // Rails restarted. Its ring is a fresh one whose entries we never asked
+      // for, so re-arm at the new position and take nothing.
+      return;
+    }
+
+    const errors = Array.isArray(body.errors) ? body.errors : [];
+    if (errors.length === 0) return;
+
+    // Mid-turn crashes belong to Leo's auto-recovery. The cursor has already
+    // moved past them, so they do not resurface when the turn ends.
+    if (this.isAgentRunning()) return;
+
+    this.onErrors(errors);
+  }
+
+  _miss() {
+    this.misses += 1;
+    if (this.misses >= MISSES_BEFORE_QUIET) this.intervalMs = this.quietIntervalMs;
+  }
+
+  _hit() {
+    this.misses = 0;
+    this.intervalMs = this.fastIntervalMs;
+  }
+}

--- a/app/frontend/chat/websocket/MessageHandler.js
+++ b/app/frontend/chat/websocket/MessageHandler.js
@@ -3,16 +3,14 @@
  */
 
 import { isCustomAgentMode } from '../utils/agentModes.js';
+import {
+  normalizeQuestions,
+  buildQuestionCardHtml,
+  buildSubmission,
+  isAnswered,
+} from '../messages/QuestionCard.js';
 
 const PAYWALL_UPGRADE_URL = 'https://llamapress.ai/pricing';
-
-// Submitted as the answer when the user picks the "See visual options" choice on a
-// UI/UX-related ask_user_question. It instructs Leo to re-ask the question visually via
-// ask_user_uiux_question rather than treating this as a normal text answer.
-const UIUX_REQUEST_DIRECTIVE =
-  'The user would like to see visual UI/UX options for this. Please call the ' +
-  'ask_user_uiux_question tool with 2-4 concrete example designs (live HTML previews) ' +
-  'for this decision instead of answering in text.';
 
 export class MessageHandler {
   constructor(appState, streamingState, messageRenderer, iframeManager, scrollManager, tokenIndicator, config) {
@@ -731,10 +729,23 @@ export class MessageHandler {
     this._playAskUserQuestionSound();
     this._showWaitingForInputBadge();
 
-    const { question, options, context, thread_id, agent_name, ui_related } = data;
+    // Leo may ask 1-4 questions in one interrupt; they're answered together and
+    // submitted once, which saves a whole round-trip per extra question.
+    const { context, thread_id, agent_name } = data;
+    const questions = normalizeQuestions(data);
+    if (!questions.length) return;
+
     const questionId = `question-${Date.now()}-${Math.random().toString(36).substr(2, 6)}`;
 
-    const html = this._buildQuestionCardHtml(questionId, question, options || [], context || '', thread_id, agent_name, !!ui_related);
+    const html = buildQuestionCardHtml({
+      questionId,
+      questions,
+      context: context || '',
+      threadId: thread_id,
+      agentName: agent_name,
+      escapeHtml: (t) => this._escapeHtml(t),
+      parseMarkdown: (t) => this.messageRenderer.markdownParser.parse(t),
+    });
     this.messageRenderer.addMessage(html, 'question_request', null);
 
     // Attach interactive event listeners after DOM render, then (if the building
@@ -788,118 +799,118 @@ export class MessageHandler {
     return true;
   }
 
-  _buildQuestionCardHtml(questionId, question, options, context, threadId, agentName, uiRelated = false) {
-    const optionButtons = options.map(opt =>
-      `<button class="plan-option-btn" data-option="${this._escapeHtml(opt)}">${this._escapeHtml(opt)}</button>`
-    ).join('');
-
-    // When the agent flags the question as UI/UX-related, offer one subtle extra choice.
-    // Selecting it submits a directive (see _attachQuestionListeners) that asks Leo to
-    // follow up with ask_user_uiux_question — i.e. show real visual previews.
-    const uiuxOptionBtn = uiRelated ? `
-      <button class="plan-option-btn plan-uiux-request-btn" data-uiux-request="true"
-              title="Have Leo show you visual UI/UX options to pick from">
-        <svg viewBox="0 0 24 24" width="13" height="13" fill="currentColor" aria-hidden="true">
-          <path d="M12 2C6.49 2 2 6.49 2 12s4.49 10 10 10c1.38 0 2.5-1.12 2.5-2.5 0-.61-.23-1.2-.64-1.67-.08-.1-.13-.21-.13-.33 0-.28.22-.5.5-.5H16c3.31 0 6-2.69 6-6 0-4.96-4.49-9-10-9zm-5.5 9c-.83 0-1.5-.67-1.5-1.5S5.67 8 6.5 8 8 8.67 8 9.5 7.33 11 6.5 11zm3-4C8.67 7 8 6.33 8 5.5S8.67 4 9.5 4s1.5.67 1.5 1.5S10.33 7 9.5 7zm5 0c-.83 0-1.5-.67-1.5-1.5S13.67 4 14.5 4s1.5.67 1.5 1.5S15.33 7 14.5 7zm3 4c-.83 0-1.5-.67-1.5-1.5S16.67 8 17.5 8s1.5.67 1.5 1.5-.67 1.5-1.5 1.5z"/>
-        </svg>See visual options
-      </button>` : '';
-
-    const skipBtn = `<button class="plan-skip-btn">Skip</button>`;
-
-    return `
-      <div class="plan-question-card" data-question-id="${questionId}"
-           data-thread-id="${threadId}" data-agent-name="${agentName}">
-        <div class="plan-question-text">${this.messageRenderer.markdownParser.parse(question)}</div>
-        ${context ? `<div class="plan-question-context">${this._escapeHtml(context)}</div>` : ''}
-        ${(options.length > 0 || uiRelated) ? `
-          <div class="plan-question-options">
-            ${optionButtons}
-            ${uiuxOptionBtn}
-            ${skipBtn}
-          </div>
-        ` : ''}
-        <button class="plan-continue-btn" style="display: none;">Continue</button>
-        <div class="plan-question-input-row">
-          <textarea class="plan-question-input" rows="2" placeholder="Add to your answer..."></textarea>
-          <button class="plan-send-btn"><i class="fa-solid fa-arrow-up"></i></button>
-        </div>
-      </div>
-    `;
-  }
-
   // cardEl lets us wire a specific node (e.g. the overlay clone, which shares the
   // chat card's data-question-id); falls back to looking it up by id in the chat.
   _attachQuestionListeners(questionId, threadId, agentName, cardEl = null) {
     const card = cardEl || document.querySelector(`[data-question-id="${questionId}"]`);
     if (!card) return;
-    let selectedOptions = [];
-    // Tracked separately from selectedOptions: this choice doesn't answer the question,
-    // it asks Leo to re-ask it visually (ask_user_uiux_question).
-    let uiuxRequested = false;
 
-    const updateContinueBtn = () => {
-      const continueBtn = card.querySelector('.plan-continue-btn');
-      const input = card.querySelector('.plan-question-input');
-      const hasSelection = selectedOptions.length > 0 || uiuxRequested;
-      const hasText = input?.value?.trim()?.length > 0;
-      continueBtn.style.display = (hasSelection || hasText) ? 'block' : 'none';
-    };
+    const items = Array.from(card.querySelectorAll('.plan-question-item'));
+    if (!items.length) return;
 
-    // Build the answer that resumes the agent (real directive) plus a friendly version
-    // to show in the user's own chat bubble. For the UI/UX request we send Leo an explicit
-    // instruction but only show "See visual options" to the user.
-    const buildSubmission = () => {
-      const freeText = card.querySelector('.plan-question-input')?.value?.trim();
-      const parts = [...selectedOptions];
-      const displayParts = [...selectedOptions];
-      if (freeText) { parts.push(freeText); displayParts.push(freeText); }
-      if (uiuxRequested) {
-        parts.push(UIUX_REQUEST_DIRECTIVE);
-        displayParts.push('See visual options');
+    // The questions are read back off the DOM rather than closed over, so the overlay
+    // clone (cloneNode copies markup, not handlers) can be wired from the same code.
+    const questions = items.map(item => ({ question: item.dataset.questionText || '' }));
+    const batched = questions.length > 1;
+
+    // One state slot per question: what was clicked, typed, skipped, or sent to previews.
+    const states = questions.map(() => ({ options: [], text: '', uiux: false, skipped: false }));
+
+    const progressEl = card.querySelector('.plan-question-progress');
+    const continueBtn = card.querySelector('.plan-continue-btn');
+
+    const refresh = () => {
+      const answered = states.filter(isAnswered).length;
+      if (batched) {
+        // Every question needs an answer (Skip counts) before Continue unlocks —
+        // otherwise a blank slot goes to Leo with nothing to map it to.
+        if (progressEl) progressEl.textContent = `${answered} of ${questions.length} answered`;
+        if (continueBtn) continueBtn.disabled = answered < questions.length;
+      } else if (continueBtn) {
+        continueBtn.style.display = answered > 0 ? 'block' : 'none';
       }
-      return { answer: parts.join(', '), display: displayParts.join(', ') };
     };
 
-    // Option toggle (multi-select). The UI/UX request chip toggles its own flag rather
-    // than contributing an option string.
+    const submit = () => {
+      const { answer, display } = buildSubmission(questions, states);
+      this._submitQuestionAnswer(card, answer, threadId, agentName, display);
+    };
+
+    // Clear a question's skip once the user actually answers it, and vice versa —
+    // they're contradictory states and the last click should win.
+    const setSkipped = (i, skipped) => {
+      states[i].skipped = skipped;
+      const item = items[i];
+      item.querySelector('.plan-skip-btn')?.classList.toggle('selected', skipped);
+      if (skipped) {
+        states[i].options = [];
+        states[i].uiux = false;
+        states[i].text = '';
+        item.querySelectorAll('.plan-option-btn').forEach(b => b.classList.remove('selected'));
+        const input = item.querySelector('.plan-question-input');
+        if (input) input.value = '';
+      }
+    };
+
+    // Option toggle (multi-select, per question). The "See visual options" chip sets
+    // its own flag rather than contributing an option string — it isn't an answer, it
+    // asks Leo to re-ask THAT question with live previews.
     card.querySelectorAll('.plan-option-btn').forEach(btn => {
       btn.addEventListener('click', () => {
+        const i = Number(btn.dataset.qi || 0);
         btn.classList.toggle('selected');
         if (btn.dataset.uiuxRequest === 'true') {
-          uiuxRequested = btn.classList.contains('selected');
+          states[i].uiux = btn.classList.contains('selected');
         } else {
           const opt = btn.dataset.option;
-          if (selectedOptions.includes(opt)) {
-            selectedOptions = selectedOptions.filter(o => o !== opt);
-          } else {
-            selectedOptions.push(opt);
-          }
+          states[i].options = states[i].options.includes(opt)
+            ? states[i].options.filter(o => o !== opt)
+            : [...states[i].options, opt];
         }
-        updateContinueBtn();
+        if (states[i].skipped) setSkipped(i, false);
+        refresh();
       });
     });
 
-    // Skip button
-    card.querySelector('.plan-skip-btn')?.addEventListener('click', () => {
+    // Skip: in a batch it marks just that question and waits for Continue; on a single
+    // question it submits the card straight away, exactly as it always has.
+    card.querySelectorAll('.plan-skip-btn').forEach(btn => {
+      btn.addEventListener('click', () => {
+        if (!batched) {
+          this._submitQuestionAnswer(card, 'skip', threadId, agentName);
+          return;
+        }
+        const i = Number(btn.dataset.qi || 0);
+        setSkipped(i, !states[i].skipped);
+        refresh();
+      });
+    });
+
+    card.querySelector('.plan-skip-all-btn')?.addEventListener('click', () => {
       this._submitQuestionAnswer(card, 'skip', threadId, agentName);
     });
 
-    // Continue button
-    card.querySelector('.plan-continue-btn')?.addEventListener('click', () => {
-      const { answer, display } = buildSubmission();
-      this._submitQuestionAnswer(card, answer, threadId, agentName, display);
+    continueBtn?.addEventListener('click', () => {
+      if (continueBtn.disabled) return;
+      submit();
     });
 
-    // Input handling
-    const input = card.querySelector('.plan-question-input');
-    const sendBtn = card.querySelector('.plan-send-btn');
-    input?.addEventListener('input', updateContinueBtn);
-    sendBtn?.addEventListener('click', () => {
-      const { answer, display } = buildSubmission();
-      if (answer.length > 0) {
-        this._submitQuestionAnswer(card, answer, threadId, agentName, display);
-      }
+    // Free text, per question.
+    card.querySelectorAll('.plan-question-input').forEach(input => {
+      const i = Number(input.dataset.qi || 0);
+      input.addEventListener('input', () => {
+        states[i].text = input.value;
+        if (states[i].skipped && input.value.trim()) setSkipped(i, false);
+        refresh();
+      });
     });
+
+    // Single-question send arrow (a batch submits through Continue instead).
+    card.querySelector('.plan-send-btn')?.addEventListener('click', () => {
+      if (states.some(isAnswered)) submit();
+    });
+
+    refresh();
 
     // Scroll question into view
     card.scrollIntoView({ behavior: 'smooth', block: 'end' });

--- a/app/frontend/chat/websocket/WebSocketManager.js
+++ b/app/frontend/chat/websocket/WebSocketManager.js
@@ -121,7 +121,20 @@ export class WebSocketManager {
     } else {
       // ActionCable is authenticated by the Rails gem, so it's ready immediately.
       this.flushOutbox();
+      this.announceReady();
     }
+  }
+
+  /**
+   * Announce that this socket may now carry authenticated traffic.
+   *
+   * `websocketConnected` fires as soon as the transport is up, which is too
+   * early: the server refuses control frames (`attach`, `cancel`) until the
+   * handshake lands, and the token fetch behind `sendAuthMessage` is async.
+   * Anything that resumes a run waits for this event instead.
+   */
+  announceReady() {
+    window.dispatchEvent(new CustomEvent('websocketReady'));
   }
 
   /**
@@ -134,9 +147,13 @@ export class WebSocketManager {
         this.send({ type: 'auth', token: token });
       } else {
         console.warn('No auth token available - WebSocket may be unauthenticated');
+        // A box with WS_AUTH_REQUIRED=false has no token and never will; don't
+        // strand the resume path waiting for a handshake that isn't coming.
+        this.announceReady();
       }
     } catch (error) {
       console.error('Failed to send auth message:', error);
+      this.announceReady();
     }
   }
 
@@ -221,6 +238,7 @@ export class WebSocketManager {
       // Now that we're live & authenticated, deliver anything that was queued
       // while the connection was down.
       this.flushOutbox();
+      this.announceReady();
       return;
     }
 

--- a/app/frontend/style.css
+++ b/app/frontend/style.css
@@ -1738,6 +1738,36 @@ button.brand-logo-thumb:hover .brand-logo-zoom {
     padding: 10px 12px;
 }
 
+/* Which half of the stack this came from. Small and quiet — it labels the entry,
+   it is not the headline — but coloured differently per kind so a list of mixed
+   errors can be scanned without reading any of them. */
+.js-error-kind {
+    display: inline-block;
+    float: right;
+    margin-left: 8px;
+    padding: 1px 7px;
+    border-radius: 999px;
+    font-size: 0.62rem;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    background: rgba(129, 178, 255, 0.16);
+    color: rgba(168, 202, 255, 0.95);
+    border: 1px solid rgba(129, 178, 255, 0.28);
+}
+
+/* A server crash is the more serious of the two — the request never completed —
+   so it gets the warmer colour and a marked edge. */
+.js-error-item--rails .js-error-kind {
+    background: rgba(255, 138, 128, 0.16);
+    color: rgba(255, 176, 168, 0.95);
+    border-color: rgba(255, 138, 128, 0.3);
+}
+
+.js-error-item--rails {
+    border-left: 3px solid rgba(255, 138, 128, 0.45);
+}
+
 /* The plain-language line leads — the jargon is support, not the headline. */
 .js-error-item-plain {
     font-size: 0.86rem;
@@ -3418,7 +3448,8 @@ body.instance-locked .lock-modal-overlay {
 }
 
 /* Skip button */
-.plan-skip-btn {
+.plan-skip-btn,
+.plan-skip-all-btn {
     background: transparent;
     border: 1px solid rgba(255, 255, 255, 0.15);
     color: rgba(255, 255, 255, 0.35);
@@ -3429,11 +3460,13 @@ body.instance-locked .lock-modal-overlay {
     transition: color 0.15s ease;
 }
 
-.plan-skip-btn:hover:not(:disabled) {
+.plan-skip-btn:hover:not(:disabled),
+.plan-skip-all-btn:hover:not(:disabled) {
     color: rgba(255, 255, 255, 0.6);
 }
 
-.plan-skip-btn:disabled {
+.plan-skip-btn:disabled,
+.plan-skip-all-btn:disabled {
     opacity: 0.5;
     cursor: default;
 }
@@ -3532,6 +3565,97 @@ body.instance-locked .lock-modal-overlay {
     font-style: italic;
     text-align: right;
     padding: 4px 0;
+    /* A batched answer is one "question → answer" line per question. */
+    white-space: pre-line;
+}
+
+
+/* ===== Batched questions (2-4 asked at once, answered together) ===== */
+/* One card, one block per question, one Continue. Saves a round-trip per question. */
+.plan-question-card.batched {
+    border: 1px solid rgba(139, 92, 246, 0.2);
+    border-radius: 12px;
+    background: rgba(139, 92, 246, 0.04);
+    padding: 6px 16px 14px;
+}
+
+.plan-question-card.batched .plan-question-item {
+    position: relative;
+    padding: 12px 0 14px 26px;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.plan-question-card.batched .plan-question-item:last-of-type {
+    border-bottom: none;
+    padding-bottom: 4px;
+}
+
+/* Numbered so the user can see at a glance how many are left. */
+.plan-question-num {
+    position: absolute;
+    left: 0;
+    top: 12px;
+    width: 18px;
+    height: 18px;
+    border-radius: 50%;
+    background: rgba(139, 92, 246, 0.2);
+    border: 1px solid rgba(139, 92, 246, 0.4);
+    color: #c4b5fd;
+    font-size: 11px;
+    font-weight: 600;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+/* The free-text box is the fallback in a batch (options are the fast path), so it
+   sits quieter and shorter than on a single-question card. */
+.plan-question-card.batched .plan-question-input {
+    font-size: 13px;
+    padding: 6px 10px;
+    background: rgba(255, 255, 255, 0.03);
+    border-color: rgba(139, 92, 246, 0.15);
+}
+
+.plan-question-card.batched .plan-question-options {
+    margin-top: 8px;
+}
+
+.plan-question-card.batched .plan-question-input-row {
+    margin-top: 8px;
+}
+
+/* A skipped question stays visibly skipped so the count makes sense. */
+.plan-skip-btn.selected {
+    border-color: rgba(255, 255, 255, 0.35);
+    color: rgba(255, 255, 255, 0.7);
+    background: rgba(255, 255, 255, 0.06);
+}
+
+.plan-question-foot {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 12px;
+    margin-top: 12px;
+    padding-top: 12px;
+    border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.plan-question-progress {
+    font-size: 12px;
+    color: #64748b;
+}
+
+.plan-question-foot-actions {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.plan-question-card.batched .plan-continue-btn {
+    margin-top: 0;
 }
 
 /* ===== UI/UX visual question (ask_user_uiux_question) ===== */
@@ -7109,6 +7233,22 @@ body.instance-locked .lock-modal-overlay {
     overflow: hidden;
 }
 
+/* Full-screen mode: the preview takes the whole viewport and the file list steps
+   aside. Toggled by the expand button in the modal header (Esc steps back out). */
+.asset-modal--expanded .asset-modal-content {
+    width: 98vw;
+    height: 96vh;
+    border-radius: 10px;
+}
+
+.asset-modal--expanded .asset-modal-list {
+    display: none;
+}
+
+.asset-modal--expanded .asset-preview-body {
+    margin: 0 12px 12px;
+}
+
 .asset-modal-header {
     display: flex;
     align-items: center;
@@ -7419,32 +7559,13 @@ body.instance-locked .lock-modal-overlay {
     color: rgba(255, 255, 255, 0.35);
 }
 
-.asset-office-btn {
-    display: inline-flex;
-    align-items: center;
-    gap: 8px;
-    padding: 9px 16px;
-    border-radius: 8px;
-    border: 1px solid rgba(139, 92, 246, 0.5);
-    background: rgba(139, 92, 246, 0.18);
-    color: #c4b5fd;
-    font-size: 13px;
-    cursor: pointer;
-    transition: all 0.15s;
-}
-
-.asset-office-btn:hover {
-    background: rgba(139, 92, 246, 0.3);
-    color: #fff;
-}
-
 .asset-office-note {
     font-size: 11px;
     color: rgba(255, 255, 255, 0.35);
     max-width: 320px;
 }
 
-/* Spreadsheet (SheetJS) preview */
+/* Spreadsheet cell-grid preview */
 .asset-sheet-tabs {
     display: flex;
     gap: 4px;

--- a/app/lib/rails_error_tray.py
+++ b/app/lib/rails_error_tray.py
@@ -1,0 +1,94 @@
+"""Shapes Rails crash-feed entries into what the chat page's error tray renders.
+
+The tray (``app/frontend/chat/ui/ErrorAttach.js``) is the quiet one-line notice
+above the composer. It already carries JavaScript errors the preview pushes over
+postMessage; this is the server-side half — the same button press that renders a
+500 puts a line there too, so the user is never left looking at a Rails error
+page wondering whether Leo can see it.
+
+Deliberately separate from ``app/lib/rails_error_watch``, which formats the SAME
+feed entries for the model. The two want opposite things: the model gets prose,
+a "fix this now" instruction and 12 backtrace frames; the tray gets short fields
+a popup can lay out and a person can skim. Sharing a formatter between them
+would make both worse.
+
+The entries are app-controlled text, so everything here is defensive: an entry
+with nothing usable in it is dropped rather than rendered blank, the backtrace
+is trimmed, and the list is capped. The browser escapes it on render; this only
+has to keep the payload sane.
+
+See docs/dev/rails_auto_recovery.md.
+"""
+from typing import Any, Dict, List, Optional
+
+# The tray is a notice, not a log viewer. A crash loop that raises forty
+# distinct errors is still one "something is broken" for the user.
+MAX_TRAY_ERRORS = 10
+
+# Enough to name the file and the line the user needs, not the framework.
+MAX_BACKTRACE_LINES = 8
+
+MAX_MESSAGE_CHARS = 500
+
+
+def tray_entry(entry: Any) -> Optional[Dict[str, Any]]:
+    """One feed entry as a tray row, or None if it carries nothing to show."""
+    if not isinstance(entry, dict):
+        return None
+
+    error_class = str(entry.get("error_class") or "").strip()
+    message = str(entry.get("message") or "").strip()[:MAX_MESSAGE_CHARS]
+
+    if not error_class and not message:
+        return None
+
+    # ``NoMethodError: undefined method `title' for nil``, or either half alone.
+    text = ": ".join(part for part in (error_class, message) if part)
+
+    return {
+        "id": f"rails-{entry.get('seq')}",
+        "kind": "rails",
+        "message": text,
+        # One field, because the tray dedupes on it and renders it as "on X".
+        "path": _where(entry),
+        "count": _count(entry),
+        "stack": _stack(entry),
+    }
+
+
+def tray_entries(entries: Any) -> List[Dict[str, Any]]:
+    """Shape a feed page, newest-biased and capped."""
+    if not isinstance(entries, list):
+        return []
+
+    shaped = [row for row in (tray_entry(e) for e in entries) if row is not None]
+
+    # The feed is oldest-first, so when there are too many the tail is the part
+    # that just happened — which is the part the user is looking at.
+    return shaped[-MAX_TRAY_ERRORS:]
+
+
+def _where(entry: Dict[str, Any]) -> str:
+    method = str(entry.get("method") or "").strip()
+    path = str(entry.get("path") or "").strip()
+    if not path:
+        # A background job crashes with no request. The tray drops the "on …"
+        # line entirely rather than showing a method with nowhere to point.
+        return ""
+    return f"{method} {path}".strip()
+
+
+def _count(entry: Dict[str, Any]) -> int:
+    try:
+        count = int(entry.get("count") or 1)
+    except (TypeError, ValueError):
+        return 1
+    return count if count > 0 else 1
+
+
+def _stack(entry: Dict[str, Any]) -> Optional[str]:
+    backtrace = entry.get("backtrace")
+    if not isinstance(backtrace, list) or not backtrace:
+        return None
+    frames = [str(frame) for frame in backtrace[:MAX_BACKTRACE_LINES]]
+    return "\n".join(frames) or None

--- a/app/lib/rails_error_watch.py
+++ b/app/lib/rails_error_watch.py
@@ -1,0 +1,303 @@
+"""Per-turn state for mid-turn Rails auto-recovery.
+
+When agent-written code crashes the Rails app, the user should never be the one
+who discovers it. ``RailsErrorWatchMiddleware`` polls the Rails error feed once
+per model call and hands whatever is new to :meth:`RailsErrorWatch.plan_injection`,
+which decides — with no HTTP and no LangGraph in the way — whether to put a
+message in front of the model.
+
+Everything that bounds the fix/break/fix loop lives in this module, because that
+loop is the failure mode the feature invites:
+
+* the cursor is primed on the FIRST model call, so only crashes caused *during
+  this turn* can inject;
+* a fingerprint is reported at most once per turn, so a render loop firing the
+  same ``NoMethodError`` 200 times costs one message;
+* after :data:`MAX_INJECTIONS_PER_TURN` attempts the next error produces a
+  "stop and explain to the user" note instead, and then the watch goes quiet;
+* the message is capped at :data:`MAX_REPORT_CHARS` so a 400-frame backtrace
+  cannot eat the context window.
+
+Installed per turn in a ``ContextVar`` exactly like ``app/lib/turn_metrics.py``:
+the request handler calls :func:`start_error_watch`, and the middleware inside
+LangGraph's node tasks resolves to the same object (tasks inherit a copy of the
+context).
+
+See docs/dev/rails_auto_recovery.md.
+"""
+from collections import OrderedDict
+from contextvars import ContextVar
+from typing import Any, Dict, List, Optional
+
+# Three swings at it. Past that, a fourth failure is far more likely to be the
+# agent thrashing than one more typo, and the user is better served by being
+# told what is broken than by watching another attempt.
+MAX_INJECTIONS_PER_TURN = 3
+
+# Hard ceiling on one injected message.
+MAX_REPORT_CHARS = 4000
+
+# Per error. The first few frames name the file to open; the rest is framework.
+MAX_BACKTRACE_LINES = 12
+
+# How far back the arming call looks. Long enough to catch "I broke it, then
+# typed a message", short enough that a crash from earlier in the session does
+# not get dredged into an unrelated turn.
+ARMING_WINDOW_SECONDS = 120
+
+_HEADER = (
+    "[automated] The Rails app crashed while you were working. The user has not "
+    "seen this yet, and it happened AFTER this turn started — so it is very "
+    "likely caused by a change you just made.\n\n"
+)
+
+_HEADER_PRE_EXISTING = (
+    "[automated] The Rails app is throwing an error RIGHT NOW — the user's "
+    "preview is showing an error page instead of their app. This started "
+    "before your turn, so it is not necessarily something you did; do not "
+    "revert work to chase it. Diagnose it from the trace below.\n\n"
+)
+
+_GIVE_UP = (
+    "[automated] The Rails app is still crashing after "
+    f"{MAX_INJECTIONS_PER_TURN} repair attempts this turn. Stop trying to fix "
+    "it. Tell the user in plain language what is broken and what you already "
+    "tried, and let them decide what to do next."
+)
+
+_TRUNCATED = "\n… (report truncated)"
+
+_current_watch: ContextVar[Optional["RailsErrorWatch"]] = ContextVar(
+    "rails_error_watch", default=None
+)
+
+# Watches also live in a small LRU keyed by thread, because a ContextVar cannot
+# span two WebSocket frames and an interrupt/resume cycle is exactly that. The
+# cap is the whole cleanup story: a watch is replaced when its thread's next
+# user message arrives, and otherwise falls off the end. Each holds a handful of
+# ints and strings.
+MAX_TRACKED_THREADS = 50
+
+_WATCHES: "OrderedDict[str, RailsErrorWatch]" = OrderedDict()
+
+
+def agent_can_auto_recover(agent_name: Optional[str]) -> bool:
+    """True for agent modes that are allowed to act on a crash report.
+
+    Plan-mode agents are read-only by design: handing one a crash it is not
+    permitted to fix produces an apology, not a repair.
+    """
+    if not agent_name:
+        return False
+    return "plan_mode" not in str(agent_name)
+
+
+def _footer(attempt: int) -> str:
+    return (
+        "\n\nFix this now, before you finish this turn: diagnose it, edit the "
+        "file, then reload the page to confirm it renders. This is attempt "
+        f"{attempt} of {MAX_INJECTIONS_PER_TURN} — if you cannot fix it, stop "
+        "and tell the user plainly what is broken."
+    )
+
+
+def _format_entry(index: int, entry: Dict[str, Any]) -> Optional[str]:
+    """One error as a block, or None if the entry carries nothing usable."""
+    error_class = str(entry.get("error_class") or "").strip()
+    message = str(entry.get("message") or "").strip()
+    if not error_class and not message:
+        return None
+
+    lines = [f"{index}) {error_class}: {message}".rstrip(": ")]
+
+    method = str(entry.get("method") or "").strip()
+    path = str(entry.get("path") or "").strip()
+    if path:
+        where = f"   at {method} {path}".rstrip()
+        try:
+            count = int(entry.get("count") or 1)
+        except (TypeError, ValueError):
+            count = 1
+        if count > 1:
+            where += f"   (raised {count}x)"
+        lines.append(where)
+
+    backtrace = entry.get("backtrace")
+    if isinstance(backtrace, list):
+        for frame in backtrace[:MAX_BACKTRACE_LINES]:
+            lines.append(f"   {frame}")
+
+    return "\n".join(lines)
+
+
+def _build_report(
+    entries: List[Dict[str, Any]], attempt: int, pre_existing: bool = False
+) -> Optional[str]:
+    header = _HEADER_PRE_EXISTING if pre_existing else _HEADER
+    footer = _footer(attempt)
+    budget = MAX_REPORT_CHARS - len(header) - len(footer)
+
+    blocks: List[str] = []
+    used = 0
+    for index, entry in enumerate(entries, start=1):
+        block = _format_entry(index, entry)
+        if block is None:
+            continue
+
+        remaining = budget - used - (1 if blocks else 0)
+        if remaining <= len(_TRUNCATED):
+            break
+        if len(block) > remaining:
+            block = block[: remaining - len(_TRUNCATED)] + _TRUNCATED
+            blocks.append(block)
+            break
+
+        blocks.append(block)
+        used += len(block) + (1 if len(blocks) > 1 else 0)
+
+    if not blocks:
+        return None
+    return header + "\n".join(blocks) + footer
+
+
+class RailsErrorWatch:
+    """Bookkeeping for one turn's worth of Rails crash recovery."""
+
+    def __init__(
+        self,
+        *,
+        thread_id: str,
+        agent_name: Optional[str],
+        api_token: Optional[str] = None,
+    ):
+        self.thread_id = thread_id
+        self.agent_name = agent_name
+        self.api_token = api_token
+
+        # None until the first model call reads where the error log stands.
+        self.cursor: Optional[int] = None
+        self.injections = 0
+        self.gave_up = False
+        self.seen_fingerprints: set = set()
+
+    @property
+    def armed(self) -> bool:
+        """Whether this turn should poll the Rails error feed at all.
+
+        Purely the mode gate. It deliberately does NOT require ``api_token``:
+        that per-user credential only exists while the human holds a Devise
+        session in the browser, and gating on it meant a signed-out user got no
+        crash recovery at all (2026-08-24). The feed client authenticates as the
+        box and falls back to ``api_token`` only where there is no box secret.
+        """
+        return agent_can_auto_recover(self.agent_name)
+
+    def prime(self, seq: int) -> None:
+        """Record where the error log stood when this turn began.
+
+        Never moves backwards: a Rails process that restarts mid-turn resets its
+        in-memory log to seq 0, and rewinding to that would replay the whole
+        ring into the turn.
+        """
+        if self.cursor is None or seq > self.cursor:
+            self.cursor = int(seq)
+
+    def advance(self, seq: int) -> None:
+        self.prime(seq)
+
+    def plan_injection(
+        self, errors: List[Dict[str, Any]], *, pre_existing: bool = False
+    ) -> Optional[str]:
+        """The message to put in front of the model, or None to stay quiet.
+
+        ``pre_existing`` means these crashes predate the turn — the user asked
+        for help with an app that was already down. Same budget, different
+        framing: the agent must not be told it probably caused something it
+        could not have.
+        """
+        if self.gave_up or not errors:
+            return None
+
+        fresh = []
+        for entry in errors:
+            fingerprint = entry.get("fingerprint") or (
+                f"{entry.get('error_class')}|{entry.get('message')}|{entry.get('path')}"
+            )
+            if fingerprint in self.seen_fingerprints:
+                continue
+            fresh.append((fingerprint, entry))
+
+        if not fresh:
+            return None
+
+        if self.injections >= MAX_INJECTIONS_PER_TURN:
+            self.gave_up = True
+            return _GIVE_UP
+
+        report = _build_report(
+            [entry for _, entry in fresh], self.injections + 1, pre_existing=pre_existing
+        )
+        if report is None:
+            return None
+
+        self.injections += 1
+        for fingerprint, _ in fresh:
+            self.seen_fingerprints.add(fingerprint)
+        return report
+
+
+def start_error_watch(
+    *, thread_id: str, agent_name: Optional[str], api_token: Optional[str] = None
+) -> RailsErrorWatch:
+    """Begin a fresh turn: new cursor, new budget. Called on a user message."""
+    watch = RailsErrorWatch(
+        thread_id=thread_id, agent_name=agent_name, api_token=api_token
+    )
+    _remember(thread_id, watch)
+    _current_watch.set(watch)
+    return watch
+
+
+def resume_error_watch(*, thread_id: str) -> Optional[RailsErrorWatch]:
+    """Re-install the watch for a turn that is continuing after an interrupt.
+
+    A turn is not one WebSocket frame. Leo's own verification step is a
+    ``browser_command`` interrupt — the graph pauses, the frontend navigates the
+    preview, and the answer arrives as a separate frame that resumes the run.
+    That navigation is the single most likely moment for a 500 to surface, so
+    the same watch (cursor, budget, fingerprints) has to come back with it.
+
+    Returns None for a thread we never armed; the caller carries on regardless.
+    """
+    watch = _WATCHES.get(thread_id)
+    if watch is None:
+        return None
+    _WATCHES.move_to_end(thread_id)
+    _current_watch.set(watch)
+    return watch
+
+
+def current_error_watch() -> Optional[RailsErrorWatch]:
+    return _current_watch.get()
+
+
+def clear_error_watch() -> None:
+    _current_watch.set(None)
+
+
+def _remember(thread_id: str, watch: RailsErrorWatch) -> None:
+    _WATCHES[thread_id] = watch
+    _WATCHES.move_to_end(thread_id)
+    while len(_WATCHES) > MAX_TRACKED_THREADS:
+        _WATCHES.popitem(last=False)
+
+
+def _reset_registry() -> None:
+    """Test hook."""
+    _WATCHES.clear()
+    _current_watch.set(None)
+
+
+def _registry_size() -> int:
+    """Test hook."""
+    return len(_WATCHES)

--- a/app/permissions.py
+++ b/app/permissions.py
@@ -92,6 +92,17 @@ DEFAULT_ROLE_MODES: dict[str, list[str]] = {
         "ticket", "engineer", "testing", "database",
         "ai_builder", "beginner", "pyxl", "chat",
     ],
+    # The llama_bot_rails gem — the chat embedded in the box's own Rails app.
+    # A verified gem token proves the box's Rails app sent the frame, but it
+    # carries a *Rails* user id, which maps to no LlamaBot account and so has no
+    # per-user role to look up. The surface gets one grant instead, matching
+    # `engineer` because that is what the embedded chat has always been able to
+    # do — the point of naming it separately is that an operator can now narrow
+    # it, and that the gate checks it at all (it used to skip `rails_auth`).
+    "rails": [
+        "ticket", "engineer", "testing", "database",
+        "ai_builder", "beginner", "pyxl", "chat",
+    ],
 }
 
 # Role used when a user's role is missing or unrecognised (least privilege).

--- a/app/routers/api.py
+++ b/app/routers/api.py
@@ -313,6 +313,142 @@ async def api_check_updates(session: Session = Depends(get_db_session)):
     return result
 
 
+@router.get("/api/overlay-ads", response_class=JSONResponse)
+async def api_overlay_ads(request: Request):
+    """Promo snippets AND the display policy for the building overlay.
+
+    Thin, fail-open proxy in front of the mothership: it owns the creative, the
+    cadence, and the rules for when a promo shows at all; we only clamp and
+    cache (see ``app.services.overlay_ads``). An unconfigured box, an old
+    mothership, or any error all return an empty list with default policy — the
+    overlay then shows no slot, exactly as before this shipped.
+
+    The signed-in user is passed along so the mothership can personalise both
+    halves. Resolved *optionally*: this must never 401, because a promo failing
+    to load is not a reason to break the build overlay.
+    """
+    from app.dependencies import _user_from_session_cookie
+    from app.services import overlay_ads
+    from app.services.mothership_client import MothershipClient
+
+    # A local override file is an explicit operator choice, so it wins over both
+    # the cache and the mothership — edit the file, reload, see the new promo.
+    local = overlay_ads.local_override()
+    if local is not None:
+        return local
+
+    # Resolved WITHOUT a FastAPI dependency on purpose: `Depends(get_db_session)`
+    # would make a DB hiccup 500 an endpoint whose whole contract is to fail open.
+    # No user just means no personalisation.
+    user = None
+    try:
+        from app.db import engine
+        if engine is not None:
+            with Session(engine) as db:
+                user = _user_from_session_cookie(request, db)
+    except Exception as e:
+        logger.info(f"Overlay ads: could not resolve user, serving unpersonalised: {e}")
+
+    # Cache per user: the mothership personalises this response, so a shared
+    # cache would serve one user's targeted promos and policy to the next.
+    cache_key = f"user:{user.id}" if user else "anon"
+
+    fresh = overlay_ads.cached(cache_key)
+    if fresh is not None:
+        return fresh
+
+    mothership = MothershipClient()
+    if not mothership.enabled:
+        return overlay_ads.empty()
+
+    # Same wire shape every mothership report uses, so a promo can be targeted
+    # by the same llamapress_user_guid the telemetry is keyed on.
+    from app.services import user_context as user_ctx
+
+    raw = await mothership.fetch_overlay_ads(
+        get_container_version(), user=user_ctx.describe(user)
+    )
+    if raw is None:
+        # Cache the miss too, so an unreachable mothership isn't re-dialed on
+        # every single build for the next minute.
+        return overlay_ads.store(overlay_ads.empty(), cache_key)
+    return overlay_ads.store(overlay_ads.normalize(raw), cache_key)
+
+
+@router.get("/api/rails-errors", response_class=JSONResponse)
+async def api_rails_errors(request: Request, username: str = Depends(auth)):
+    """The Rails app's recent crashes, for the chat page's error tray.
+
+    The tray above the composer already shows JavaScript errors the preview
+    pushes over postMessage. This is the other half: press a button, get a 500,
+    and the same notice says so — instead of the user staring at a Rails error
+    page wondering whether Leo can see it.
+
+    Why LlamaBot proxies instead of the browser reading Rails directly:
+    ``GET /llama_bot/errors`` sets no CORS headers and the chat page is a
+    different origin, so a direct fetch is blocked. Proxying also keeps the
+    whole feature inside the LlamaBot image — it works against any gem already
+    serving the feed, with no skeleton release in the way.
+
+    Polled every few seconds by a signed-in user, so it stays cheap and quiet:
+    the work is one request on the Docker network, and every failure answers
+    "no information" rather than something the tray would have to render.
+    """
+    return await _rails_errors(request)
+
+
+def _rails_errors_feed(token: str):
+    from app.services.rails_error_feed import RailsErrorFeedClient
+
+    return RailsErrorFeedClient(token=token)
+
+
+async def _rails_errors(request: Request, feed_factory=_rails_errors_feed):
+    """Everything the route does. Split out so tests can inject a fake feed."""
+    from app.lib import rails_error_tray
+
+    unavailable = {"seq": None, "errors": [], "available": False}
+
+    # Header, never a query parameter: this is a live 30-minute Rails bearer
+    # token and query strings end up in access logs and browser history.
+    token = (request.headers.get("X-Rails-Api-Token") or "").strip()
+    if not token:
+        # Signed into LlamaBot but not into the Rails app. Nothing to poll.
+        return unavailable
+
+    since = _rails_error_cursor(request.query_params.get("since"))
+
+    try:
+        result = await feed_factory(token).fetch(since=since)
+    except Exception as e:  # noqa: BLE001 - a broken feed is not a broken page
+        logger.debug(f"Rails error feed unavailable: {e}")
+        return unavailable
+
+    if result is None:
+        # Gem too old for the endpoint, token expired, or Rails restarting.
+        return unavailable
+
+    seq, errors = result
+    return {
+        "seq": seq,
+        "errors": rails_error_tray.tray_entries(errors),
+        "available": True,
+    }
+
+
+def _rails_error_cursor(raw) -> Optional[int]:
+    """The caller's cursor, or None to make this a probe.
+
+    Anything that is not a plain non-negative integer becomes a probe rather
+    than 0 — reading a garbled cursor as 0 would replay the whole ring into the
+    tray, which is how the user would get shown crashes from yesterday.
+    """
+    value = str(raw or "").strip()
+    if not value.isdigit():
+        return None
+    return int(value)
+
+
 class UpdateRequest(BaseModel):
     llamabot_version: str
     llamapress_version: str
@@ -987,6 +1123,8 @@ async def api_submit_feedback(request: Request, body: FeedbackRequest, username:
         len((debug_context or {}).get("recent_events") or []),
     )
 
+    from app.services import user_context as user_ctx
+
     result = await mothership.submit_feedback(
         thread_id=body.thread_id,
         rating=body.rating,
@@ -995,6 +1133,9 @@ async def api_submit_feedback(request: Request, body: FeedbackRequest, username:
         content=body.content,
         sent_at=body.sent_at,
         debug_context=debug_context,
+        # HTTP path: no turn stamp to fall back on, so resolve the signed-in
+        # user from the session cookie here.
+        user=user_ctx.for_request(request),
     )
     return {"success": bool(result and result.get("success"))}
 
@@ -1057,6 +1198,8 @@ async def api_report_frontend_error(
     try:
         from datetime import datetime, timezone
 
+        from app.services import user_context as user_ctx
+
         await mothership.report_error(
             thread_id=body.thread_id,
             error_class=body.error_class,
@@ -1068,6 +1211,7 @@ async def api_report_frontend_error(
             occurred_at=datetime.now(timezone.utc).isoformat(),
             fingerprint=fingerprint,
             source="frontend",
+            user=user_ctx.for_request(request),
         )
     except Exception as e:
         logger.warning(f"Frontend error report failed: {e}")
@@ -2140,17 +2284,13 @@ PREVIEW_PATH_PREFIXES = {
 }
 
 
-@router.get("/api/uploaded-files/preview")
-async def preview_uploaded_file(path: str, download: bool = False, username: str = Depends(auth)):
-    """Serve an uploaded file.
+def _resolve_uploaded_file(path: str) -> tuple[str, str]:
+    """Map an "app/imports/foo.xlsx" style path onto a real file on disk.
 
-    download=1 always forces a download (Content-Disposition: attachment).
-    Otherwise we serve inline only for browser-native types (raster images, PDF);
-    everything else — Office docs, slideshows, SVG — downloads. Capped at 50MB.
+    Returns (absolute_path, filename). Raises HTTPException for anything outside
+    the two allowed upload roots, for traversal attempts, for missing files, and
+    for files above the preview size cap.
     """
-    import pathlib
-    from fastapi.responses import FileResponse
-
     base_dir = None
     filename = None
     for prefix, candidate_base in PREVIEW_PATH_PREFIXES.items():
@@ -2176,10 +2316,132 @@ async def preview_uploaded_file(path: str, download: bool = False, username: str
     if size > MAX_PREVIEW_BYTES:
         raise HTTPException(status_code=413, detail=f"File too large to preview ({size} bytes, max {MAX_PREVIEW_BYTES})")
 
+    return real_full, filename
+
+
+@router.get("/api/uploaded-files/preview")
+async def preview_uploaded_file(path: str, download: bool = False, username: str = Depends(auth)):
+    """Serve an uploaded file.
+
+    download=1 always forces a download (Content-Disposition: attachment).
+    Otherwise we serve inline only for browser-native types (raster images, PDF);
+    everything else — Office docs, slideshows, SVG — downloads. Capped at 50MB.
+    """
+    import pathlib
+    from fastapi.responses import FileResponse
+
+    real_full, filename = _resolve_uploaded_file(path)
+
     ext = pathlib.Path(filename).suffix.lower()
     inline = (not download) and ext in INLINE_PREVIEW_EXTENSIONS
     disposition = "inline" if inline else "attachment"
     return FileResponse(real_full, filename=filename, content_disposition_type=disposition)
+
+
+# ---------------------------------------------------------------------------
+# Spreadsheet preview — parsed HERE, on the box, never by a third party.
+#
+# The asset library used to hand spreadsheets to Microsoft's Office Online
+# viewer (view.officeapps.live.com) in an iframe. That can never work: the
+# viewer fetches the file from Microsoft's servers, and /api/uploaded-files/preview
+# requires this user's session. So we do the boring thing — parse the workbook
+# with openpyxl (already a dependency, used by the pyxl agent) and hand the
+# frontend plain rows of cell values to draw as a grid.
+# ---------------------------------------------------------------------------
+
+# openpyxl reads the OOXML family only. Legacy binary .xls/.xlsb are not covered.
+SHEET_PREVIEW_EXTENSIONS = {'.xlsx', '.xlsm', '.xltx', '.xltm'}
+DELIMITED_PREVIEW_EXTENSIONS = {'.csv': ',', '.tsv': '\t'}
+
+SHEET_PREVIEW_MAX_ROWS = 500
+SHEET_PREVIEW_MAX_COLS = 100
+
+
+def _cell_to_str(value) -> str:
+    """Render one cell for display. Dates as ISO, floats without trailing .0."""
+    import datetime as _dt
+
+    if value is None:
+        return ""
+    if isinstance(value, bool):
+        return "TRUE" if value else "FALSE"
+    if isinstance(value, (_dt.datetime, _dt.date, _dt.time)):
+        return value.isoformat(sep=" ") if isinstance(value, _dt.datetime) else value.isoformat()
+    if isinstance(value, float) and value.is_integer():
+        return str(int(value))
+    return str(value)
+
+
+@router.get("/api/uploaded-files/sheet", response_class=JSONResponse)
+async def preview_uploaded_sheet(path: str, sheet: int = 0, username: str = Depends(auth)):
+    """Parse an uploaded spreadsheet/CSV and return one sheet as rows of strings.
+
+    Response: {"sheets": [names...], "active": i, "rows": [[cell, ...], ...],
+               "total_rows": n, "truncated": bool}
+    415 means "this format can't be parsed here" — the caller falls back to its
+    client-side reader (legacy .xls/.xlsb).
+    """
+    import csv
+    import io
+    import pathlib
+
+    real_full, filename = _resolve_uploaded_file(path)
+    ext = pathlib.Path(filename).suffix.lower()
+
+    if ext in DELIMITED_PREVIEW_EXTENSIONS:
+        delimiter = DELIMITED_PREVIEW_EXTENSIONS[ext]
+        with open(real_full, "r", encoding="utf-8-sig", errors="replace", newline="") as fh:
+            all_rows = list(csv.reader(io.StringIO(fh.read()), delimiter=delimiter))
+        total_rows = len(all_rows)
+        rows = [[_cell_to_str(c) for c in r[:SHEET_PREVIEW_MAX_COLS]] for r in all_rows[:SHEET_PREVIEW_MAX_ROWS]]
+        return {
+            "sheets": [filename],
+            "active": 0,
+            "rows": rows,
+            "total_rows": total_rows,
+            "truncated": total_rows > SHEET_PREVIEW_MAX_ROWS,
+        }
+
+    if ext not in SHEET_PREVIEW_EXTENSIONS:
+        raise HTTPException(status_code=415, detail=f"No server-side preview for {ext} files")
+
+    try:
+        import openpyxl
+        wb = openpyxl.load_workbook(real_full, data_only=True, read_only=True)
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.warning(f"Spreadsheet preview failed for {filename}: {e}")
+        raise HTTPException(status_code=422, detail="Could not read this workbook")
+
+    try:
+        names = list(wb.sheetnames)
+        if not names:
+            raise HTTPException(status_code=422, detail="Workbook has no sheets")
+        index = sheet if 0 <= sheet < len(names) else 0
+        ws = wb[names[index]]
+
+        rows = []
+        total_rows = 0
+        for row in ws.iter_rows(values_only=True):
+            total_rows += 1
+            if len(rows) < SHEET_PREVIEW_MAX_ROWS:
+                rows.append([_cell_to_str(c) for c in row[:SHEET_PREVIEW_MAX_COLS]])
+
+        # Trim trailing all-blank rows openpyxl reports for formatted-but-empty cells.
+        while rows and not any(c for c in rows[-1]):
+            rows.pop()
+            total_rows -= 1
+
+        return {
+            "sheets": names,
+            "active": index,
+            "rows": rows,
+            "total_rows": total_rows,
+            "truncated": total_rows > len(rows),
+        }
+    finally:
+        wb.close()
 
 
 # ============== Remote Setup API ==============

--- a/app/routers/ui.py
+++ b/app/routers/ui.py
@@ -29,6 +29,11 @@ from app.services.magic_link_service import (
     verify_magic_link_token,
 )
 from app.services.mothership_client import MothershipClient
+from app.services.sso_origin import (
+    brand_display_name,
+    remember_sso_origin,
+    resolve_sso_origin,
+)
 
 # Role → agent-mode permissions live in app/permissions.py — the single source of
 # truth this router and the WebSocket gate both read. Re-exported here because
@@ -191,27 +196,33 @@ frontend_dir = Path(__file__).parent.parent / "frontend"
 _SSO_CTA_PLACEHOLDER = "<!--SSO_CTA-->"
 
 
-def _render_sso_login_cta() -> str:
-    """Build the "Sign in with your LlamaPress.ai account" CTA for the login page.
+def _render_sso_login_cta(request: Request = None) -> str:
+    """Build the "Sign in with your <brand> account" CTA for the login page.
 
     Unified Login's discoverable entry point: a link that top-navigates to the
     mothership's ``/sso/leo/{instance_name}`` SSO endpoint (which mints a grant
     and bounces back to ``/auth/consume``). ``target="_top"`` is REQUIRED — the
-    login page can render inside the chat's app-preview iframe and LlamaPress.ai
-    won't load framed, so the click must break out to the top window.
+    login page can render inside the chat's app-preview iframe and the
+    mothership won't load framed, so the click must break out to the top window.
+
+    Host and copy both follow the brand domain this browser arrived from
+    (``resolve_sso_origin``): a builtwithleo.com user gets sent back to
+    builtwithleo.com, not to the ``mothership_url`` in instance.json.
 
     Returns "" on self-hosted instances (no mothership configured) so those users
     see the unchanged stock username/password form — never a broken button.
     """
     mothership = MothershipClient()
-    base = mothership.mothership_url
     name = mothership.instance_name
+    base = resolve_sso_origin(request, mothership.mothership_url or "") if request \
+        else (mothership.mothership_url or "").rstrip("/") or None
     if not base or not name:
         return ""
     sso_url = f"{base.rstrip('/')}/sso/leo/{name}"
+    brand = escape(brand_display_name(sso_url))
     return (
         f'<a class="sso-cta" href="{escape(sso_url, quote=True)}" target="_top">'
-        "Sign in with your LlamaPress.ai account</a>"
+        f"Sign in with your {brand} account</a>"
         '<div class="sso-divider"><span>or</span></div>'
     )
 
@@ -440,8 +451,12 @@ async def login_get(
             html = f.read()
         # Inject the Unified Login CTA on mothership-managed instances; on
         # self-hosted boxes the placeholder is replaced with "" (stock form).
-        html = html.replace(_SSO_CTA_PLACEHOLDER, _render_sso_login_cta())
-        return HTMLResponse(content=html)
+        html = html.replace(_SSO_CTA_PLACEHOLDER, _render_sso_login_cta(request))
+        response = HTMLResponse(content=html)
+        # A mothership link into /login can carry ?sso_origin= too; remember it
+        # so the CTA and any later bounce stay on that brand.
+        remember_sso_origin(request, response, MothershipClient().mothership_url or "")
+        return response
 
     try:
         username = verify_magic_link_token(token)
@@ -474,6 +489,9 @@ async def login_get(
 
     response = RedirectResponse(url=redirect_url, status_code=302)
     _set_session_cookie(response, user)
+    # The legacy magic link can carry ?sso_origin= as well, so a user who came in
+    # from builtwithleo.com keeps that brand on any later sign-in prompt.
+    remember_sso_origin(request, response, MothershipClient().mothership_url or "")
     return response
 
 

--- a/app/routers/unified_login.py
+++ b/app/routers/unified_login.py
@@ -18,7 +18,10 @@ Design contract (frozen, mirrored by prod + the Phase 3 gem):
     adoption key for the admin account created at claim time;
   * grant_expired / grant_used are EXPECTED (refresh, bookmark) and degrade
     gracefully — never an error-page dead end;
-  * one retry bounce max (loop breaker via the ``retry`` param).
+  * one retry bounce max (loop breaker via the ``retry`` param);
+  * every user-facing link back to the mothership uses the brand domain the
+    browser arrived from (``?sso_origin=``, remembered in a cookie — see
+    app/services/sso_origin.py), never the server-to-server ``mothership_url``.
 """
 
 import logging
@@ -36,6 +39,11 @@ from app.dependencies import _user_from_session_cookie
 from app.models import User
 from app.routers.ui import _set_session_cookie
 from app.services.mothership_client import MothershipClient
+from app.services.sso_origin import (
+    brand_display_name,
+    remember_sso_origin,
+    resolve_sso_origin,
+)
 from app.services.user_service import get_user_by_username, hash_password
 
 logger = logging.getLogger(__name__)
@@ -101,9 +109,14 @@ def _sso_url(mothership: MothershipClient, request: Request, *, retry: bool) -> 
     ``retry=True`` adds ``retry=1`` so the mothership knows to bounce back here
     with a fresh token AND so our loop breaker fires if that fresh token also
     fails. The "Continue with LlamaPress" link uses ``retry=False``.
+
+    The host comes from ``resolve_sso_origin`` — the brand domain this browser
+    actually arrived from (builtwithleo.com vs llamapress.ai), NOT the
+    server-to-server ``mothership_url``. Bouncing a builtwithleo.com user to
+    llamapress.ai lands them on a different Rails session and a sign-in wall.
     """
-    base = mothership.mothership_url
     name = mothership.instance_name
+    base = resolve_sso_origin(request, mothership.mothership_url or "")
     if not base or not name:
         return None
     params = _passthrough_params(request)
@@ -233,11 +246,12 @@ def _login_page_with_error(mothership: MothershipClient, request: Request) -> HT
     )
     sso = _sso_url(mothership, request, retry=False)
     if sso:
+        brand = escape(brand_display_name(sso))
         banner += (
             f'<div style="margin-top:16px;text-align:center;">'
             f'<a href="{escape(sso, quote=True)}" '
             f'style="color:#a78bfa;text-decoration:underline;">'
-            "Continue with LlamaPress</a></div>"
+            f"Continue with {brand}</a></div>"
         )
     # login.html carries an empty <div id="message"></div> placeholder.
     if '<div id="message"></div>' in html:
@@ -282,6 +296,11 @@ async def auth_consume(
 
         response = RedirectResponse(url=redirect_url, status_code=302)
         _set_session_cookie(response, user)
+        # Remember which brand domain this browser came from so a LATER bounce
+        # (expired grant, sign-out) returns to it rather than to the configured
+        # mothership_url. Not threaded into redirect_url — the chat has no use
+        # for it and it would sit in the address bar.
+        remember_sso_origin(request, response, mothership.mothership_url or "")
         return response
 
     # 4. Failure paths.
@@ -297,7 +316,9 @@ async def auth_consume(
     if error_code in BOUNCE_CODES and not retry:
         sso = _sso_url(mothership, request, retry=True)
         if sso:
-            return RedirectResponse(url=sso, status_code=302)
+            response = RedirectResponse(url=sso, status_code=302)
+            remember_sso_origin(request, response, mothership.mothership_url or "")
+            return response
 
     # 4c/4d. Terminal: loop already broken (retry present), mothership_unreachable
     #     (a bounce can't help), or an unexpected code. Report the stuck user and
@@ -308,7 +329,9 @@ async def auth_consume(
         error_message=error_code or "unknown",
         traceback_str="",
     )
-    return _login_page_with_error(mothership, request)
+    response = _login_page_with_error(mothership, request)
+    remember_sso_origin(request, response, mothership.mothership_url or "")
+    return response
 
 
 class RedeemRailsGrantRequest(BaseModel):

--- a/app/services/mothership_client.py
+++ b/app/services/mothership_client.py
@@ -89,6 +89,27 @@ class MothershipClient:
         """
         return self.enabled and not telemetry_disabled()
 
+    @staticmethod
+    def _resolve_user(user: Optional[dict]) -> Optional[dict]:
+        """Who this report is about: the explicit argument, else the turn stamp.
+
+        HTTP callers hand the identity in directly (they have the request and
+        therefore the session cookie). The WebSocket paths cannot: report_message
+        fires deep inside RequestHandler, which is constructed once per
+        connection BEFORE authentication runs, so there is no user object to
+        thread down. Those turns stamp app/services/user_context.py at auth time
+        and this reads it back. Unset -> None -> the payload simply omits the
+        user, exactly as it did before this existed.
+        """
+        if user is not None:
+            return user
+        try:
+            from app.services import user_context
+
+            return user_context.current()
+        except Exception:  # noqa: BLE001 - telemetry must never break a turn
+            return None
+
     @property
     def instance_name(self) -> Optional[str]:
         """Get instance name from config."""
@@ -144,6 +165,7 @@ class MothershipClient:
         tool_calls: Optional[list] = None,
         tool_call_id: Optional[str] = None,
         timings: Optional[dict] = None,
+        user: Optional[dict] = None,
     ) -> Optional[dict]:
         """
         POST /api/leonardo/report_message
@@ -160,6 +182,13 @@ class MothershipClient:
         tokens-per-second of the model call that produced this reply, so the
         mothership has a per-message performance series alongside token usage.
         See docs/dev/performance_telemetry.md.
+
+        ``user`` says WHO sent it — ``{id, username, email,
+        llamapress_user_guid, role, is_admin}``. Defaults to the turn's stamped
+        identity, so WebSocket callers need pass nothing. Omitted entirely when
+        unknown (a Rails-gem token, a legacy box). See
+        app/services/user_context.py for why the guid is the join key and email
+        is not.
         """
         if not self.reporting_enabled:
             return None
@@ -183,6 +212,9 @@ class MothershipClient:
                     payload["tool_call_id"] = tool_call_id
                 if timings:
                     payload["timings"] = timings
+                reported_user = self._resolve_user(user)
+                if reported_user:
+                    payload["user"] = reported_user
                 response = await client.post(
                     f"{self.config['mothership_url']}/api/leonardo/report_message",
                     json=payload,
@@ -212,6 +244,7 @@ class MothershipClient:
         content: Optional[str] = None,
         sent_at: Optional[str] = None,
         debug_context: Optional[dict] = None,
+        user: Optional[dict] = None,
     ) -> Optional[dict]:
         """
         POST /api/leonardo/submit_feedback
@@ -242,6 +275,9 @@ class MothershipClient:
                     payload["sent_at"] = sent_at
                 if debug_context:
                     payload["debug_context"] = debug_context
+                reported_user = self._resolve_user(user)
+                if reported_user:
+                    payload["user"] = reported_user
                 response = await client.post(
                     f"{self.config['mothership_url']}/api/leonardo/submit_feedback",
                     json=payload,
@@ -349,6 +385,7 @@ class MothershipClient:
         fingerprint: Optional[str] = None,
         recovered: Optional[bool] = None,
         source: str = "llamabot",
+        user: Optional[dict] = None,
     ) -> None:
         """
         POST /api/leonardo/report_error
@@ -392,6 +429,9 @@ class MothershipClient:
                     payload["fingerprint"] = fingerprint
                 if recovered is not None:
                     payload["recovered"] = recovered
+                reported_user = self._resolve_user(user)
+                if reported_user:
+                    payload["user"] = reported_user
                 response = await client.post(
                     f"{self.config['mothership_url']}/api/leonardo/report_error",
                     json=payload,
@@ -418,6 +458,7 @@ class MothershipClient:
         model: Optional[str] = None,
         llamabot_version: Optional[str] = None,
         occurred_at: Optional[str] = None,
+        user: Optional[dict] = None,
     ) -> None:
         """
         POST /api/leonardo/report_turn_metrics
@@ -462,6 +503,9 @@ class MothershipClient:
                     payload["llamabot_version"] = llamabot_version
                 if occurred_at:
                     payload["occurred_at"] = occurred_at
+                reported_user = self._resolve_user(user)
+                if reported_user:
+                    payload["user"] = reported_user
                 response = await client.post(
                     f"{self.config['mothership_url']}/api/leonardo/report_turn_metrics",
                     json=payload,
@@ -573,4 +617,46 @@ class MothershipClient:
             return None
         except httpx.RequestError as e:
             logger.error(f"Teardown notification request failed: {e}")
+            return None
+
+    async def fetch_overlay_ads(
+        self, current_llamabot: str, user: Optional[dict] = None
+    ) -> Optional[dict]:
+        """
+        POST /api/leonardo/overlay_ads
+
+        Fetch the promo HTML snippets AND the display policy for the "Your App is
+        Building!" overlay. The mothership owns the content, the rotation cadence
+        and the rules for when a promo shows at all, so all three can be changed
+        (and personalised per user) with no instance deploy.
+
+        Returns ``{"ads": [...], "rotate_seconds": int}`` or ``None`` on any error
+        — including a 404 from a mothership that hasn't shipped the endpoint yet.
+        Fully fail-open: the overlay simply shows no promo slot.
+
+        Gated on ``enabled`` (configured), not ``reporting_enabled`` — this pulls
+        content down rather than reporting anything about this box, so the
+        telemetry kill switch must not blank the product surface.
+        """
+        if not self.enabled:
+            return None
+
+        try:
+            async with httpx.AsyncClient(timeout=5.0) as client:
+                response = await client.post(
+                    f"{self.config['mothership_url']}/api/leonardo/overlay_ads",
+                    json={
+                        "instance_name": self.config["instance_name"],
+                        "llamabot_version": current_llamabot,
+                        # Who is looking at it, so the mothership can personalise
+                        # the creative AND the display policy. Omitted when the
+                        # request has no session.
+                        "user": user,
+                    },
+                    headers={"Authorization": f"Bearer {self.config['mothership_api_token']}"},
+                )
+                response.raise_for_status()
+                return response.json()
+        except Exception as e:
+            logger.info(f"Overlay ad fetch failed (no promos will show): {e}")
             return None

--- a/app/services/overlay_ads.py
+++ b/app/services/overlay_ads.py
@@ -1,0 +1,244 @@
+"""Promo ("jumbotron") slot for the building overlay.
+
+The mothership owns the creative: it stores HTML snippets and hands them to
+instances over ``POST /api/leonardo/overlay_ads``. LlamaBot only carries the
+plumbing — fetch, sanity-check, cache briefly, hand to the browser — so a promo
+can be written/edited on the mothership and picked up on the next build without
+touching an instance.
+
+Two rules this module exists to enforce:
+
+1. **Fail open, always.** No mothership, an old mothership that 404s the
+   endpoint, a timeout, garbage JSON — all of it degrades to "no promos", never
+   to a broken overlay. Nothing here raises.
+2. **Bound what a remote payload can do.** The snippets are rendered by the
+   browser, so the count, the per-snippet size, the slot height and the rotation
+   cadence are all clamped here rather than trusted. (The browser renders each
+   snippet in a *sandboxed, opaque-origin* iframe — see ``OverlayAds.js`` — so
+   the HTML itself can never reach the chat DOM, cookies or session.)
+"""
+import json
+import logging
+import time
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+#: Operator override, same directory as instance.json. When present it WINS over
+#: the mothership — that's the point: drop a file here to preview promo HTML on a
+#: box before the creative is published fleet-wide (and it's how this feature is
+#: QA'd at all on a box whose mothership hasn't shipped the endpoint). Same
+#: payload shape as the mothership response; the clamps below still apply.
+LOCAL_OVERRIDE_PATH = ".leonardo/overlay_ads.json"
+
+#: Hard ceilings on anything a remote payload can ask the overlay to do.
+MAX_ADS = 10
+MAX_AD_BYTES = 64 * 1024
+
+DEFAULT_ROTATE_SECONDS = 180
+MIN_ROTATE_SECONDS = 15
+MAX_ROTATE_SECONDS = 3600
+
+DEFAULT_AD_HEIGHT = 140
+MIN_AD_HEIGHT = 60
+MAX_AD_HEIGHT = 400
+
+# ---------------------------------------------------------------------------
+# Display policy — WHEN the jumbotron shows, as opposed to WHAT it shows.
+#
+# This lives on the mothership on purpose: which builds get a promo, how long we
+# wait before showing one, and how often a given browser sees one are all things
+# worth experimenting with and personalising per user, and none of them should
+# need an image build to change. Everything here is a *default* the mothership's
+# `policy` object overrides field by field, so an old mothership (or one that
+# sends no policy at all) still gets working behaviour.
+#
+# The instance keeps two guarantees regardless of what the mothership sends:
+#   1. Never during a question — Leo is blocked on the user; nothing competes.
+#      That's why "question" is not an offerable mode below.
+#   2. Every value is clamped. A policy can tune the product, not break it.
+# ---------------------------------------------------------------------------
+
+#: Layouts a promo may appear in. "question" is deliberately absent — see above.
+SELECTABLE_MODES = ("building", "plan")
+
+#: Hold the promo back for the first few seconds of a build. Without this a short
+#: build flashes an ad for two seconds and yanks it away, which reads as a bug.
+DEFAULT_SHOW_AFTER_SECONDS = 5
+MAX_SHOW_AFTER_SECONDS = 300
+
+#: Per-browser cooldown between promos. 0 = show on every build (the default;
+#: turn it up from the mothership if promos start feeling relentless).
+DEFAULT_MIN_INTERVAL_SECONDS = 0
+MAX_MIN_INTERVAL_SECONDS = 86400
+
+DEFAULT_POLICY = {
+    "enabled": True,
+    "show_after_seconds": DEFAULT_SHOW_AFTER_SECONDS,
+    "modes": list(SELECTABLE_MODES),
+    "min_interval_seconds": DEFAULT_MIN_INTERVAL_SECONDS,
+}
+
+#: How long a fetched payload is reused. Short enough that editing a promo on the
+#: mothership shows up on the next build or two (the point of the feature), long
+#: enough that a user hammering Enter doesn't hammer the mothership.
+CACHE_TTL_SECONDS = 60
+
+def empty() -> dict:
+    """A fresh "nothing to show" payload. A function, not a constant, so callers
+    can never mutate the shared default out from under each other."""
+    return {
+        "ads": [],
+        "rotate_seconds": DEFAULT_ROTATE_SECONDS,
+        "policy": dict(DEFAULT_POLICY),
+        "variant": None,
+    }
+
+
+#: Back-compat alias for the tests/callers that only compare shapes.
+EMPTY = empty()
+
+_cache: dict[str, tuple[float, dict]] = {}
+
+
+def _clamp(value, low, high, default):
+    """Coerce ``value`` to an int inside [low, high]; ``default`` if it isn't one."""
+    try:
+        n = int(value)
+    except (TypeError, ValueError):
+        return default
+    return max(low, min(high, n))
+
+
+def normalize(payload) -> dict:
+    """Turn a raw mothership payload into the shape the overlay consumes.
+
+    Always returns ``{"ads": [...], "rotate_seconds": int}``. Malformed entries
+    are dropped individually — one bad snippet must not blank the whole slot.
+    """
+    if not isinstance(payload, dict):
+        return empty()
+
+    raw_ads = payload.get("ads")
+    if not isinstance(raw_ads, list):
+        return empty()
+
+    ads = []
+    for index, entry in enumerate(raw_ads):
+        if len(ads) >= MAX_ADS:
+            logger.info(f"Overlay ads truncated to {MAX_ADS}; mothership sent {len(raw_ads)}")
+            break
+        if not isinstance(entry, dict):
+            continue
+        html = entry.get("html")
+        if not isinstance(html, str) or not html.strip():
+            continue
+        if len(html.encode("utf-8")) > MAX_AD_BYTES:
+            # Dropped, never truncated: a half-snippet is broken markup.
+            logger.info(f"Overlay ad {entry.get('id', index)!r} dropped (over {MAX_AD_BYTES} bytes)")
+            continue
+        ad_id = entry.get("id")
+        ads.append({
+            "id": str(ad_id) if ad_id else f"ad-{index}",
+            "html": html,
+            "height": _clamp(entry.get("height"), MIN_AD_HEIGHT, MAX_AD_HEIGHT, DEFAULT_AD_HEIGHT),
+        })
+
+    variant = payload.get("variant")
+    return {
+        "ads": ads,
+        "rotate_seconds": _clamp(
+            payload.get("rotate_seconds"),
+            MIN_ROTATE_SECONDS,
+            MAX_ROTATE_SECONDS,
+            DEFAULT_ROTATE_SECONDS,
+        ),
+        "policy": normalize_policy(payload.get("policy")),
+        # Opaque experiment/segment label. The instance does nothing with it
+        # beyond echoing it into `leoAds.status()`, so whoever is running the
+        # experiment can see which arm a browser actually got.
+        "variant": str(variant) if variant else None,
+    }
+
+
+def normalize_policy(raw) -> dict:
+    """Merge the mothership's `policy` over the baked-in defaults, clamped.
+
+    Every field is independently optional: sending `{"show_after_seconds": 20}`
+    changes only the delay and leaves the rest at their defaults. A policy that
+    is missing, null, or not an object gives the defaults untouched.
+    """
+    policy = dict(DEFAULT_POLICY)
+    if not isinstance(raw, dict):
+        return policy
+
+    if "enabled" in raw:
+        policy["enabled"] = bool(raw.get("enabled"))
+
+    if "show_after_seconds" in raw:
+        policy["show_after_seconds"] = _clamp(
+            raw.get("show_after_seconds"), 0, MAX_SHOW_AFTER_SECONDS,
+            DEFAULT_SHOW_AFTER_SECONDS,
+        )
+
+    if "min_interval_seconds" in raw:
+        policy["min_interval_seconds"] = _clamp(
+            raw.get("min_interval_seconds"), 0, MAX_MIN_INTERVAL_SECONDS,
+            DEFAULT_MIN_INTERVAL_SECONDS,
+        )
+
+    if "modes" in raw:
+        wanted = raw.get("modes")
+        if isinstance(wanted, list):
+            # Intersect rather than trust: an unknown mode is dropped, and
+            # "question" can never be selected (Leo is blocked on the user).
+            modes = [m for m in SELECTABLE_MODES if m in wanted]
+            dropped = [m for m in wanted if m not in SELECTABLE_MODES]
+            if dropped:
+                logger.info(f"Overlay ad policy: ignoring unselectable modes {dropped}")
+            policy["modes"] = modes
+
+    return policy
+
+
+def local_override() -> Optional[dict]:
+    """Normalized payload from ``LOCAL_OVERRIDE_PATH``, or ``None`` if there isn't
+    a usable one. Never raises — a typo'd override file falls back to the
+    mothership rather than blanking the overlay.
+    """
+    try:
+        path = Path(LOCAL_OVERRIDE_PATH)
+        if not path.is_file():
+            return None
+        return normalize(json.loads(path.read_text()))
+    except Exception as e:
+        logger.warning(f"Ignoring unreadable {LOCAL_OVERRIDE_PATH}: {e}")
+        return None
+
+
+def cached(key: str = "anon") -> Optional[dict]:
+    """The last normalized payload for ``key`` if it's still fresh, else ``None``.
+
+    Keyed per user because the mothership personalises both the creative and the
+    display policy. A single process-wide cache would hand the first requester's
+    (possibly targeted) promos to everyone else signed into the same box.
+    """
+    entry = _cache.get(key)
+    if entry is None:
+        return None
+    fetched_at, payload = entry
+    if time.monotonic() - fetched_at > CACHE_TTL_SECONDS:
+        return None
+    return payload
+
+
+def store(payload: dict, key: str = "anon") -> dict:
+    """Cache a normalized payload under ``key`` and return it."""
+    _cache[key] = (time.monotonic(), payload)
+    return payload
+
+
+def clear_cache() -> None:
+    """Drop the cache (tests, and any future 'refresh promos now' control)."""
+    _cache.clear()

--- a/app/services/rails_error_feed.py
+++ b/app/services/rails_error_feed.py
@@ -1,0 +1,153 @@
+"""Reads the Rails app's recent-crash feed (``GET /llama_bot/errors``).
+
+Served by ``LlamaBotRails::ErrorsController`` in the llama_bot_rails gem, which
+keeps the last 25 exceptions in memory with a monotonic ``seq``. We poll rather
+than being pushed to because Rails does not know LlamaBot's URL, and because
+polling also catches crashes in background jobs and in requests the user's
+browser never made.
+
+Contract, and the reason it is this blunt: this runs once per model call on
+every turn. **Every failure returns None** — an expired token, a Rails restart,
+a box on a gem that predates the endpoint, a garbled body. None means "no
+information", the middleware stays quiet, and the turn proceeds exactly as it
+would have. Nothing in here may raise into a turn.
+
+See docs/dev/rails_auto_recovery.md.
+"""
+import hashlib
+import hmac
+import logging
+import os
+from typing import Any, Dict, List, Optional, Tuple
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_BASE_URL = os.getenv("RAILS_BASE_URL", "http://llamapress:3000")
+ENDPOINT_PATH = "/llama_bot/errors"
+
+# Short on purpose. A slow answer is worth less than a fast turn, and the
+# request is local to the Docker network.
+TIMEOUT_SECONDS = 1.0
+
+# The box-internal credential. Both containers are handed the same
+# SECRET_KEY_BASE from the same .env, so each side derives the same value and
+# nothing has to be provisioned.
+#
+# This replaced authenticating as the signed-in Rails user. That version read
+# the per-user `api_token` off the WebSocket frame, which only exists while the
+# human holds a Devise session in the browser tab — so the feature silently
+# no-opped for anyone signed out (2026-08-24: "no Rails api_token on the
+# frame"). Whether the box can read its OWN error log must not hinge on a
+# browser session.
+#
+# Plain HMAC-SHA256, matching OpenSSL::HMAC.hexdigest on the Ruby side. Not
+# ActiveSupport's MessageVerifier: that is Marshal-based and cannot be
+# reproduced here.
+FEED_TOKEN_PURPOSE = b"llamabot-error-feed"
+FEED_SCHEME = "LlamaBotFeed"
+
+
+def feed_token() -> Optional[str]:
+    """The box-internal feed credential, or None if there is no shared secret."""
+    secret = os.getenv("SECRET_KEY_BASE", "").strip()
+    if not secret:
+        return None
+    return hmac.new(secret.encode(), FEED_TOKEN_PURPOSE, hashlib.sha256).hexdigest()
+
+
+class RailsErrorFeedClient:
+    """One-call client for the Rails recent-crash feed."""
+
+    def __init__(
+        self,
+        *,
+        base_url: Optional[str] = None,
+        token: Optional[str] = None,
+        timeout: float = TIMEOUT_SECONDS,
+        client_factory=None,
+    ):
+        self.base_url = (base_url or DEFAULT_BASE_URL).rstrip("/")
+        self.token = token
+        self.timeout = timeout
+        # Injectable so tests drive an httpx.MockTransport instead of a socket.
+        self._client_factory = client_factory or (
+            lambda timeout: httpx.AsyncClient(timeout=timeout)
+        )
+
+    async def fetch(
+        self, *, since: Optional[int], within: Optional[int] = None
+    ) -> Optional[Tuple[int, List[Dict[str, Any]]]]:
+        """Return ``(cursor, errors)``, or None if we learned nothing.
+
+        ``since`` is the steady state: everything after a cursor we hold. It
+        always wins — once armed, re-sending a window would re-deliver crashes
+        the turn has already been told about.
+
+        ``within=<seconds>`` (with ``since=None``) is the arming call: what has
+        crashed recently. Needed because the common case is an app that is
+        ALREADY broken when the user asks for a fix — nothing new is coming, so
+        a cursor alone would stay silent while they stare at an error page.
+
+        Neither is a bare cursor probe.
+        """
+        authorization = self._authorization()
+        if authorization is None:
+            return None
+
+        if since is not None:
+            params = {"since": str(int(since))}
+        elif within is not None:
+            params = {"within": str(int(within))}
+        else:
+            params = {}
+
+        try:
+            async with self._client_factory(self.timeout) as client:
+                response = await client.get(
+                    f"{self.base_url}{ENDPOINT_PATH}",
+                    params=params,
+                    headers={"Authorization": authorization},
+                )
+                if response.status_code != 200:
+                    logger.debug(
+                        "rails error feed: HTTP %s (gem too old, or token expired)",
+                        response.status_code,
+                    )
+                    return None
+                payload = response.json()
+        except Exception as exc:  # noqa: BLE001 - must never break a turn
+            logger.debug("rails error feed unavailable: %s", exc)
+            return None
+
+        return self._parse(payload)
+
+    def _authorization(self) -> Optional[str]:
+        """Box credential first, per-user token as a fallback, else nothing.
+
+        The fallback keeps this working on a box whose Rails container does not
+        share SECRET_KEY_BASE (an ejected app), where the signed-in user's token
+        is the only credential there is.
+        """
+        box = feed_token()
+        if box:
+            return f"{FEED_SCHEME} {box}"
+        if self.token:
+            return f"LlamaBot {self.token}"
+        return None
+
+    @staticmethod
+    def _parse(payload: Any) -> Optional[Tuple[int, List[Dict[str, Any]]]]:
+        if not isinstance(payload, dict):
+            return None
+
+        seq = payload.get("seq")
+        if not isinstance(seq, int) or isinstance(seq, bool):
+            return None
+
+        errors = payload.get("errors", [])
+        if not isinstance(errors, list):
+            return None
+
+        return seq, [entry for entry in errors if isinstance(entry, dict)]

--- a/app/services/rails_message_verifier.py
+++ b/app/services/rails_message_verifier.py
@@ -1,0 +1,314 @@
+"""Verify ``ActiveSupport::MessageVerifier`` tokens minted by ``llama_bot_rails``.
+
+The gem hands the browser a token for the chat WebSocket::
+
+    Rails.application.message_verifier(:llamabot_ws)
+         .generate({session_id:, user_id:}, expires_in: 30.minutes)
+
+and every frame from the Rails-embedded chat carries a freshly minted one
+(``app/channels/llama_bot_rails/chat_channel.rb`` mints per ``receive``).
+
+Before this module existed LlamaBot did not check the signature at all — it
+accepted any string containing ``--`` as proof of a trusted internal caller,
+which made the whole agent-authorization gate forgeable from the public
+internet. Verification happens locally: on a Leo box the llamabot and Rails
+containers read the same ``SECRET_KEY_BASE``, so there is no HTTP round trip
+to Rails per connection.
+
+Wire format (all of it confirmed against a live Rails 7.2.3 box, not read off
+the docs — see ``app/tests/test_rails_token_verification.py`` for the golden
+vectors this was built from)::
+
+    <base64(serialized payload)>--<hex HMAC of that base64 text>
+
+  * **Key** — ``PBKDF2-HMAC(secret_key_base, "llamabot_ws", 1000, 64)``, whose
+    digest is Rails' ``key_generator_hash_digest_class``. A stock Rails 7.2 box
+    uses **SHA1** here even on ``load_defaults 7.2`` — measured, not assumed;
+    an app that has set it to SHA256 is equally valid, so both are tried.
+  * **Signature** — HMAC over the base64 *text*, using ``MessageVerifier``'s own
+    digest, which defaults to SHA1 and is a *separate* setting from the
+    derivation digest above. Confusing the two is the easy mistake here, and it
+    fails in the most misleading way possible: a self-minted test vector still
+    round-trips, because it is wrong in both directions at once. Only a token
+    from a real Rails app catches it.
+  * **Payload** — Marshal on a stock box, JSON where the app has opted into
+    ``message_serializer = :json``. Rails' own ``*WithFallback`` serializers
+    read either, so this does too.
+  * **Metadata** — Rails 7.1+ wraps the payload as
+    ``{"_rails" => {"data" => …, "exp" => …, "pur" => …}}`` when any of
+    expiry/purpose is set, and leaves it bare when none is.
+
+Marshal parsing runs **only after** the HMAC checks out, so the bytes handed to
+it are already proven to come from the box's own Rails app. The reader is still
+a strict allowlist that raises on any type it doesn't know — it never
+constructs objects, so a Marshal payload cannot become code execution.
+"""
+import base64
+import binascii
+import hashlib
+import hmac
+import json
+import logging
+import os
+from functools import lru_cache
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+# Rails' KeyGenerator defaults, and the salt the gem names its verifier with.
+KEY_SALT = "llamabot_ws"
+KEY_ITERATIONS = 1000
+KEY_LENGTH = 64
+
+# Rails' `key_generator_hash_digest_class`. SHA1 is what a stock box actually
+# uses; SHA256 covers an app that has opted into it. Offering both costs two
+# cheap PBKDF2 runs (cached) and gives an attacker nothing — every candidate
+# still needs the secret.
+KEY_DIGESTS = ("sha1", "sha256")
+
+# MessageVerifier's message digest defaults to SHA1. A box that has rotated to a
+# stronger one still verifies: every candidate needs the same HMAC key, so
+# offering more than one costs nothing an attacker can use.
+CANDIDATE_DIGESTS = ("sha1", "sha256", "sha512")
+
+
+class InvalidRailsToken(Exception):
+    """Token failed signature, structure, or expiry checks."""
+
+
+# --------------------------------------------------------------------------
+# Ruby Marshal (format 4.8) — the small, strict subset a token payload uses.
+# --------------------------------------------------------------------------
+
+class _MarshalReader:
+    """Reads the handful of Marshal types a MessageVerifier payload can hold.
+
+    Supports nil/true/false, integers, symbols, strings, arrays and hashes,
+    plus the symbol- and object-link back-references Ruby emits for repeats.
+    Anything else — user-defined types, ``Object`` dumps — raises. A token
+    payload is a flat hash of scalars, so a wider reader would only add ways
+    to be wrong.
+    """
+
+    def __init__(self, data: bytes):
+        self.d = data
+        self.i = 0
+        self.symbols: list = []
+        self.objects: list = []
+
+    def _byte(self) -> int:
+        if self.i >= len(self.d):
+            raise InvalidRailsToken("truncated marshal payload")
+        b = self.d[self.i]
+        self.i += 1
+        return b
+
+    def _take(self, n: int) -> bytes:
+        if n < 0 or self.i + n > len(self.d):
+            raise InvalidRailsToken("truncated marshal payload")
+        s = self.d[self.i:self.i + n]
+        self.i += n
+        return s
+
+    def _long(self) -> int:
+        """Ruby's packed variable-length integer."""
+        c = self._byte()
+        if c > 127:
+            c -= 256
+        if c == 0:
+            return 0
+        if c > 0:
+            if c > 4:
+                return c - 5
+            val = 0
+            for k in range(c):
+                val |= self._byte() << (8 * k)
+            return val
+        if c < -4:
+            return c + 5
+        val = -1
+        for k in range(-c):
+            val &= ~(0xFF << (8 * k))
+            val |= self._byte() << (8 * k)
+        return val
+
+    def read(self) -> Any:
+        t = self._byte()
+        if t == 0x30:            # '0' nil
+            return None
+        if t == 0x54:            # 'T'
+            return True
+        if t == 0x46:            # 'F'
+            return False
+        if t == 0x69:            # 'i' integer
+            return self._long()
+        if t == 0x3A:            # ':' symbol
+            sym = self._take(self._long()).decode("utf-8", "replace")
+            self.symbols.append(sym)
+            return sym
+        if t == 0x3B:            # ';' symbol back-reference
+            idx = self._long()
+            if not 0 <= idx < len(self.symbols):
+                raise InvalidRailsToken("bad symbol link")
+            return self.symbols[idx]
+        if t == 0x22:            # '"' string
+            s = self._take(self._long()).decode("utf-8", "replace")
+            self.objects.append(s)
+            return s
+        if t == 0x49:            # 'I' object carrying instance variables
+            inner = self.read()
+            for _ in range(self._long()):
+                self.read()      # ivar name (e.g. :E, the encoding flag)
+                self.read()      # ivar value — encoding is not data we need
+            return inner
+        if t == 0x5B:            # '[' array
+            n = self._long()
+            arr: list = []
+            self.objects.append(arr)
+            for _ in range(n):
+                arr.append(self.read())
+            return arr
+        if t == 0x7B:            # '{' hash
+            n = self._long()
+            h: dict = {}
+            self.objects.append(h)
+            for _ in range(n):
+                k = self.read()
+                h[k] = self.read()
+            return h
+        if t == 0x40:            # '@' object back-reference
+            idx = self._long()
+            if not 0 <= idx < len(self.objects):
+                raise InvalidRailsToken("bad object link")
+            return self.objects[idx]
+        raise InvalidRailsToken(f"unsupported marshal type {chr(t)!r}")
+
+
+def _marshal_load(blob: bytes) -> Any:
+    if len(blob) < 2 or blob[0] != 0x04:
+        raise InvalidRailsToken("not a marshal payload")
+    return _MarshalReader(blob[2:]).read()
+
+
+def _deserialize(blob: bytes) -> Any:
+    """JSON if it parses, else Marshal — mirroring Rails' *WithFallback pair."""
+    try:
+        return json.loads(blob.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return _marshal_load(blob)
+
+
+# --------------------------------------------------------------------------
+# Signature + metadata
+# --------------------------------------------------------------------------
+
+@lru_cache(maxsize=16)
+def derive_key(secret_key_base: str, salt: str = KEY_SALT,
+               key_digest: str = "sha1") -> bytes:
+    """Rails' ``KeyGenerator`` key for a named verifier.
+
+    Cached because the gem mints a fresh token on *every* frame, so this would
+    otherwise run PBKDF2 twice per chat message.
+    """
+    return hashlib.pbkdf2_hmac(
+        key_digest, secret_key_base.encode("utf-8"), salt.encode("utf-8"),
+        KEY_ITERATIONS, KEY_LENGTH,
+    )
+
+
+def _signature_ok(encoded: str, signature: str,
+                  secret_key_base: str, salt: str) -> bool:
+    message = encoded.encode("utf-8")
+    matched = False
+    for key_digest in KEY_DIGESTS:
+        key = derive_key(secret_key_base, salt, key_digest)
+        for digest in CANDIDATE_DIGESTS:
+            expected = hmac.new(key, message, digest).hexdigest()
+            # No early return: comparing every candidate keeps the work done
+            # constant whether or not an early one matched.
+            if hmac.compare_digest(expected, signature):
+                matched = True
+    return matched
+
+
+def _unwrap_metadata(payload: Any, purpose: Optional[str]) -> Any:
+    """Strip Rails' ``_rails`` envelope, enforcing expiry and purpose.
+
+    A payload minted with neither expiry nor purpose is stored bare, so an
+    envelope-less payload is legitimate — it simply never expires.
+    """
+    if not isinstance(payload, dict) or "_rails" not in payload:
+        if purpose is not None:
+            raise InvalidRailsToken("token carries no purpose")
+        return payload
+
+    meta = payload["_rails"]
+    if not isinstance(meta, dict):
+        raise InvalidRailsToken("malformed metadata envelope")
+
+    if meta.get("pur") != purpose:
+        raise InvalidRailsToken("purpose mismatch")
+
+    exp = meta.get("exp")
+    if exp is not None:
+        if not isinstance(exp, str):
+            raise InvalidRailsToken("malformed expiry")
+        try:
+            expires_at = datetime.fromisoformat(exp.replace("Z", "+00:00"))
+        except ValueError:
+            raise InvalidRailsToken("unparseable expiry")
+        if expires_at.tzinfo is None:
+            expires_at = expires_at.replace(tzinfo=timezone.utc)
+        if expires_at <= datetime.now(timezone.utc):
+            raise InvalidRailsToken("token expired")
+
+    if "data" in meta:
+        return meta["data"]
+    if "message" in meta:
+        # Pre-7.1 envelope: the real payload is base64 inside the metadata.
+        try:
+            inner = base64.b64decode(meta["message"])
+        except (binascii.Error, ValueError):
+            raise InvalidRailsToken("malformed legacy envelope")
+        return _deserialize(inner)
+    raise InvalidRailsToken("metadata envelope carries no payload")
+
+
+def verify(token: str, secret_key_base: str, *,
+           salt: str = KEY_SALT, purpose: Optional[str] = None) -> Any:
+    """Return the payload a Rails MessageVerifier token carries, or raise.
+
+    Raises :class:`InvalidRailsToken` for anything that does not verify — a bad
+    signature, a foreign key, an expired token, a malformed payload.
+    """
+    if not token or not isinstance(token, str):
+        raise InvalidRailsToken("empty token")
+
+    parts = token.split("--")
+    if len(parts) != 2:
+        raise InvalidRailsToken("token is not <payload>--<signature>")
+    encoded, signature = parts
+    if not encoded or not signature:
+        raise InvalidRailsToken("token is not <payload>--<signature>")
+
+    if not _signature_ok(encoded, signature, secret_key_base, salt):
+        raise InvalidRailsToken("signature mismatch")
+
+    try:
+        blob = base64.b64decode(encoded, validate=True)
+    except (binascii.Error, ValueError):
+        raise InvalidRailsToken("payload is not base64")
+
+    return _unwrap_metadata(_deserialize(blob), purpose)
+
+
+def secret_key_base() -> Optional[str]:
+    """The shared secret, or None if this deployment never supplied one.
+
+    Both containers on a Leo box read the same ``.env``. If it is missing there
+    is no way to tell a real Rails token from a forged one, so callers must
+    treat None as "reject", never as "trust".
+    """
+    value = os.getenv("SECRET_KEY_BASE")
+    return value if value else None

--- a/app/services/sso_origin.py
+++ b/app/services/sso_origin.py
@@ -1,0 +1,172 @@
+"""Which mothership domain a user came from — the SSO return-to-brand contract.
+
+The mothership Rails app answers on more than one domain (``llamapress.ai`` and
+``builtwithleo.com``), but a box only knows the one baked into
+``.leonardo/instance.json`` as ``mothership_url``. So a user who signed in at
+builtwithleo.com and later needs to re-authorize got bounced to llamapress.ai —
+a different domain, therefore a different Rails session, therefore a surprise
+"sign in" wall on a brand they never used.
+
+The fix is a threaded param, not a guess: the mothership appends
+``sso_origin=<its own base URL>`` when it redirects a browser into the box
+(``/auth/consume``, and the legacy ``/login?token=`` magic link). We validate it
+against an allowlist, remember it in a cookie, and build every later
+user-facing mothership link from it. Nothing else about the flow changes —
+server-to-server calls still go to the configured ``mothership_url``, which is
+the credentialed channel.
+
+Guessing was considered and rejected: instance boxes all live on
+``*.llamapress.ai``, so the Host header carries no brand signal, and ``Referer``
+is routinely stripped across a cross-origin redirect.
+
+Open-redirect safety: only an allowlisted host is ever honored. Anything else
+(including a plausible-looking lookalike) falls back to the configured
+mothership URL, so a crafted ``?sso_origin=`` cannot aim the sign-in link at an
+attacker's page.
+"""
+
+import logging
+import os
+from urllib.parse import urlparse
+
+logger = logging.getLogger(__name__)
+
+#: Cookie remembering the brand domain for this browser. Server-read only.
+SSO_ORIGIN_COOKIE = "leo_sso_origin"
+
+#: A year — the origin is a branding preference, not a credential, and it should
+#: outlive the session cookie so a returning user still sees "their" domain.
+SSO_ORIGIN_MAX_AGE = 365 * 24 * 3600
+
+#: Apex domains the mothership answers on. A host matches when it IS one of
+#: these or is a subdomain of one. Extend without a release via the
+#: ``SSO_ORIGIN_HOSTS`` env var (comma-separated apex domains).
+DEFAULT_SSO_ORIGIN_HOSTS = ("llamapress.ai", "builtwithleo.com")
+
+#: How each brand names itself in sign-in copy. Unlisted hosts use the bare host.
+BRAND_DISPLAY_NAMES = {
+    "llamapress.ai": "LlamaPress.ai",
+    "builtwithleo.com": "Leo",
+}
+
+
+def _env_hosts() -> tuple:
+    raw = os.getenv("SSO_ORIGIN_HOSTS", "")
+    return tuple(h.strip().lower() for h in raw.split(",") if h.strip())
+
+
+def _host_of(url: str) -> str:
+    """Lowercased hostname of a URL (or of a bare host string), no port."""
+    if not url:
+        return ""
+    candidate = url if "//" in url else f"//{url}"
+    return (urlparse(candidate).hostname or "").lower()
+
+
+def allowed_hosts(mothership_url: str = "") -> tuple:
+    """Apex domains an ``sso_origin`` may point at.
+
+    The configured ``mothership_url`` is always allowed — a self-hosted or
+    staging mothership is by definition the trusted one for that box.
+    """
+    hosts = list(DEFAULT_SSO_ORIGIN_HOSTS) + list(_env_hosts())
+    configured = _host_of(mothership_url)
+    if configured:
+        hosts.append(configured)
+    return tuple(dict.fromkeys(hosts))
+
+
+def sanitize_sso_origin(value: str, mothership_url: str = "") -> str | None:
+    """Normalize a claimed origin to ``scheme://host``, or None if not allowed.
+
+    Accepts a full URL or a bare host. Path, query and fragment are dropped —
+    we only ever want the base to hang ``/sso/leo/{name}`` off.
+    """
+    if not value or not isinstance(value, str):
+        return None
+    value = value.strip()
+    if not value:
+        return None
+
+    parsed = urlparse(value if "//" in value else f"//{value}")
+    if parsed.scheme and parsed.scheme not in ("http", "https"):
+        return None
+    host = (parsed.hostname or "").lower()
+    if not host:
+        return None
+
+    if not any(host == a or host.endswith(f".{a}") for a in allowed_hosts(mothership_url)):
+        logger.info("Ignoring sso_origin for non-allowlisted host: %s", host)
+        return None
+
+    # Keep an explicit port (dev/staging mothership on :3000); default to https
+    # so a scheme-less or http claim can't downgrade a public brand domain.
+    scheme = parsed.scheme or "https"
+    if scheme == "http" and host not in ("localhost", "127.0.0.1") and not parsed.port:
+        scheme = "https"
+    netloc = f"{host}:{parsed.port}" if parsed.port else host
+    return f"{scheme}://{netloc}"
+
+
+def resolve_sso_origin(request, mothership_url: str = "") -> str | None:
+    """The brand base URL to build user-facing mothership links from.
+
+    Precedence: this request's ``?sso_origin=`` → the remembered cookie → the
+    configured ``mothership_url``. Returns None when nothing is configured
+    (self-hosted box with no mothership — the caller renders no SSO link).
+    """
+    claimed = ""
+    try:
+        claimed = request.query_params.get("sso_origin") or ""
+    except Exception:
+        claimed = ""
+    origin = sanitize_sso_origin(claimed, mothership_url)
+    if origin:
+        return origin
+
+    try:
+        remembered = request.cookies.get(SSO_ORIGIN_COOKIE) or ""
+    except Exception:
+        remembered = ""
+    origin = sanitize_sso_origin(remembered, mothership_url)
+    if origin:
+        return origin
+
+    return (mothership_url or "").rstrip("/") or None
+
+
+def remember_sso_origin(request, response, mothership_url: str = "") -> None:
+    """Persist this request's ``?sso_origin=`` on the response, if it's valid.
+
+    Only ever writes a validated, allowlisted origin — an unknown or malformed
+    claim leaves whatever the browser already had alone.
+    """
+    try:
+        claimed = request.query_params.get("sso_origin") or ""
+    except Exception:
+        return
+    origin = sanitize_sso_origin(claimed, mothership_url)
+    if not origin:
+        return
+    # Imported late: token_service reads env at import time and this module is
+    # pulled in by tests that don't boot the app.
+    from app.services.token_service import SESSION_COOKIE_SECURE
+
+    response.set_cookie(
+        key=SSO_ORIGIN_COOKIE,
+        value=origin,
+        httponly=True,
+        secure=SESSION_COOKIE_SECURE,
+        samesite="lax",
+        path="/",
+        max_age=SSO_ORIGIN_MAX_AGE,
+    )
+
+
+def brand_display_name(origin: str) -> str:
+    """How to name the brand behind ``origin`` in sign-in copy."""
+    host = _host_of(origin)
+    for apex, label in BRAND_DISPLAY_NAMES.items():
+        if host == apex or host.endswith(f".{apex}"):
+            return label
+    return host or "LlamaPress.ai"

--- a/app/services/token_service.py
+++ b/app/services/token_service.py
@@ -9,6 +9,13 @@ from typing import Optional
 import jwt
 
 from app.models import User
+from app.services import rails_message_verifier
+
+# Role a verified Rails-gem caller is authorized as. The gem's token proves the
+# box's own Rails app sent the frame, but a Rails user id maps to no LlamaBot
+# account, so there is no per-user role to look up — the whole surface gets one
+# grant, which an operator can narrow like any other role.
+RAILS_ROLE = "rails"
 
 logger = logging.getLogger(__name__)
 
@@ -185,42 +192,75 @@ def verify_ws_token(token: str) -> Optional[dict]:
 
 
 def is_rails_token(token: str) -> bool:
-    """
-    Check if a token appears to be a Rails MessageVerifier token.
-    Rails tokens are base64-encoded and contain '--' separator.
+    """Does this look like a Rails MessageVerifier token rather than a JWT?
 
-    Args:
-        token: Token string to check
-
-    Returns:
-        True if it looks like a Rails token
+    Purely a router between the two verifiers — it decides nothing about trust.
+    Rails tokens are ``<base64>--<hex signature>``; JWTs are three dot-separated
+    segments. Testing for the JWT shape beats the old ``startswith("eyJ")``
+    check, which misread a *JSON*-serialized Rails token (its base64 also starts
+    ``eyJ``) as a JWT and refused it.
     """
-    # Rails MessageVerifier tokens have format: base64_data--base64_signature
-    return '--' in token and not token.startswith('eyJ')
+    if not token or not isinstance(token, str):
+        return False
+    if "--" not in token:
+        return False
+    return len(token.split(".")) != 3
 
 
 def verify_rails_token(token: str) -> Optional[dict]:
-    """
-    Verify a Rails MessageVerifier token.
+    """Verify a token minted by ``llama_bot_rails`` for the chat WebSocket.
 
-    Since we trust the Rails app as an internal service, we don't cryptographically
-    verify the token. We just check it looks valid and extract minimal info.
+    This used to verify nothing — it returned a ``rails_auth`` payload for any
+    string containing ``--``, on the stated premise that Rails is "a trusted
+    internal service". Nothing established that the caller *was* Rails, so the
+    premise was assumed rather than checked, and ``{"api_token": "x--y"}`` was
+    enough to authenticate from the public internet and skip the agent-mode
+    gate. The signature is now checked against the ``SECRET_KEY_BASE`` both
+    containers share, which is what makes that premise true.
 
-    Args:
-        token: Rails MessageVerifier token string
-
-    Returns:
-        Minimal payload dict if valid-looking, None otherwise
+    Returns the caller's identity, or None if the token does not verify.
     """
     if not is_rails_token(token):
         return None
 
-    # Trust the Rails token - return a minimal payload indicating Rails origin
-    # The actual session/user info is managed by the Rails app
+    secret = rails_message_verifier.secret_key_base()
+    if not secret:
+        # Nothing to check the signature against, so every token is
+        # indistinguishable from a forgery. Refuse rather than trust.
+        logger.error(
+            "Rails token refused: SECRET_KEY_BASE is not set in this container, "
+            "so gem tokens cannot be verified. The Rails-embedded chat needs the "
+            "same SECRET_KEY_BASE as the Rails app."
+        )
+        return None
+
+    try:
+        payload = rails_message_verifier.verify(token, secret)
+    except rails_message_verifier.InvalidRailsToken as e:
+        logger.warning(f"Rails token rejected: {e}")
+        return None
+    except Exception as e:  # a malformed payload must not 500 the socket
+        logger.warning(f"Rails token rejected (malformed): {e}")
+        return None
+
+    if not isinstance(payload, dict):
+        logger.warning("Rails token rejected: payload is not a hash")
+        return None
+
+    rails_user_id = payload.get("user_id")
+
+    # `user_id` is deliberately absent. It names a LlamaBot auth-DB user and is
+    # stamped as the turn owner (request_context.set_current_user_id); a Rails
+    # app's user id is a different namespace and would resolve to the wrong
+    # account. The Rails id travels under its own key.
     return {
-        "sub": "rails_gem",
+        "sub": f"rails_user:{rails_user_id}" if rails_user_id is not None else "rails_gem",
         "type": "rails_auth",
-        "source": "llama_bot_rails"
+        "source": "llama_bot_rails",
+        "rails_user_id": rails_user_id,
+        "session_id": payload.get("session_id"),
+        "role": RAILS_ROLE,
+        "is_admin": False,
     }
 
 

--- a/app/services/user_context.py
+++ b/app/services/user_context.py
@@ -1,0 +1,147 @@
+"""Who a mothership report is about.
+
+Every outbound report (``report_message``, ``report_error``,
+``report_turn_metrics``, ``submit_feedback``, the overlay-ad fetch) used to
+carry ``instance_name`` and nothing else about *who* was at the keyboard. On a
+multi-user box that made the whole telemetry series unattributable: the
+mothership could see that "instance foo sent 400 messages" but not that three
+different people sent them.
+
+This module builds the single wire shape those reports attach, and holds the
+per-turn stamp the reporting paths read when the caller has no ``User`` object
+in hand (the WebSocket turn is the big one — ``report_message`` is fired deep
+inside the request handler, which is constructed before authentication).
+
+**Mapping to a llamapress.ai account happens on the mothership, not here.**
+``llamapress_user_guid`` is minted BY the mothership during unified login and
+stored on the local shadow user (see app/routers/unified_login.py), so the box
+is not translating anything — it is echoing back a foreign key the mothership
+already owns. Legacy username/password users have no guid; they report with
+``llamapress_user_guid: None`` and are only identifiable per-box, which is
+correct: no llamapress.ai account exists to map them to.
+
+``email`` rides along as a human-readable label for triage. It is a *synced
+copy* of the mothership profile, never a join key — matching accounts by email
+is exactly the spoofable path unified_login refuses to take.
+"""
+
+import logging
+from contextvars import ContextVar
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+#: The identity of the turn currently being served, stamped by the WebSocket
+#: handler right after auth and read back by MothershipClient. A ContextVar (not
+#: a global) because several turns run concurrently in one process; contextvars
+#: are per-task and are copied into the ``asyncio.create_task`` fire-and-forget
+#: reports the handler spawns.
+#:
+#: Fails closed, for the same reason app/lib/request_context.py does: unset
+#: means "unknown", never "the only user on this box". Mis-attributed telemetry
+#: is worse than absent telemetry.
+_current: ContextVar[Optional[dict]] = ContextVar("llamabot_report_user", default=None)
+
+
+def describe(user) -> Optional[dict]:
+    """The wire shape for a ``User`` row. Never raises."""
+    if user is None:
+        return None
+    try:
+        return {
+            "id": getattr(user, "id", None),
+            "username": getattr(user, "username", None),
+            "email": getattr(user, "email", None),
+            "llamapress_user_guid": getattr(user, "llamapress_user_guid", None),
+            "role": getattr(user, "role", None),
+            "is_admin": bool(getattr(user, "is_admin", False)),
+        }
+    except Exception as e:  # noqa: BLE001 - telemetry must never break a turn
+        logger.info(f"Could not describe user for reporting: {e}")
+        return None
+
+
+def for_user_id(user_id) -> Optional[dict]:
+    """Look the user up by local id and describe them. Never raises.
+
+    Resolved WITHOUT a FastAPI dependency (and swallowing every failure) on
+    purpose: a DB hiccup must degrade telemetry to "unattributed", not break
+    the WebSocket connection this is called from.
+    """
+    if not isinstance(user_id, int):
+        return None
+    try:
+        from sqlmodel import Session
+
+        from app.db import engine
+        from app.models import User
+
+        if engine is None:
+            return None
+        with Session(engine) as session:
+            return describe(session.get(User, user_id))
+    except Exception as e:  # noqa: BLE001
+        logger.info(f"Could not resolve user {user_id} for reporting: {e}")
+        return None
+
+
+def from_token_payload(payload: Optional[dict]) -> Optional[dict]:
+    """Best-effort identity from a verified WS token, for callers with no DB row.
+
+    Two cases reach this: a browser JWT whose user lookup failed (DB hiccup),
+    and a ``llama_bot_rails`` gem token, which names a RAILS user in a different
+    namespace and has no LlamaBot account behind it at all. Both are worth
+    reporting as partial identities — "the Rails-embedded chat, Rails user 5"
+    beats an unattributed row — but neither carries a guid, so neither maps to a
+    llamapress.ai account.
+    """
+    if not isinstance(payload, dict):
+        return None
+    described = {
+        "id": payload.get("user_id"),
+        "username": payload.get("sub"),
+        "email": None,
+        "llamapress_user_guid": None,
+        "role": payload.get("role"),
+        "is_admin": bool(payload.get("is_admin", False)),
+    }
+    if payload.get("source"):
+        described["source"] = payload["source"]
+    if payload.get("rails_user_id") is not None:
+        described["rails_user_id"] = payload["rails_user_id"]
+    return described
+
+
+def for_request(request) -> Optional[dict]:
+    """Identity behind an HTTP request's session cookie, or None. Never raises."""
+    try:
+        from sqlmodel import Session
+
+        from app.db import engine
+        from app.dependencies import _user_from_session_cookie
+
+        if engine is None:
+            return None
+        with Session(engine) as session:
+            return describe(_user_from_session_cookie(request, session))
+    except Exception as e:  # noqa: BLE001
+        logger.info(f"Could not resolve request user for reporting: {e}")
+        return None
+
+
+def set_current(user_context: Optional[dict]) -> object:
+    """Stamp the identity this turn belongs to. Returns a token for ``reset``."""
+    return _current.set(user_context)
+
+
+def current() -> Optional[dict]:
+    """The identity this turn belongs to, or None if unknown."""
+    return _current.get()
+
+
+def reset(token: object) -> None:
+    """Restore the previous value (best-effort; never raises)."""
+    try:
+        _current.reset(token)  # type: ignore[arg-type]
+    except (ValueError, TypeError):
+        pass

--- a/app/tests/js/batched_questions.test.mjs
+++ b/app/tests/js/batched_questions.test.mjs
@@ -1,0 +1,205 @@
+// Batched ask_user_question: 1-4 questions in one card, answered in one round-trip.
+//
+// The properties worth pinning are the ones the AGENT depends on and that would rot
+// silently: that a batch answer maps each answer back to its question, that a
+// per-question "See visual options" request names WHICH question (otherwise Leo can't
+// tell which one to draw) and says the other answers still stand (otherwise Leo
+// re-asks everything), and that a single question still produces the exact flat
+// format it always did.
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  normalizeQuestions,
+  buildQuestionCardHtml,
+  buildSubmission,
+  isAnswered,
+  uiuxRequestDirective,
+} from '../../frontend/chat/messages/QuestionCard.js';
+
+const blank = () => ({ options: [], text: '', uiux: false, skipped: false });
+
+// Stand-ins for the MessageHandler helpers the builder takes by injection.
+const escapeHtml = (s) => String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+const parseMarkdown = (s) => `<p>${escapeHtml(s)}</p>`;
+
+const render = (questions, extra = {}) => buildQuestionCardHtml({
+  questionId: 'q-1',
+  questions,
+  threadId: 't-1',
+  agentName: 'rails_plan_mode_agent',
+  escapeHtml,
+  parseMarkdown,
+  ...extra,
+});
+
+// ---------------------------------------------------------------- normalize
+
+test('reads the questions batch off the frame', () => {
+  const qs = normalizeQuestions({
+    questions: [
+      { question: 'Which pages?', options: ['All', 'Checkout'] },
+      { question: 'What style?', ui_related: true },
+    ],
+  });
+  assert.equal(qs.length, 2);
+  assert.deepEqual(qs[0].options, ['All', 'Checkout']);
+  assert.equal(qs[0].ui_related, false);
+  assert.equal(qs[1].ui_related, true);
+  assert.deepEqual(qs[1].options, []);
+});
+
+test('falls back to the legacy single-question fields', () => {
+  // An older backend (or a replayed frame) sends no `questions` array at all.
+  const qs = normalizeQuestions({ question: 'Which pages?', options: ['All'], ui_related: true });
+  assert.deepEqual(qs, [{ question: 'Which pages?', options: ['All'], ui_related: true }]);
+});
+
+test('drops blank questions rather than rendering an empty block', () => {
+  assert.equal(normalizeQuestions({ questions: [{ question: 'Real?' }, { question: '  ' }] }).length, 1);
+});
+
+// ---------------------------------------------------------------- markup
+
+test('renders one block per question, numbered, in a batch', () => {
+  const html = render([
+    { question: 'Which pages?', options: ['All'], ui_related: false },
+    { question: 'What style?', options: [], ui_related: true },
+    { question: 'Send email?', options: ['Yes', 'No'], ui_related: false },
+  ]);
+  assert.equal(html.match(/class="plan-question-item"/g).length, 3);
+  assert.match(html, /data-count="3"/);
+  assert.match(html, /class="plan-question-card batched"/);
+  assert.match(html, /0 of 3 answered/);
+});
+
+test('the visual-options chip is per-question, not per-card', () => {
+  const html = render([
+    { question: 'Which pages?', options: ['All'], ui_related: false },
+    { question: 'What style?', options: [], ui_related: true },
+  ]);
+  const chips = html.match(/plan-uiux-request-btn/g) || [];
+  assert.equal(chips.length, 1, 'only the ui_related question gets the chip');
+  // ...and it is wired to question index 1.
+  assert.match(html, /data-qi="1" data-uiux-request="true"/);
+});
+
+test('a single question keeps the send arrow; a batch uses one Continue', () => {
+  assert.match(render([{ question: 'Which pages?', options: [], ui_related: false }]), /plan-send-btn/);
+  const batch = render([
+    { question: 'A?', options: [], ui_related: false },
+    { question: 'B?', options: [], ui_related: false },
+  ]);
+  assert.doesNotMatch(batch, /plan-send-btn/);
+  assert.match(batch, /class="plan-continue-btn" disabled/);
+  assert.match(batch, /plan-skip-all-btn/);
+});
+
+test('quotes in a question or option cannot break out of an attribute', () => {
+  // _escapeHtml (textContent → innerHTML) does not escape quotes, so attribute
+  // values have to be escaped here or a question like this ends the attribute early.
+  const html = render([{ question: 'Use the "big" hero?', options: ['the "wide" one'], ui_related: false }]);
+  assert.match(html, /data-question-text="Use the &quot;big&quot; hero\?"/);
+    assert.match(html, /data-option="the &quot;wide&quot; one"/);
+});
+
+// ---------------------------------------------------------------- submission
+
+test('a single question submits the original flat format', () => {
+  // Unchanged from one-at-a-time, so existing agent behaviour is untouched.
+  const qs = [{ question: 'Which pages?', options: ['All', 'Checkout'], ui_related: false }];
+  const s = { ...blank(), options: ['Checkout'], text: 'and the cart' };
+  assert.deepEqual(buildSubmission(qs, [s]), {
+    answer: 'Checkout, and the cart',
+    display: 'Checkout, and the cart',
+  });
+});
+
+test('a batch pairs every answer with its question', () => {
+  const qs = [
+    { question: 'Which pages?', options: [], ui_related: false },
+    { question: 'Send email?', options: [], ui_related: false },
+  ];
+  const { answer } = buildSubmission(qs, [
+    { ...blank(), options: ['Checkout'] },
+    { ...blank(), options: ['Yes'] },
+  ]);
+  assert.match(answer, /1\. Which pages\?\n→ Checkout/);
+  assert.match(answer, /2\. Send email\?\n→ Yes/);
+});
+
+test('a skipped question says so instead of going out blank', () => {
+  const qs = [
+    { question: 'Which pages?', options: [], ui_related: false },
+    { question: 'Send email?', options: [], ui_related: false },
+  ];
+  const { answer, display } = buildSubmission(qs, [
+    { ...blank(), options: ['Checkout'] },
+    { ...blank(), skipped: true },
+  ]);
+  assert.match(answer, /2\. Send email\?\n→ \(skipped/);
+  assert.match(display, /Send email\? → \(skipped\)/);
+});
+
+test('visual options on one question names it and protects the other answers', () => {
+  const qs = [
+    { question: 'Which pages?', options: [], ui_related: false },
+    { question: 'What should the button look like?', options: [], ui_related: true },
+    { question: 'Send email?', options: [], ui_related: false },
+  ];
+  const { answer, display } = buildSubmission(qs, [
+    { ...blank(), options: ['Checkout'] },
+    { ...blank(), uiux: true },
+    { ...blank(), options: ['Yes'] },
+  ]);
+
+  // Names the question, so Leo knows which one to draw previews for.
+  assert.match(answer, /ask_user_uiux_question/);
+  assert.match(answer, /"What should the button look like\?"/);
+  // Tells Leo the other two answers stand, so it doesn't re-ask the whole batch.
+  assert.match(answer, /do not re-ask those/);
+  // The other answers are still in the payload.
+  assert.match(answer, /→ Checkout/);
+  assert.match(answer, /→ Yes/);
+  // The user just sees the friendly label, not the directive.
+  assert.doesNotMatch(display, /ask_user_uiux_question/);
+  assert.match(display, /See visual options/);
+});
+
+test('text typed alongside a visual request rides along as preview context', () => {
+  const qs = [
+    { question: 'Which style?', options: [], ui_related: true },
+    { question: 'Send email?', options: [], ui_related: false },
+  ];
+  const { answer } = buildSubmission(qs, [
+    { ...blank(), uiux: true, text: 'something minimal' },
+    { ...blank(), options: ['Yes'] },
+  ]);
+  assert.match(answer, /something minimal/);
+});
+
+test('the single-question directive still works and names the question', () => {
+  const qs = [{ question: 'Which style?', options: [], ui_related: true }];
+  const { answer, display } = buildSubmission(qs, [{ ...blank(), uiux: true }]);
+  assert.match(answer, /ask_user_uiux_question/);
+  assert.match(answer, /"Which style\?"/);
+  assert.equal(display, 'See visual options');
+  // No batch-only clause when there are no other answers to protect.
+  assert.doesNotMatch(answer, /do not re-ask those/);
+});
+
+test('uiuxRequestDirective degrades safely with no question text', () => {
+  assert.match(uiuxRequestDirective(''), /for this\./);
+});
+
+// ---------------------------------------------------------------- gating
+
+test('Continue gating counts skips as answered', () => {
+  assert.equal(isAnswered(blank()), false);
+  assert.equal(isAnswered({ ...blank(), skipped: true }), true);
+  assert.equal(isAnswered({ ...blank(), uiux: true }), true);
+  assert.equal(isAnswered({ ...blank(), options: ['A'] }), true);
+  assert.equal(isAnswered({ ...blank(), text: '  ' }), false, 'whitespace is not an answer');
+  assert.equal(isAnswered({ ...blank(), text: 'x' }), true);
+});

--- a/app/tests/js/github_device_autopoll.test.mjs
+++ b/app/tests/js/github_device_autopoll.test.mjs
@@ -1,0 +1,184 @@
+// GitHub device-flow auto-polling (the /gh modal).
+//
+// The whole point of the device flow is that the user should never have to press
+// "check now" — they type the code on github.com and the modal notices. What
+// makes that fail in a real browser is not the happy path, it's:
+//
+//   1. the chat tab is BACKGROUNDED while they authorize on github.com, so
+//      timers are throttled to ~1/min — coming back must re-check immediately,
+//      not sit on a stale timer;
+//   2. the success poll installs the token on the host (docker cp, tens of
+//      seconds) — a second poll firing underneath it would ask GitHub about an
+//      already-redeemed device code and paint an error over the success;
+//   3. one transient 5xx must not end the wait.
+//
+// Drives the real poller against injected timers/fetch, like overlay_ads.
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  DEFAULT_INTERVAL,
+  DeviceAuthPoller,
+  MIN_WATCH_SECONDS,
+  POLL_ENDPOINT,
+} from '../../frontend/chat/checkpoints/GitHubAuthModal.js';
+
+/** Controllable clock + timers: nothing waits on real time. */
+function harness({ replies = [], expiresIn = 900 } = {}) {
+  const state = {
+    clock: 0,
+    pending: null,          // the one scheduled poll
+    calls: [],              // fetch bodies
+    results: [],            // [status, data]
+    listeners: {},
+  };
+
+  const timers = {
+    setTimeout(fn, ms) { state.pending = { fn, at: state.clock + ms }; return 1; },
+    clearTimeout() { state.pending = null; },
+  };
+
+  const poller = new DeviceAuthPoller({
+    deviceCode: 'DEV-CODE',
+    interval: DEFAULT_INTERVAL,
+    expiresIn,
+    now: () => state.clock,
+    timers,
+    fetchFn: async (url, opts) => {
+      state.calls.push({ url, body: JSON.parse(opts.body) });
+      const next = replies.shift() ?? { status: 'pending' };
+      if (typeof next === 'function') return next();
+      if (next.httpError) return { ok: false, status: 500 };
+      return { ok: true, json: async () => next };
+    },
+    doc: { addEventListener: (n, fn) => { state.listeners[n] = fn; }, removeEventListener: (n) => { delete state.listeners[n]; }, visibilityState: 'visible' },
+    win: { addEventListener: (n, fn) => { state.listeners[n] = fn; }, removeEventListener: (n) => { delete state.listeners[n]; } },
+    onResult: (status, data) => state.results.push([status, data]),
+  });
+
+  /** Advance the clock and run the scheduled poll if it came due. */
+  state.advance = async (seconds) => {
+    state.clock += seconds * 1000;
+    const due = state.pending;
+    if (due && due.at <= state.clock) { state.pending = null; await due.fn(); }
+  };
+  state.wake = async (name = 'visibilitychange') => { await state.listeners[name]?.(); };
+
+  return { poller, state };
+}
+
+test('polls on its own — no user click needed', async () => {
+  const { poller, state } = harness();
+  poller.start();
+  assert.equal(state.calls.length, 0, 'no poll before the first interval');
+
+  await state.advance(DEFAULT_INTERVAL);
+  assert.equal(state.calls.length, 1);
+  assert.equal(state.calls[0].url, POLL_ENDPOINT);
+  assert.equal(state.calls[0].body.device_code, 'DEV-CODE');
+
+  await state.advance(DEFAULT_INTERVAL);
+  assert.equal(state.calls.length, 2, 'pending keeps the loop going');
+});
+
+test('keeps checking for at least two minutes of pending replies', async () => {
+  const { poller, state } = harness();
+  poller.start();
+  const ticks = MIN_WATCH_SECONDS / DEFAULT_INTERVAL;
+  for (let i = 0; i < ticks; i++) await state.advance(DEFAULT_INTERVAL);
+  assert.equal(state.calls.length, ticks);
+  assert.equal(state.results.filter(([s]) => s !== 'pending').length, 0, 'still waiting, not errored out');
+});
+
+test('returning to the tab re-checks immediately instead of waiting out a throttled timer', async () => {
+  const { poller, state } = harness();
+  poller.start();
+  await state.advance(DEFAULT_INTERVAL);          // one poll, then backgrounded
+  assert.equal(state.calls.length, 1);
+
+  state.clock += 60 * 1000;                        // browser throttled us for a minute
+  await state.wake('visibilitychange');            // user comes back from github.com
+  assert.equal(state.calls.length, 2, 'checked on wake');
+});
+
+test('a wake inside GitHub rate-limit window does not fire an extra poll', async () => {
+  const { poller, state } = harness();
+  poller.start();
+  await state.advance(DEFAULT_INTERVAL);
+  state.clock += 1000;                             // only 1s since the last poll
+  await state.wake('focus');
+  assert.equal(state.calls.length, 1, 'respected the interval floor');
+});
+
+test('no second poll while the success install is still running', async () => {
+  let release;
+  const slowSuccess = () => new Promise((res) => { release = () => res({ ok: true, json: async () => ({ status: 'success', message: 'ok' }) }); });
+  const { poller, state } = harness({ replies: [slowSuccess] });
+  poller.start();
+
+  const inFlight = state.advance(DEFAULT_INTERVAL);
+  state.clock += 30 * 1000;                        // token install drags on
+  await state.wake('visibilitychange');
+  await state.advance(DEFAULT_INTERVAL);
+  assert.equal(state.calls.length, 1, 'nothing polled underneath the in-flight check');
+
+  release();
+  await inFlight;
+  assert.deepEqual(state.results.map(([s]) => s), ['success']);
+  assert.equal(state.pending, null, 'stopped after success');
+});
+
+test('a transient server error keeps the wait alive', async () => {
+  const { poller, state } = harness({ replies: [{ httpError: true }, { status: 'pending' }, { status: 'success' }] });
+  poller.start();
+  await state.advance(DEFAULT_INTERVAL);
+  assert.equal(state.results.filter(([s]) => s === 'error').length, 0, 'one 5xx is not fatal');
+  await state.advance(DEFAULT_INTERVAL);
+  await state.advance(DEFAULT_INTERVAL);
+  assert.deepEqual(state.results.at(-1)[0], 'success');
+});
+
+test('repeated failures surface an error instead of spinning forever', async () => {
+  const { poller, state } = harness({ replies: Array.from({ length: 6 }, () => ({ httpError: true })) });
+  poller.start();
+  for (let i = 0; i < 6; i++) await state.advance(DEFAULT_INTERVAL);
+  assert.equal(state.results.at(-1)[0], 'error');
+  assert.equal(state.pending, null);
+});
+
+test('slow_down backs the interval off and keeps polling', async () => {
+  const { poller, state } = harness({ replies: [{ status: 'slow_down', interval: 10 }] });
+  poller.start();
+  await state.advance(DEFAULT_INTERVAL);
+  await state.advance(DEFAULT_INTERVAL);
+  assert.equal(state.calls.length, 1, 'waited the longer interval');
+  await state.advance(DEFAULT_INTERVAL);
+  assert.equal(state.calls.length, 2);
+});
+
+test('expired and denied stop the loop', async () => {
+  for (const status of ['expired', 'denied']) {
+    const { poller, state } = harness({ replies: [{ status }] });
+    poller.start();
+    await state.advance(DEFAULT_INTERVAL);
+    assert.equal(state.results.at(-1)[0], status);
+    assert.equal(state.pending, null, `${status} stops polling`);
+  }
+});
+
+test('gives up once the device code lifetime is over', async () => {
+  const { poller, state } = harness({ expiresIn: 30 });
+  poller.start();
+  for (let i = 0; i < 30; i++) await state.advance(DEFAULT_INTERVAL);
+  assert.equal(state.results.at(-1)[0], 'expired');
+  assert.equal(state.pending, null);
+});
+
+test('close() stops everything and unhooks the wake listeners', async () => {
+  const { poller, state } = harness();
+  poller.start();
+  poller.stop();
+  assert.equal(state.pending, null);
+  assert.deepEqual(Object.keys(state.listeners), []);
+});

--- a/app/tests/js/inactivity_banner_disabled.test.mjs
+++ b/app/tests/js/inactivity_banner_disabled.test.mjs
@@ -1,0 +1,59 @@
+// 0.7.4: the yellow "Session expiring soon due to inactivity." banner is turned
+// OFF, not deleted. The lease machinery behind it (activity sync to the backend,
+// /api/lease-status, the banner markup and its "Continue Working" button) all
+// stays in place — only the UI that pops the banner is suppressed, behind a
+// single flag that flips back to true when we want it again.
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { readFileSync } from 'node:fs';
+
+const APP_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const INDEX_JS = readFileSync(resolve(APP_ROOT, 'frontend', 'chat', 'index.js'), 'utf8');
+const CHAT_HTML = readFileSync(resolve(APP_ROOT, 'frontend', 'chat.html'), 'utf8');
+
+const { INACTIVITY_WARNING_BANNER_ENABLED } = await import(
+  resolve(APP_ROOT, 'frontend', 'chat', 'config.js')
+);
+
+/** Grab a method body out of index.js by name, up to the closing brace column. */
+function methodBody(name) {
+  const start = INDEX_JS.indexOf(`\n  ${name}(`);
+  assert.notEqual(start, -1, `${name}() is missing from index.js`);
+  const end = INDEX_JS.indexOf('\n  }', start);
+  assert.notEqual(end, -1, `could not find the end of ${name}()`);
+  return INDEX_JS.slice(start, end);
+}
+
+test('the banner is disabled by a single flag', () => {
+  assert.equal(INACTIVITY_WARNING_BANNER_ENABLED, false);
+});
+
+test('index.js reads the flag instead of hardcoding the behaviour', () => {
+  assert.match(INDEX_JS, /INACTIVITY_WARNING_BANNER_ENABLED/);
+  assert.match(
+    INDEX_JS,
+    /import\s*\{[^}]*INACTIVITY_WARNING_BANNER_ENABLED[^}]*\}\s*from\s*'\.\/config\.js'/,
+  );
+});
+
+test('nothing shows the banner while the flag is off', () => {
+  assert.match(methodBody('showTimeoutWarning'), /if\s*\(\s*!INACTIVITY_WARNING_BANNER_ENABLED\s*\)\s*return/);
+});
+
+test('the inactivity poll does not run while the flag is off', () => {
+  assert.match(methodBody('startInactivityCheck'), /if\s*\(\s*!INACTIVITY_WARNING_BANNER_ENABLED\s*\)\s*return/);
+});
+
+test('the functionality is kept, not deleted', () => {
+  // Banner markup + its continue button survive in the page.
+  assert.match(CHAT_HTML, /data-llamabot="timeout-warning"/);
+  assert.match(CHAT_HTML, /data-llamabot="continue-session"/);
+  // The lease/activity plumbing is untouched.
+  assert.match(INDEX_JS, /\/api\/lease-status/);
+  assert.match(INDEX_JS, /\/api\/update-activity/);
+  assert.match(INDEX_JS, /checkInactivityWarning\s*\(\)\s*\{/);
+  assert.match(INDEX_JS, /hideTimeoutWarning\s*\(\)\s*\{/);
+});

--- a/app/tests/js/my_uploads_opens_modal.test.mjs
+++ b/app/tests/js/my_uploads_opens_modal.test.mjs
@@ -1,0 +1,156 @@
+// "My Uploads" must open the full Asset Library modal directly.
+//
+// It used to open a small intermediate panel — the same list of filenames with
+// no previews — from which you clicked an expand button to reach the real
+// library. Two clicks to get anywhere useful; the panel is skipped now.
+//
+// Also guards the spreadsheet preview: it must render a cell grid from the
+// server parse, never hand the file to Microsoft's Office Online viewer.
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const APP_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const { FileAttachmentManager } = await import(
+  resolve(APP_ROOT, 'frontend', 'chat', 'ui', 'FileAttachmentManager.js')
+);
+
+/** Minimal element stand-in: records listeners and classList state. */
+function fakeEl(initialClasses = ['hidden']) {
+  const classes = new Set(initialClasses);
+  return {
+    handlers: {},
+    attrs: {},
+    innerHTML: '',
+    addEventListener(evt, fn) { this.handlers[evt] = fn; },
+    setAttribute(k, v) { this.attrs[k] = v; },
+    getAttribute(k) { return this.attrs[k]; },
+    classList: {
+      add: (c) => classes.add(c),
+      remove: (c) => classes.delete(c),
+      contains: (c) => classes.has(c),
+      toggle: (c, on) => { on ? classes.add(c) : classes.delete(c); },
+    },
+    contains: () => false,
+    querySelectorAll: () => [],
+    querySelector: () => null,
+  };
+}
+
+/** initFileBrowser registers a document-level outside-click listener. */
+function withFakeDocument(run) {
+  const prev = globalThis.document;
+  globalThis.document = { addEventListener() {} };
+  try { return run(); } finally { globalThis.document = prev; }
+}
+
+test('clicking My Uploads opens the asset modal, not the small panel', () => {
+  const manager = new FileAttachmentManager();
+  const browseBtn = fakeEl();
+  const panel = fakeEl();
+  const list = fakeEl();
+
+  let opened = 0;
+  let toggledPanel = 0;
+  manager.openAssetModal = () => { opened += 1; };
+  manager.toggleFileBrowser = () => { toggledPanel += 1; };
+
+  withFakeDocument(() => manager.initFileBrowser(browseBtn, panel, list, null));
+  browseBtn.handlers.click({ stopPropagation() {} });
+
+  assert.equal(opened, 1, 'the asset library modal must open');
+  assert.equal(toggledPanel, 0, 'the intermediate file-browser panel must be skipped');
+});
+
+test('the attach menu closes when My Uploads opens the modal', () => {
+  const manager = new FileAttachmentManager();
+  const browseBtn = fakeEl();
+  const menu = fakeEl();
+  manager.attachMenu = menu;
+  manager.openAssetModal = () => {};
+
+  withFakeDocument(() => manager.initFileBrowser(browseBtn, fakeEl(), fakeEl(), null));
+  browseBtn.handlers.click({ stopPropagation() {} });
+
+  assert.ok(menu.classList.contains('hidden'), 'the file-attach menu must close');
+});
+
+test('spreadsheets render from the server parse endpoint', async () => {
+  const manager = new FileAttachmentManager();
+  const stage = fakeEl();
+  const requested = [];
+  globalThis.fetch = async (url) => {
+    requested.push(url);
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ sheets: ['Data'], active: 0, rows: [['a', '1']], total_rows: 1, truncated: false }),
+    };
+  };
+
+  let gridRows = null;
+  manager.renderSheetGrid = (rows) => { gridRows = rows; };
+  stage.querySelector = () => fakeEl();
+
+  await manager.renderSpreadsheetPreview('app/imports/book.xlsx', '/api/uploaded-files/preview?path=x', stage);
+
+  assert.equal(requested.length, 1);
+  assert.ok(requested[0].startsWith('/api/uploaded-files/sheet?path='), `unexpected URL: ${requested[0]}`);
+  assert.deepEqual(gridRows, [['a', '1']]);
+});
+
+test('a 415 from the server falls back to the client-side reader', async () => {
+  const manager = new FileAttachmentManager();
+  const stage = fakeEl();
+  globalThis.fetch = async () => ({ ok: false, status: 415 });
+
+  let fellBack = 0;
+  manager.renderSpreadsheetPreviewClientSide = async () => { fellBack += 1; };
+
+  await manager.renderSpreadsheetPreview('app/imports/old.xls', '/api/uploaded-files/preview?path=x', stage);
+
+  assert.equal(fellBack, 1, 'legacy .xls must still render via SheetJS');
+});
+
+
+/** An asset modal wired up with just the pieces initAssetModal touches. */
+function makeAssetModal() {
+  const manager = new FileAttachmentManager();
+  const expandBtn = fakeEl([]);
+  const modal = fakeEl([]);
+  const parts = {
+    '[data-llamabot="asset-modal-expand"]': expandBtn,
+    '[data-llamabot="asset-modal-list"]': fakeEl([]),
+    '[data-llamabot="asset-modal-preview"]': fakeEl([]),
+    '[data-llamabot="asset-modal-count"]': fakeEl([]),
+  };
+  modal.querySelector = (sel) => parts[sel] || null;
+
+  withFakeDocument(() => manager.initAssetModal(modal, null));
+  return { manager, modal, expandBtn };
+}
+
+test('the expand button full-screens the asset library and back', () => {
+  const { manager, modal, expandBtn } = makeAssetModal();
+
+  expandBtn.handlers.click();
+  assert.ok(modal.classList.contains('asset-modal--expanded'), 'must go full screen');
+  assert.equal(expandBtn.getAttribute('aria-pressed'), 'true');
+
+  expandBtn.handlers.click();
+  assert.ok(!modal.classList.contains('asset-modal--expanded'), 'must collapse again');
+  assert.equal(expandBtn.getAttribute('aria-pressed'), 'false');
+  assert.ok(manager.assetModalExpandBtn, 'the button stays wired');
+});
+
+test('closing the modal drops full screen so the file list is back next time', () => {
+  const { manager, modal, expandBtn } = makeAssetModal();
+
+  expandBtn.handlers.click();
+  manager.hideAssetModal();
+
+  assert.ok(modal.classList.contains('hidden'));
+  assert.ok(!modal.classList.contains('asset-modal--expanded'));
+});

--- a/app/tests/js/overlay_ads.test.mjs
+++ b/app/tests/js/overlay_ads.test.mjs
@@ -1,0 +1,307 @@
+// Building-overlay promo slot ("jumbotron").
+//
+// The snippets are remote HTML rendered inside the signed-in chat page, so the
+// property that actually matters is the sandbox: `allow-scripts` WITHOUT
+// `allow-same-origin`, which keeps a promo in an opaque origin where it can
+// animate itself but can't touch the session. The rest is rotation mechanics and
+// the fail-open contract (any fetch trouble → no slot at all).
+//
+// Drives the real module against a stub DOM, like building_overlay_escape.
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  AD_SANDBOX,
+  DEFAULT_ROTATE_SECONDS,
+  OverlayAdRotator,
+  adDocument,
+  loadOverlayAds,
+} from '../../frontend/chat/ui/OverlayAds.js';
+
+class FakeElement {
+  constructor(tag) {
+    this.tagName = tag;
+    this.attrs = {};
+    this.style = {};
+    this.children = [];
+    this._html = '';
+  }
+  setAttribute(k, v) { this.attrs[k] = v; }
+  getAttribute(k) { return this.attrs[k]; }
+  appendChild(c) { this.children.push(c); return c; }
+  set innerHTML(v) { this._html = v; if (v === '') this.children = []; }
+  get innerHTML() { return this._html; }
+}
+
+const fakeDoc = { createElement: (tag) => new FakeElement(tag) };
+
+/** setInterval/setTimeout capture, so rotation is testable without waiting. */
+function fakeTimers() {
+  const t = {
+    intervals: [],
+    timeouts: [],
+    setInterval(fn, ms) { t.intervals.push({ fn, ms }); return t.intervals.length; },
+    clearInterval(id) { t.intervals[id - 1] = null; },
+    setTimeout(fn, ms) { t.timeouts.push({ fn, ms }); return t.timeouts.length; },
+    clearTimeout(id) { t.timeouts[id - 1] = null; },
+    // Fire the rotation tick and then its cross-fade callback.
+    tick() {
+      t.intervals.filter(Boolean).forEach((i) => i.fn());
+      const pending = t.timeouts.filter(Boolean);
+      t.timeouts = [];
+      pending.forEach((x) => x.fn());
+    },
+  };
+  return t;
+}
+
+const ADS = [
+  { id: 'one', html: '<b>One</b>', height: 140 },
+  { id: 'two', html: '<b>Two</b>', height: 200 },
+  { id: 'three', html: '<b>Three</b>', height: 140 },
+];
+
+function mount(ads, rotateSeconds = 180) {
+  const timers = fakeTimers();
+  const slot = new FakeElement('div');
+  const seen = [];
+  const rotator = new OverlayAdRotator({
+    ads, rotateSeconds, doc: fakeDoc, timers, onAdChange: (ad) => seen.push(ad.id),
+  });
+  const mounted = rotator.mount(slot);
+  return { rotator, slot, timers, mounted, seen, frame: rotator.frame };
+}
+
+// -- the sandbox ------------------------------------------------------------
+
+test('ad frame is sandboxed with scripts but NOT same-origin', () => {
+  const { frame } = mount(ADS);
+  const flags = frame.getAttribute('sandbox').split(/\s+/);
+
+  assert.ok(flags.includes('allow-scripts'), 'promos may animate themselves');
+  assert.ok(
+    !flags.includes('allow-same-origin'),
+    'allow-same-origin + allow-scripts cancels the sandbox and hands the promo the session',
+  );
+  assert.ok(flags.includes('allow-popups'), 'a promo link must be able to open a tab');
+  assert.equal(AD_SANDBOX, frame.getAttribute('sandbox'));
+});
+
+test('ad frame does not leak the instance URL as a referrer', () => {
+  const { frame } = mount(ADS);
+  assert.equal(frame.getAttribute('referrerpolicy'), 'no-referrer');
+});
+
+test('snippet is wrapped so links open in a new tab', () => {
+  const doc = adDocument('<a href="https://llamapress.ai">Go</a>');
+  assert.match(doc, /<base target="_blank"/);
+  assert.match(doc, /<a href="https:\/\/llamapress\.ai">Go<\/a>/);
+});
+
+// -- rotation ---------------------------------------------------------------
+
+test('first ad renders immediately', () => {
+  const { frame, seen } = mount(ADS);
+  assert.match(frame.srcdoc, /<b>One<\/b>/);
+  assert.deepEqual(seen, ['one'], 'the overlay is told which promo is up');
+});
+
+test('the rotator does NOT size its own slot', () => {
+  // How much room a promo gets is the overlay's call — it fills the pane while
+  // Leo starts up, but yields to the todo list once there's a plan. A rotator
+  // that wrote slot.style.height would fight that on every rotation.
+  const { slot } = mount(ADS);
+  assert.equal(slot.style.height, undefined);
+});
+
+test('rotation advances on the mothership cadence and wraps around', () => {
+  const { frame, timers, rotator, seen } = mount(ADS, 180);
+
+  assert.equal(timers.intervals[0].ms, 180 * 1000);
+
+  timers.tick();
+  assert.match(frame.srcdoc, /<b>Two<\/b>/);
+  assert.equal(rotator.currentAd.height, 200, 'the promo carries its own height hint');
+
+  timers.tick();
+  assert.match(frame.srcdoc, /<b>Three<\/b>/);
+
+  timers.tick();
+  assert.match(frame.srcdoc, /<b>One<\/b>/, 'wraps back to the first promo');
+  assert.equal(rotator.index, 0);
+  assert.deepEqual(seen, ['one', 'two', 'three', 'one']);
+});
+
+test('a single ad is a static banner — no rotation timer', () => {
+  const { timers, mounted } = mount([ADS[0]]);
+  assert.equal(mounted, true);
+  assert.equal(timers.intervals.length, 0);
+});
+
+test('no ads means no slot at all', () => {
+  const { mounted, slot } = mount([]);
+  assert.equal(mounted, false);
+  assert.equal(slot.children.length, 0);
+});
+
+test('stop() kills the rotation timer and empties the slot', () => {
+  const { rotator, timers, slot } = mount(ADS);
+  rotator.stop();
+
+  assert.equal(timers.intervals.filter(Boolean).length, 0);
+  assert.equal(slot.children.length, 0);
+  assert.equal(rotator.frame, null);
+
+  rotator.stop(); // idempotent — removeStreamingOverlay can run twice
+});
+
+// -- fail-open fetch --------------------------------------------------------
+
+test('loadOverlayAds returns the payload on success', async () => {
+  const out = await loadOverlayAds(async () => ({
+    ok: true,
+    json: async () => ({ ads: ADS, rotate_seconds: 90 }),
+  }));
+
+  assert.equal(out.ads.length, 3);
+  assert.equal(out.rotateSeconds, 90);
+});
+
+test('loadOverlayAds drops entries with no html', async () => {
+  const out = await loadOverlayAds(async () => ({
+    ok: true,
+    json: async () => ({ ads: [{ id: 'blank', html: '  ' }, { id: 'ok', html: '<b>x</b>' }] }),
+  }));
+
+  assert.deepEqual(out.ads.map((a) => a.id), ['ok']);
+  assert.equal(out.rotateSeconds, DEFAULT_ROTATE_SECONDS);
+});
+
+for (const [name, fetchImpl] of [
+  ['a network error', async () => { throw new Error('offline'); }],
+  ['a non-200', async () => ({ ok: false, json: async () => ({}) })],
+  ['unparseable JSON', async () => ({ ok: true, json: async () => { throw new Error('bad'); } })],
+  ['a payload with no ads key', async () => ({ ok: true, json: async () => ({}) })],
+]) {
+  test(`loadOverlayAds fails open on ${name}`, async () => {
+    const out = await loadOverlayAds(fetchImpl);
+    assert.deepEqual(out.ads, []);
+    assert.equal(out.rotateSeconds, DEFAULT_ROTATE_SECONDS);
+    assert.equal(out.variant, null);
+    assert.equal(out.policy.enabled, true, 'a dead endpoint still yields a usable policy');
+  });
+}
+
+// -- display policy: WHEN the jumbotron shows ------------------------------
+//
+// The product judgement is the mothership's; these pin that the client applies
+// its verdict faithfully and fails open when the browser won't cooperate.
+
+import { DEFAULT_POLICY, LAST_SHOWN_KEY, evaluatePolicy, policyAllowsMode, recordShown }
+  from '../../frontend/chat/ui/OverlayAds.js';
+
+function fakeStorage(initial = {}) {
+  const map = { ...initial };
+  return {
+    map,
+    getItem: (k) => (k in map ? map[k] : null),
+    setItem: (k, v) => { map[k] = v; },
+    removeItem: (k) => { delete map[k]; },
+  };
+}
+
+const NOW = 1_700_000_000_000;
+
+test('policy defaults hold back the promo for the first few seconds', () => {
+  // A short build that flashes an ad and yanks it away reads as a bug.
+  const v = evaluatePolicy({ ads: ADS, policy: DEFAULT_POLICY, now: NOW, storage: fakeStorage() });
+  assert.equal(v.show, true);
+  assert.equal(v.delayMs, DEFAULT_POLICY.show_after_seconds * 1000);
+});
+
+test('show_after_seconds: 0 shows immediately', () => {
+  const v = evaluatePolicy({
+    ads: ADS, policy: { ...DEFAULT_POLICY, show_after_seconds: 0 }, now: NOW, storage: fakeStorage(),
+  });
+  assert.equal(v.delayMs, 0);
+  assert.equal(v.reason, 'ok');
+});
+
+test('enabled: false is a kill switch', () => {
+  const v = evaluatePolicy({
+    ads: ADS, policy: { ...DEFAULT_POLICY, enabled: false }, now: NOW, storage: fakeStorage(),
+  });
+  assert.equal(v.show, false);
+  assert.equal(v.reason, 'disabled-by-policy');
+});
+
+test('no ads means no promo, whatever the policy says', () => {
+  const v = evaluatePolicy({ ads: [], policy: DEFAULT_POLICY, now: NOW, storage: fakeStorage() });
+  assert.equal(v.show, false);
+  assert.equal(v.reason, 'no-ads');
+});
+
+test('cooldown suppresses a promo seen too recently, and reports how long is left', () => {
+  const storage = fakeStorage({ [LAST_SHOWN_KEY]: String(NOW - 60_000) }); // 60s ago
+  const v = evaluatePolicy({
+    ads: ADS, policy: { ...DEFAULT_POLICY, min_interval_seconds: 1800 }, now: NOW, storage,
+  });
+
+  assert.equal(v.show, false);
+  assert.match(v.reason, /^cooldown:\d+s-left$/);
+});
+
+test('cooldown lets the promo through once it has elapsed', () => {
+  const storage = fakeStorage({ [LAST_SHOWN_KEY]: String(NOW - 3600_000) }); // an hour ago
+  const v = evaluatePolicy({
+    ads: ADS, policy: { ...DEFAULT_POLICY, min_interval_seconds: 1800 }, now: NOW, storage,
+  });
+  assert.equal(v.show, true);
+});
+
+test('a cooldown we cannot read fails OPEN', () => {
+  // Private mode / embedded contexts throw on localStorage. Not being able to
+  // read the clock is not a reason to suppress the promo.
+  const hostile = { getItem() { throw new Error('denied'); }, setItem() { throw new Error('denied'); } };
+  const v = evaluatePolicy({
+    ads: ADS, policy: { ...DEFAULT_POLICY, min_interval_seconds: 1800 }, now: NOW, storage: hostile,
+  });
+
+  assert.equal(v.show, true);
+  assert.doesNotThrow(() => recordShown(NOW, hostile));
+});
+
+test('recordShown stamps the cooldown clock', () => {
+  const storage = fakeStorage();
+  recordShown(NOW, storage);
+  assert.equal(storage.map[LAST_SHOWN_KEY], String(NOW));
+});
+
+test('policyAllowsMode honours a narrowed mode list', () => {
+  assert.equal(policyAllowsMode({ modes: ['building'] }, 'building'), true);
+  assert.equal(policyAllowsMode({ modes: ['building'] }, 'plan'), false);
+  assert.equal(policyAllowsMode({ modes: [] }, 'building'), false, 'empty list = never show');
+});
+
+test('policyAllowsMode falls back to defaults when the policy is malformed', () => {
+  assert.equal(policyAllowsMode(null, 'building'), true);
+  assert.equal(policyAllowsMode({ modes: 'building' }, 'building'), true);
+});
+
+test('loadOverlayAds carries policy and variant through', async () => {
+  const out = await loadOverlayAds(async () => ({
+    ok: true,
+    json: async () => ({ ads: ADS, policy: { show_after_seconds: 12 }, variant: 'arm-b' }),
+  }));
+
+  assert.equal(out.policy.show_after_seconds, 12);
+  assert.equal(out.policy.enabled, true, 'unspecified fields keep their default');
+  assert.equal(out.variant, 'arm-b');
+});
+
+test('loadOverlayAds falls back to the default policy when the endpoint dies', async () => {
+  const out = await loadOverlayAds(async () => { throw new Error('offline'); });
+  assert.deepEqual(out.policy, { ...DEFAULT_POLICY });
+  assert.equal(out.variant, null);
+});

--- a/app/tests/js/overlay_chrome_without_ads.test.mjs
+++ b/app/tests/js/overlay_chrome_without_ads.test.mjs
@@ -1,0 +1,201 @@
+// The building overlay must be UNCHANGED when there is no promo to show.
+//
+// The jumbotron shrinks the status block into a compact top-left pill so the
+// promo owns the pane. That trade only makes sense when a promo is actually on
+// screen: if the mothership is down, unconfigured, or the policy suppresses the
+// slot, the user should see the pre-jumbotron overlay exactly as it was — big
+// centered animation under a big title.
+//
+// So the property under test is "chrome follows the promo, not the feature":
+// no promo → classic proportions; promo mounted → compact ones.
+//
+// Drives the real IframeManager against a stub DOM, like iframe_session_restore.
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+class FakeClassList {
+  constructor(initial = []) { this._set = new Set(initial); }
+  add(...n) { n.forEach((x) => this._set.add(x)); }
+  remove(...n) { n.forEach((x) => this._set.delete(x)); }
+  contains(n) { return this._set.has(n); }
+}
+
+/** Enough of a DOM node for the overlay: styles, children, and re-parenting. */
+class FakeElement {
+  constructor(tag = 'div', { classes = [], dataset = {} } = {}) {
+    this.tagName = tag;
+    this.classList = new FakeClassList(classes);
+    this.dataset = dataset;
+    this.style = {};
+    this.attrs = {};
+    this.children = [];
+    this.parentNode = null;
+    this.src = '';
+    this.value = '';
+    this.clientWidth = 1200;
+    this._html = '';
+  }
+  get firstChild() { return this.children[0] || null; }
+  _detach(c) {
+    if (c.parentNode) {
+      const i = c.parentNode.children.indexOf(c);
+      if (i >= 0) c.parentNode.children.splice(i, 1);
+    }
+  }
+  appendChild(c) { this._detach(c); this.children.push(c); c.parentNode = this; return c; }
+  insertBefore(c, ref) {
+    this._detach(c);
+    const i = ref ? this.children.indexOf(ref) : -1;
+    if (i >= 0) this.children.splice(i, 0, c); else this.children.push(c);
+    c.parentNode = this;
+    return c;
+  }
+  setAttribute(k, v) { this.attrs[k] = v; }
+  getAttribute(k) { return this.attrs[k]; }
+  addEventListener() {}
+  querySelector() { return null; }
+  querySelectorAll() { return []; }
+  set innerHTML(v) { this._html = v; if (v === '') this.children = []; }
+  get innerHTML() { return this._html; }
+}
+
+/** The chat.html container + globals IframeManager and the overlay read. */
+function makeEnv({ payload = null, ok = true } = {}) {
+  const els = {
+    'live-site-frame': new FakeElement('iframe', { classes: ['content-iframe', 'active'] }),
+    'url-input': new FakeElement('input'),
+    'url-dropdown': new FakeElement(),
+  };
+  const container = {
+    querySelector(sel) {
+      const m = /\[data-llamabot="([^"]+)"\]/.exec(sel);
+      return (m && els[m[1]]) || null;
+    },
+    querySelectorAll(sel) {
+      if (sel === '.content-iframe') return [els['live-site-frame']];
+      return [];
+    },
+  };
+
+  const browserContent = new FakeElement('div', { classes: ['browser-content'] });
+
+  globalThis.window = {
+    location: { protocol: 'https:', host: 'box.llamapress.ai', pathname: '/chat', search: '', hash: '' },
+    history: { replaceState() {} },
+    localStorage: { getItem: () => null, setItem: () => {} },
+    LLAMABOT_USER_ROLE: 'engineer',
+    addEventListener() {},
+  };
+  globalThis.localStorage = window.localStorage;
+  globalThis.document = {
+    addEventListener() {},
+    createElement: (tag) => new FakeElement(tag),
+    createTextNode: (text) => ({ nodeType: 3, textContent: text, children: [] }),
+    getElementById: () => null,
+    querySelector(sel) {
+      if (sel === '.browser-content') return browserContent;
+      // Pretend the lottie player script is already on the page.
+      if (sel.includes('lottie-player')) return new FakeElement('script');
+      return null; // no message history → the plan mirror stays out of the way
+    },
+    head: new FakeElement('head'),
+  };
+  // Real timers would keep the test process alive on the 20s tip rotation.
+  globalThis.setInterval = () => 1;
+  globalThis.clearInterval = () => {};
+  globalThis.requestAnimationFrame = () => 1;
+  globalThis.ResizeObserver = class { observe() {} disconnect() {} };
+  globalThis.MutationObserver = class { observe() {} disconnect() {} };
+  globalThis.fetch = async () => ({
+    ok,
+    json: async () => payload,
+  });
+
+  return { container, browserContent };
+}
+
+const { IframeManager } = await import('../../frontend/chat/ui/IframeManager.js');
+
+/** Named handles on the overlay's children, in DOM order. */
+function overlayParts(browserContent) {
+  const overlay = browserContent.children.find((c) => c.attrs?.id === undefined && c.style.zIndex === '10')
+    || browserContent.children[browserContent.children.length - 1];
+  const findById = (id) => {
+    const walk = (node) => {
+      for (const c of node.children) {
+        if (c.id === id) return c;
+        const hit = walk(c);
+        if (hit) return hit;
+      }
+      return null;
+    };
+    return walk(overlay);
+  };
+  const adSlot = findById('overlayAdSlot');
+  const lottie = findById('lottieAnimation');
+  return { overlay, adSlot, lottie, title: lottie.parentNode };
+}
+
+/** Build the overlay and let the (already-resolved) ad fetch settle. */
+async function showOverlay(env) {
+  const mgr = new IframeManager(env.container);
+  mgr.createStreamingOverlay({ text: 'Your App is Building!' });
+  await new Promise((r) => setImmediate(r));   // fetch → policy → mount
+  return mgr;
+}
+
+const ADS_PAYLOAD = {
+  ads: [{ id: 'promo', html: '<b>Promo</b>', height: 140 }],
+  rotate_seconds: 180,
+  // No hold-back, so the promo is up by the time we assert.
+  policy: { enabled: true, show_after_seconds: 0, modes: ['building', 'plan'], min_interval_seconds: 0 },
+};
+
+// ---------------------------------------------------------------------------
+
+test('no promo → the overlay looks exactly like it did before the jumbotron', async () => {
+  const env = makeEnv({ payload: { ads: [] } });
+  await showOverlay(env);
+  const { overlay, adSlot, lottie } = overlayParts(env.browserContent);
+
+  assert.equal(adSlot.style.display, 'none', 'an empty payload must not leave an empty slot on screen');
+  // The animation is its own full-width block under the pill, not a row item.
+  assert.equal(lottie.parentNode, overlay);
+  assert.equal(lottie.style.width, '100%');
+  assert.equal(lottie.children[0].style.width, '240px', 'the big building animation is back');
+  assert.equal(overlay.children[0].style.justifyContent, 'center', 'the status pill is centered again');
+});
+
+test('no promo because the mothership is down → still the classic overlay', async () => {
+  const env = makeEnv({ ok: false });
+  await showOverlay(env);
+  const { overlay, adSlot, lottie } = overlayParts(env.browserContent);
+
+  assert.equal(adSlot.style.display, 'none');
+  assert.equal(lottie.parentNode, overlay);
+  assert.equal(lottie.children[0].style.width, '240px');
+});
+
+test('a mounted promo shrinks the status block into the compact pill', async () => {
+  const env = makeEnv({ payload: ADS_PAYLOAD });
+  await showOverlay(env);
+  const { overlay, adSlot, lottie } = overlayParts(env.browserContent);
+
+  assert.equal(adSlot.style.display, 'block');
+  assert.notEqual(lottie.parentNode, overlay, 'the animation moves into the pill beside the title');
+  assert.equal(lottie.parentNode.firstChild, lottie, 'and sits ahead of the title/tip stack');
+  assert.equal(lottie.children[0].style.width, '58px', 'a small ball, so the promo owns the pane');
+});
+
+test('a promo suppressed by policy leaves the classic overlay untouched', async () => {
+  const env = makeEnv({
+    payload: { ...ADS_PAYLOAD, policy: { ...ADS_PAYLOAD.policy, enabled: false } },
+  });
+  await showOverlay(env);
+  const { overlay, adSlot, lottie } = overlayParts(env.browserContent);
+
+  assert.equal(adSlot.style.display, 'none');
+  assert.equal(lottie.parentNode, overlay);
+  assert.equal(lottie.children[0].style.width, '240px');
+});

--- a/app/tests/js/overlay_devtools.test.mjs
+++ b/app/tests/js/overlay_devtools.test.mjs
@@ -1,0 +1,147 @@
+// window.leoAds — the console handle for driving the building overlay.
+//
+// It's a convenience wrapper, so the properties worth pinning are the ones that
+// would silently rot: that it lands on window at all, that show() tears down an
+// existing overlay first (createStreamingOverlay no-ops while one is up), and
+// that the mode shortcuts reach _setOverlayMode.
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { installOverlayDevtools } from '../../frontend/chat/ui/OverlayDevtools.js';
+
+/** Records what the helper asked the IframeManager to do. */
+function stubManager() {
+  const calls = [];
+  return {
+    calls,
+    _overlayMode: 'building',
+    _overlayAdRotator: {
+      ads: [{ id: 'a' }, { id: 'b' }],
+      rotateSeconds: 180,
+      currentAd: { id: 'a' },
+      next() { calls.push('rotator.next'); },
+    },
+    _overlayAdVerdict: 'ok',
+    _overlayAdPolicy: { enabled: true, modes: ['building', 'plan'] },
+    _overlayAdVariant: 'arm-b',
+    _overlayAdDelayTimer: null,
+    removeStreamingOverlay() { calls.push('remove'); },
+    createStreamingOverlay(opts) { calls.push(['create', opts]); },
+    _setOverlayMode(mode) { calls.push(['mode', mode]); },
+  };
+}
+
+function stubWindow(overlayPresent = false) {
+  return {
+    document: { getElementById: (id) => (overlayPresent && id === 'streamingOverlay' ? {} : null) },
+    console: { table() {} },
+    fetch: async () => ({ json: async () => ({ ads: [{ id: 'a', height: 140, html: '<b>x</b>' }] }) }),
+  };
+}
+
+test('installs itself on window', () => {
+  const win = stubWindow();
+  const returned = installOverlayDevtools(stubManager(), win);
+  assert.equal(win.leoAds, returned);
+  assert.equal(typeof win.leoAds.show, 'function');
+});
+
+test('show() removes any existing overlay before creating one', () => {
+  // createStreamingOverlay early-returns while an overlay is on screen, so
+  // without the remove first, a second show() would silently do nothing.
+  const im = stubManager();
+  const leoAds = installOverlayDevtools(im, stubWindow());
+  leoAds.show();
+
+  assert.equal(im.calls[0], 'remove');
+  assert.equal(im.calls[1][0], 'create');
+  assert.equal(im.calls[1][1].text, 'Your App is Building!');
+  assert.equal(im.calls[1][1].showCloseButton, true);
+});
+
+test('show() accepts a custom title', () => {
+  const im = stubManager();
+  installOverlayDevtools(im, stubWindow()).show('Custom');
+  assert.equal(im.calls[1][1].text, 'Custom');
+});
+
+test('toggle() hides when an overlay is up and shows when it is not', () => {
+  const up = stubManager();
+  installOverlayDevtools(up, stubWindow(true)).toggle();
+  assert.deepEqual(up.calls, ['remove']);
+
+  const down = stubManager();
+  installOverlayDevtools(down, stubWindow(false)).toggle();
+  assert.equal(down.calls[1][0], 'create');
+});
+
+test('mode shortcuts reach _setOverlayMode', () => {
+  const im = stubManager();
+  const leoAds = installOverlayDevtools(im, stubWindow());
+  leoAds.plan(); leoAds.question(); leoAds.building();
+
+  assert.deepEqual(im.calls, [['mode', 'plan'], ['mode', 'question'], ['mode', 'building']]);
+});
+
+test('next() drives the rotator', () => {
+  const im = stubManager();
+  installOverlayDevtools(im, stubWindow()).next();
+  assert.deepEqual(im.calls, ['rotator.next']);
+});
+
+test('the shortcuts no-op instead of throwing when no overlay is up', () => {
+  // _setOverlayMode and _overlayAdRotator are null between builds; hitting the
+  // helper then is the normal case, not a mistake.
+  const im = { removeStreamingOverlay() {}, createStreamingOverlay() {},
+               _setOverlayMode: null, _overlayAdRotator: null, _overlayMode: null };
+  const leoAds = installOverlayDevtools(im, stubWindow());
+
+  leoAds.next(); leoAds.plan(); leoAds.question(); leoAds.building();
+  assert.deepEqual(leoAds.status(), {
+    overlay: false, mode: null, ads: 0, showing: null, rotateSeconds: null,
+    verdict: null, policy: null, variant: null, pendingDelay: false,
+  });
+});
+
+test('status() reports what is on screen, and WHY', () => {
+  // `verdict` is the whole point: when no promo shows, this is what tells you
+  // whether it was the cooldown, the kill switch, or simply no creative.
+  const leoAds = installOverlayDevtools(stubManager(), stubWindow(true));
+  assert.deepEqual(leoAds.status(), {
+    overlay: true, mode: 'building', ads: 2, showing: 'a', rotateSeconds: 180,
+    verdict: 'ok', policy: { enabled: true, modes: ['building', 'plan'] },
+    variant: 'arm-b', pendingDelay: false,
+  });
+});
+
+test('status() surfaces a suppression reason instead of just an absent ad', () => {
+  const im = stubManager();
+  im._overlayAdRotator = null;
+  im._overlayAdVerdict = 'cooldown:1799s-left';
+  const leoAds = installOverlayDevtools(im, stubWindow(true));
+
+  assert.equal(leoAds.status().verdict, 'cooldown:1799s-left');
+  assert.equal(leoAds.status().showing, null);
+});
+
+test('resetCooldown clears the stored timestamp', () => {
+  const win = stubWindow();
+  const store = { 'llamabot.overlayAds.lastShownAt': '123' };
+  win.localStorage = { removeItem: (k) => { delete store[k]; } };
+  installOverlayDevtools(stubManager(), win).resetCooldown();
+
+  assert.equal('llamabot.overlayAds.lastShownAt' in store, false);
+});
+
+test('resetCooldown survives a hostile localStorage', () => {
+  const win = stubWindow();
+  win.localStorage = { removeItem() { throw new Error('denied'); } };
+  assert.doesNotThrow(() => installOverlayDevtools(stubManager(), win).resetCooldown());
+});
+
+test('ads() returns what the endpoint is serving', async () => {
+  const leoAds = installOverlayDevtools(stubManager(), stubWindow());
+  const body = await leoAds.ads();
+  assert.deepEqual(body.ads.map((a) => a.id), ['a']);
+});

--- a/app/tests/js/preview_js_error_attach.test.mjs
+++ b/app/tests/js/preview_js_error_attach.test.mjs
@@ -308,7 +308,7 @@ test('the banner is one compact line: count, Read more, and a Show Leo box', () 
   const { banner, sendError } = harness();
   sendError(anError());
 
-  assert.match(banner.innerHTML, /1 error detected/);
+  assert.match(banner.innerHTML, /1 JavaScript error detected/);
   assert.match(banner.innerHTML, /Read more/);
   assert.match(banner.innerHTML, /Show Leo/);
   assert.match(banner.innerHTML, /type="checkbox"[^>]*checked/);
@@ -421,12 +421,228 @@ test('the count pluralises', () => {
   const { banner, sendError } = harness();
   sendError(anError({ id: 'a', message: 'boom a' }));
   sendError(anError({ id: 'b', message: 'boom b' }));
-  assert.match(banner.innerHTML, /2 errors detected/);
+  assert.match(banner.innerHTML, /2 JavaScript errors detected/);
 });
 
-test('repeats count toward the total', () => {
-  const { banner, sendError } = harness();
+test('a repeat of the same error stays one problem in the notice', () => {
+  // The count is how many times it fired, not how many things are broken. The
+  // popup carries "happened N times" on the entry itself; the notice would only
+  // be alarming if it turned one broken page into "50 errors detected".
+  const { attach, banner, sendError } = harness();
   sendError(anError());
   sendError(anError({ id: 'again' }));
-  assert.match(banner.innerHTML, /2 errors detected/);
+
+  assert.match(banner.innerHTML, /1 JavaScript error detected/);
+  assert.equal(attach.errors[0].count, 2);
+});
+
+test('two different errors are two problems', () => {
+  const { banner, sendError } = harness();
+  sendError(anError({ id: 'a', message: 'boom a' }));
+  sendError(anError({ id: 'b', message: 'boom b' }));
+  assert.match(banner.innerHTML, /2 JavaScript errors detected/);
+});
+
+// ---------------------------------------------------------------------------
+// Rails server errors, in the same tray
+// ---------------------------------------------------------------------------
+//
+// Same notice, same "Show Leo" box, second source. These do not arrive over
+// postMessage — the Rails app cannot reach this page — they come from
+// ui/RailsErrorPoll.js, which reads them through LlamaBot. From here on they are
+// ordinary tray entries, distinguished only by `kind`.
+
+function aServerError(overrides = {}) {
+  return {
+    id: 'rails-5',
+    kind: 'rails',
+    message: "NoMethodError: undefined method `title' for nil",
+    path: 'GET /posts/1',
+    count: 1,
+    stack: 'app/views/posts/show.html.erb:3',
+    ...overrides
+  };
+}
+
+test('a server error lands in the same tray as a JS error', () => {
+  const { attach, banner, sendError } = harness();
+  sendError(anError());
+  attach.record(aServerError());
+
+  assert.equal(attach.errors.length, 2);
+  assert.match(banner.innerHTML, /1 Rails error, 1 JavaScript error detected/);
+});
+
+test('a server error carries the times Rails raised it', () => {
+  // The gem collapses a render loop into a count rather than 200 rows, so the
+  // count is the only place that information exists.
+  const { attach } = harness();
+  attach.record(aServerError({ count: 12 }));
+  assert.equal(attach.errors[0].count, 12);
+});
+
+test('re-reporting the same server error takes the higher count, not one more', () => {
+  // The feed re-stamps an entry when it repeats, so the same crash can arrive
+  // twice carrying its running total. Incrementing would double-count it.
+  const { attach } = harness();
+  attach.record(aServerError({ count: 3 }));
+  attach.record(aServerError({ count: 5 }));
+
+  assert.equal(attach.errors.length, 1);
+  assert.equal(attach.errors[0].count, 5);
+});
+
+test('a JS error with no count still increments on a repeat', () => {
+  const { attach, sendError } = harness();
+  sendError(anError());
+  sendError(anError({ id: 'again' }));
+  assert.equal(attach.errors[0].count, 2);
+});
+
+test('server errors go to Leo under their own tag', () => {
+  // The JS block says "JavaScript error ... from their app preview", which would
+  // be a lie about a Ruby backtrace — and the two want different fixes.
+  const { attach, sendError } = harness();
+  sendError(anError());
+  attach.record(aServerError());
+
+  const block = attach.buildMessageBlock();
+  assert.match(block, /<PAGE_JS_ERRORS>[\s\S]*TypeError[\s\S]*<\/PAGE_JS_ERRORS>/);
+  assert.match(block, /<RAILS_SERVER_ERRORS>[\s\S]*NoMethodError[\s\S]*<\/RAILS_SERVER_ERRORS>/);
+  const jsBlock = block.match(/<PAGE_JS_ERRORS>([\s\S]*?)<\/PAGE_JS_ERRORS>/)[1];
+  assert.ok(!jsBlock.includes('NoMethodError'), 'no Ruby in the JS block');
+});
+
+test('a tray with only server errors sends no JavaScript block', () => {
+  const { attach } = harness();
+  attach.record(aServerError());
+
+  const block = attach.buildMessageBlock();
+  assert.ok(!block.includes('<PAGE_JS_ERRORS>'));
+  assert.match(block, /<RAILS_SERVER_ERRORS>/);
+});
+
+test('a tray with only JS errors is unchanged', () => {
+  const { attach, sendError } = harness();
+  sendError(anError());
+
+  const block = attach.buildMessageBlock();
+  assert.match(block, /<PAGE_JS_ERRORS>/);
+  assert.ok(!block.includes('<RAILS_SERVER_ERRORS>'));
+});
+
+test('the server backtrace rides along', () => {
+  const { attach } = harness();
+  attach.record(aServerError());
+  assert.match(attach.buildMessageBlock(), /app\/views\/posts\/show\.html\.erb:3/);
+});
+
+test('server errors are consumed by a send like any other', () => {
+  const { attach } = harness();
+  attach.record(aServerError());
+  attach.clear();
+  assert.equal(attach.errors.length, 0);
+});
+
+test('server error text is escaped in the popup', () => {
+  const { attach, body } = harness();
+  attach.record(aServerError({ message: 'NoMethodError: <img src=x onerror=alert(1)>' }));
+  attach.openDetails();
+
+  const html = body.children[body.children.length - 1].innerHTML;
+  assert.ok(!html.includes('<img src=x'));
+  assert.match(html, /&lt;img src=x/);
+});
+
+test('a server error reads as a server problem, not a page problem', () => {
+  assert.match(friendlySummary(aServerError()), /server/i);
+});
+
+test('common Rails failures get their own plain sentence', () => {
+  const say = (message) => friendlySummary(aServerError({ message }));
+
+  assert.match(say('ActiveRecord::RecordNotFound: Couldn\'t find Post'), /couldn't find|doesn't exist/i);
+  assert.match(say('ActiveRecord::StatementInvalid: PG::UndefinedColumn'), /database/i);
+  assert.match(say('ActionView::Template::Error: undefined method'), /page|render/i);
+  assert.match(say('ActiveRecord::PendingMigrationError'), /database/i);
+});
+
+test('an unrecognised server error still says something useful', () => {
+  assert.match(friendlySummary(aServerError({ message: 'Whatever::Error: hmm' })), /server/i);
+});
+
+// ---------------------------------------------------------------------------
+// Telling the two kinds apart
+//
+// The tray carries both browser errors (pushed from the preview over
+// postMessage) and Rails crashes (polled from the server's own error feed).
+// Until now it rendered "3 errors detected" for either, which hides the single
+// most useful fact: a JavaScript error means the page loaded and something
+// misbehaved, a Rails error means the request never made it out of the server —
+// and the server ones happen even when the screen looks perfectly fine.
+// ---------------------------------------------------------------------------
+
+function trayWith(entries) {
+  const tray = new ErrorAttach({ getAllowedOrigin: () => RAILS_ORIGIN });
+  const banner = new FakeElement();
+  tray.init(banner, new FakeElement());
+  entries.forEach((e) => tray.record(e));
+  return { tray, banner };
+}
+
+const jsError = (message = 'x is not a function') => ({
+  id: `js-${message}`, kind: 'error', message, path: '/dash',
+});
+const railsError = (message = 'undefined method `titl?') => ({
+  id: `rails-${message}`, kind: 'rails', message, path: '/posts/3',
+});
+
+test('banner names JavaScript when only browser errors are present', () => {
+  const { banner } = trayWith([jsError()]);
+  assert.match(banner.innerHTML, /1 JavaScript error detected/);
+  assert.doesNotMatch(banner.innerHTML, /Rails/);
+});
+
+test('banner names Rails when only server errors are present', () => {
+  const { banner } = trayWith([railsError()]);
+  assert.match(banner.innerHTML, /1 Rails error detected/);
+  assert.doesNotMatch(banner.innerHTML, /JavaScript/);
+});
+
+test('banner breaks the count down when both kinds are present', () => {
+  const { banner } = trayWith([jsError(), railsError()]);
+  assert.match(banner.innerHTML, /1 Rails/);
+  assert.match(banner.innerHTML, /1 JavaScript/);
+});
+
+test('banner pluralises each kind independently', () => {
+  const { banner } = trayWith([jsError('a'), jsError('b'), railsError('c')]);
+  assert.match(banner.innerHTML, /1 Rails error/);
+  assert.match(banner.innerHTML, /2 JavaScript errors/);
+});
+
+test('banner counts distinct problems, not occurrences', () => {
+  // A crashing page raises the same error on every render; Rails counts those
+  // in the dozens. "50 errors detected" would be alarming and wrong.
+  const { tray, banner } = trayWith([railsError('same')]);
+  tray.record({ ...railsError('same'), count: 40 });
+  assert.match(banner.innerHTML, /1 Rails error detected/);
+});
+
+test('each popup entry is labelled with its kind', () => {
+  const { tray } = trayWith([jsError(), railsError()]);
+  const html = tray._detailsHtml();
+  assert.match(html, /js-error-kind[^>]*>Rails</);
+  assert.match(html, /js-error-kind[^>]*>JavaScript</);
+});
+
+test('a Rails entry is marked so it can be styled apart', () => {
+  const { tray } = trayWith([railsError()]);
+  assert.match(tray._detailsHtml(), /js-error-item--rails/);
+});
+
+test('the kind label cannot be injected from error text', () => {
+  const { tray } = trayWith([{ id: 'x', kind: '<img src=x onerror=alert(1)>', message: 'hi' }]);
+  const html = tray._detailsHtml();
+  assert.doesNotMatch(html, /<img src=x/);
 });

--- a/app/tests/js/rails_error_poll.test.mjs
+++ b/app/tests/js/rails_error_poll.test.mjs
@@ -1,0 +1,313 @@
+// Tests for the Rails crash poller behind the chat error tray
+// (ui/RailsErrorPoll.js).
+//
+// The tray already shows JavaScript errors the preview pushes over postMessage.
+// Server-side crashes cannot be pushed — the Rails app has no handle on the
+// chat page — so LlamaBot proxies the gem's crash feed and this class polls it.
+//
+// The properties that matter, in the order a user would notice them breaking:
+// the tray arms itself on load and never shows crashes that predate the session;
+// a repeat poll never re-reports what it already showed; a Rails restart (which
+// rewinds the feed's sequence to zero) does not wedge the poller forever; while
+// Leo is mid-turn the errors are Leo's to fix, not the user's to read; and no
+// failure anywhere — no token, dead feed, garbage body — can throw into the page.
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { RailsErrorPoll } from '../../frontend/chat/ui/RailsErrorPoll.js';
+
+const ERROR = {
+  id: 'rails-5',
+  kind: 'rails',
+  message: 'NoMethodError: undefined method `title\' for nil',
+  path: 'GET /posts/1',
+  count: 1,
+  stack: 'app/views/posts/show.html.erb:3',
+};
+
+/**
+ * @param {Array} responses - one entry per tick; a body, or an Error to throw.
+ */
+function harness(responses, opts = {}) {
+  const calls = [];
+  const recorded = [];
+  let running = false;
+
+  const poll = new RailsErrorPoll({
+    getToken: opts.getToken || (async () => 'tok-abc'),
+    isAgentRunning: () => running,
+    onErrors: (errors) => recorded.push(...errors),
+    isVisible: opts.isVisible || (() => true),
+    fetchImpl: async (url, init) => {
+      calls.push({ url, headers: (init && init.headers) || {} });
+      const next = responses.shift();
+      if (next instanceof Error) throw next;
+      if (next && next.__http) return { ok: false, status: next.__http };
+      return { ok: true, status: 200, json: async () => next };
+    },
+  });
+
+  return {
+    poll,
+    calls,
+    recorded,
+    setRunning: (v) => { running = v; },
+    since: (i) => new URL(calls[i].url, 'https://box.example').searchParams.get('since'),
+  };
+}
+
+const body = (seq, errors = [], available = true) => ({ seq, errors, available });
+
+// ---------------------------------------------------------------------------
+// Arming
+// ---------------------------------------------------------------------------
+
+test('the first poll is a cursor probe and shows nothing', async () => {
+  const h = harness([body(9, [ERROR])]);
+  await h.poll.tick();
+
+  assert.equal(h.since(0), null, 'no since= on the probe');
+  assert.deepEqual(h.recorded, [], 'crashes from before the page opened are not news');
+});
+
+test('later polls ask for what came after the probe', async () => {
+  const h = harness([body(9), body(10, [ERROR])]);
+  await h.poll.tick();
+  await h.poll.tick();
+
+  assert.equal(h.since(1), '9');
+  assert.deepEqual(h.recorded, [ERROR]);
+});
+
+test('the cursor advances so an error is reported once', async () => {
+  const h = harness([body(9), body(10, [ERROR]), body(10, [])]);
+  await h.poll.tick();
+  await h.poll.tick();
+  await h.poll.tick();
+
+  assert.equal(h.since(2), '10');
+  assert.equal(h.recorded.length, 1);
+});
+
+// ---------------------------------------------------------------------------
+// Rails restarting
+// ---------------------------------------------------------------------------
+
+test('a feed that rewound is re-armed instead of going deaf', async () => {
+  // Rails restarts, its in-memory ring resets to seq 0. Holding a cursor of 10
+  // would mean asking for "everything after 10" forever — the tray would never
+  // show another error for the rest of the session.
+  const h = harness([body(9), body(10, [ERROR]), body(2, []), body(3, [ERROR])]);
+  await h.poll.tick();
+  await h.poll.tick();
+  await h.poll.tick();   // sees seq go backwards; re-arms at 2, takes nothing
+  await h.poll.tick();
+
+  assert.equal(h.since(3), '2');
+  assert.equal(h.recorded.length, 2);
+});
+
+test('a rewind does not replay the entries in that response', async () => {
+  const h = harness([body(9), body(10, [ERROR]), body(2, [ERROR])]);
+  await h.poll.tick();
+  await h.poll.tick();
+  await h.poll.tick();
+
+  assert.equal(h.recorded.length, 1, 'the post-restart page is somebody else’s history');
+});
+
+// ---------------------------------------------------------------------------
+// Staying out of Leo's way
+// ---------------------------------------------------------------------------
+
+test('crashes during an agent turn are left to Leo', async () => {
+  // Leo already polls this feed mid-turn and repairs what it broke, without the
+  // user ever seeing the broken page. Popping a notice at the same time would
+  // hand the user a problem that is already being fixed.
+  const h = harness([body(9), body(10, [ERROR])]);
+  await h.poll.tick();
+  h.setRunning(true);
+  await h.poll.tick();
+
+  assert.deepEqual(h.recorded, []);
+});
+
+test('the cursor still moves during a turn, so the errors do not surface later', async () => {
+  const h = harness([body(9), body(10, [ERROR]), body(10, [])]);
+  await h.poll.tick();
+  h.setRunning(true);
+  await h.poll.tick();
+  h.setRunning(false);
+  await h.poll.tick();
+
+  assert.equal(h.since(2), '10');
+  assert.deepEqual(h.recorded, []);
+});
+
+// ---------------------------------------------------------------------------
+// Degrading quietly
+// ---------------------------------------------------------------------------
+
+test('no Rails token means no request at all', async () => {
+  const h = harness([body(9)], { getToken: async () => null });
+  await h.poll.tick();
+
+  assert.equal(h.calls.length, 0);
+});
+
+test('the token travels in a header, never the query string', async () => {
+  const h = harness([body(9)]);
+  await h.poll.tick();
+
+  assert.equal(h.calls[0].headers['X-Rails-Api-Token'], 'tok-abc');
+  assert.ok(!h.calls[0].url.includes('tok-abc'));
+});
+
+test('an unavailable feed holds the cursor rather than losing its place', async () => {
+  // A gem too old to serve the endpoint, an expired token, Rails mid-restart.
+  const h = harness([body(9), body(null, [], false), body(10, [ERROR])]);
+  await h.poll.tick();
+  await h.poll.tick();
+  await h.poll.tick();
+
+  assert.equal(h.since(2), '9');
+  assert.deepEqual(h.recorded, [ERROR]);
+});
+
+test('a feed that never answers backs off instead of hammering', async () => {
+  const h = harness([body(9), ...Array(5).fill(body(null, [], false))]);
+  await h.poll.tick();
+  const fast = h.poll.intervalMs;
+  for (let i = 0; i < 5; i += 1) await h.poll.tick();
+
+  assert.ok(h.poll.intervalMs > fast, 'a box on an old gem should not poll every few seconds');
+});
+
+test('the interval recovers as soon as the feed answers again', async () => {
+  const h = harness([body(9), ...Array(5).fill(body(null, [], false)), body(9)]);
+  await h.poll.tick();
+  const fast = h.poll.intervalMs;
+  for (let i = 0; i < 6; i += 1) await h.poll.tick();
+
+  assert.equal(h.poll.intervalMs, fast);
+});
+
+test('a thrown fetch is not a broken page', async () => {
+  const h = harness([body(9), new Error('offline'), body(10, [ERROR])]);
+  await h.poll.tick();
+  await h.poll.tick();
+  await h.poll.tick();
+
+  assert.deepEqual(h.recorded, [ERROR]);
+});
+
+test('an HTTP error is not a broken page', async () => {
+  const h = harness([body(9), { __http: 500 }, body(10, [ERROR])]);
+  await h.poll.tick();
+  await h.poll.tick();
+  await h.poll.tick();
+
+  assert.deepEqual(h.recorded, [ERROR]);
+});
+
+test('a garbled body is ignored', async () => {
+  const h = harness([body(9), { seq: 'not-a-number', errors: 'nope' }, body(10, [ERROR])]);
+  await h.poll.tick();
+  await h.poll.tick();
+  await h.poll.tick();
+
+  assert.equal(h.since(2), '9', 'the bad seq did not become the cursor');
+  assert.deepEqual(h.recorded, [ERROR]);
+});
+
+// ---------------------------------------------------------------------------
+// Not doing work nobody asked for
+// ---------------------------------------------------------------------------
+
+test('a hidden tab does not poll', async () => {
+  const h = harness([body(9), body(10, [ERROR])], { isVisible: () => false });
+  await h.poll.tick();
+
+  assert.equal(h.calls.length, 0);
+});
+
+test('a slow poll does not stack up behind itself', async () => {
+  let release;
+  const gate = new Promise((r) => { release = r; });
+  const calls = [];
+  const poll = new RailsErrorPoll({
+    getToken: async () => 'tok',
+    onErrors: () => {},
+    fetchImpl: async (url) => {
+      calls.push(url);
+      await gate;
+      return { ok: true, status: 200, json: async () => body(9) };
+    },
+  });
+
+  const first = poll.tick();
+  await poll.tick();          // arrives while the first is still in flight
+  release();
+  await first;
+
+  assert.equal(calls.length, 1);
+});
+
+// ---------------------------------------------------------------------------
+// The seam: poller -> tray
+// ---------------------------------------------------------------------------
+//
+// index.js wires these two together with one line
+// (`onErrors: (errors) => errors.forEach(e => this.errorAttach.record(e))`), so
+// the shape the endpoint returns has to be the shape the tray records. This
+// pins that against a real captured response — a live `GET /telemetry_boom`
+// against the dev box on 2026-08-23.
+
+test('a real endpoint response lands in the tray as one notice', async () => {
+  const { ErrorAttach } = await import('../../frontend/chat/ui/ErrorAttach.js');
+
+  class El {
+    constructor() { this.innerHTML = ''; this.children = []; this._c = new Set(); }
+    get classList() {
+      return { add: (n) => this._c.add(n), remove: (n) => this._c.delete(n), contains: (n) => this._c.has(n) };
+    }
+    addEventListener() {}
+    querySelectorAll() { return []; }
+    appendChild(e) { this.children.push(e); return e; }
+  }
+  globalThis.window = { addEventListener() {} };
+  globalThis.document = { createElement: () => new El(), body: new El(), addEventListener() {}, removeEventListener() {} };
+
+  const banner = new El();
+  const attach = new ErrorAttach({ getAllowedOrigin: () => 'https://rails.example' });
+  attach.init(banner, new El());
+
+  const captured = {
+    seq: 2,
+    available: true,
+    errors: [{
+      id: 'rails-2',
+      kind: 'rails',
+      message: 'RuntimeError: Telemetry smoke test: deliberate crash',
+      path: 'GET /telemetry_boom',
+      count: 2,
+      stack: "app/controllers/telemetry_boom_controller.rb:6:in `show'",
+    }],
+  };
+
+  const poll = new RailsErrorPoll({
+    getToken: async () => 'tok',
+    onErrors: (errors) => errors.forEach((e) => attach.record(e)),
+    fetchImpl: async () => ({ ok: true, status: 200, json: async () => captured }),
+  });
+
+  poll.cursor = 1;            // already armed
+  await poll.tick();
+
+  // One broken route is one problem, however many times it fired; the "2" lives
+  // on the entry in the popup, not in the notice.
+  assert.match(banner.innerHTML, /1 Rails error detected/);
+  assert.equal(attach.errors[0].count, 2);
+  assert.match(attach.buildMessageBlock(), /<RAILS_SERVER_ERRORS>[\s\S]*telemetry_boom_controller/);
+});

--- a/app/tests/js/ws_attach_waits_for_auth.test.mjs
+++ b/app/tests/js/ws_attach_waits_for_auth.test.mjs
@@ -1,0 +1,49 @@
+// `attach` must not race the auth handshake.
+//
+// The server now refuses control frames until the socket has authenticated.
+// The client used to fire `attach` on a 300ms timer after `websocketConnected`,
+// hoping the async token fetch had finished first — when it hadn't, the resumed
+// run lost its live output and the spinner hung. `websocketReady` is the real
+// signal: it fires on `auth_success`, or immediately for ActionCable (which the
+// Rails gem has already authenticated).
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const appRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const manager = readFileSync(join(appRoot, 'frontend/chat/websocket/WebSocketManager.js'), 'utf8');
+const index = readFileSync(join(appRoot, 'frontend/chat/index.js'), 'utf8');
+
+test('auth_success announces readiness', () => {
+  const block = manager.slice(manager.indexOf("data.type === 'auth_success'"));
+  assert.match(block.slice(0, 400), /this\.announceReady\(\)/);
+});
+
+test('ActionCable is ready as soon as it connects', () => {
+  const block = manager.slice(manager.indexOf('ActionCable is authenticated by the Rails gem'));
+  assert.match(block.slice(0, 200), /this\.announceReady\(\)/);
+});
+
+test('a box with no token still becomes ready', () => {
+  // WS_AUTH_REQUIRED=false: no token is ever coming, so waiting would strand
+  // the resume path forever.
+  const block = manager.slice(manager.indexOf('No auth token available'));
+  assert.match(block.slice(0, 300), /this\.announceReady\(\)/);
+});
+
+test('announceReady dispatches websocketReady', () => {
+  assert.match(manager, /announceReady\(\)\s*\{\s*window\.dispatchEvent\(new CustomEvent\('websocketReady'\)\)/);
+});
+
+test('attach listens for websocketReady, not websocketConnected', () => {
+  const block = index.slice(index.indexOf("type: 'attach'") - 900, index.indexOf("type: 'attach'") + 200);
+  assert.match(block, /addEventListener\('websocketReady'/);
+  assert.doesNotMatch(block, /addEventListener\('websocketConnected'/);
+});
+
+test('the 300ms guess is gone', () => {
+  const block = index.slice(index.indexOf("type: 'attach'") - 900, index.indexOf("type: 'attach'") + 200);
+  assert.doesNotMatch(block, /setTimeout/);
+});

--- a/app/tests/rails_token_vectors.py
+++ b/app/tests/rails_token_vectors.py
@@ -1,0 +1,33 @@
+"""Golden ``llama_bot_rails`` WebSocket tokens, minted by a real Rails app.
+
+Not fixtures our own code produced — these came out of Rails 7.2.3 with the
+gem loaded, reproducing exactly how ``Rails.application.message_verifier(
+:llamabot_ws)`` builds its verifier, signed with the throwaway secret in
+:data:`TEST_SKB`. That is what makes them worth anything: they prove the Python
+verifier agrees with Ruby rather than with itself.
+
+The measured parameters on a stock box, none of which are safe to assume:
+
+  * signing digest      SHA1
+  * key_generator digest OpenSSL::Digest::SHA1  ← *not* the same setting
+  * serializer          MarshalWithFallback
+
+The first cut of this file used SHA256 for the key derivation, on the strength
+of a written description. Every test passed, because the vectors had been
+minted under the same wrong assumption — and a token from the live Rails app
+was rejected. Regenerate these against a real container; never hand-edit them,
+and never mint them from Python.
+"""
+
+TEST_SKB = "llamabot-test-secret-key-base-do-not-use-in-production-0123456789"
+OTHER_SKB = "a-completely-different-secret-key-base-9876543210"
+
+VALID = "BAh7BkkiC19yYWlscwY6BkVUewdJIglkYXRhBjsAVHsHOg9zZXNzaW9uX2lkSSILc2Vzcy0xBjsAVDoMdXNlcl9pZGkCkhBJIghleHAGOwBUSSIdMjA5OS0wMS0wMVQwMDowMDowMC4wMDBaBjsAVA==--7ee6f04c9464123fdf2d64a87fe24460abc3c2f2"
+VALID_NO_USER = "BAh7BkkiC19yYWlscwY6BkVUewdJIglkYXRhBjsAVHsHOg9zZXNzaW9uX2lkSSILc2Vzcy0yBjsAVDoMdXNlcl9pZDBJIghleHAGOwBUSSIdMjA5OS0wMS0wMVQwMDowMDowMC4wMDBaBjsAVA==--3882566dab1098e28d1929d919b1d72fda377008"
+EXPIRED = "BAh7BkkiC19yYWlscwY6BkVUewdJIglkYXRhBjsAVHsHOg9zZXNzaW9uX2lkSSILc2Vzcy0zBjsAVDoMdXNlcl9pZGkMSSIIZXhwBjsAVEkiHTIwMjYtMDgtMjVUMDA6MzU6NDYuNDk5WgY7AFQ=--96f3a9cf61e869380a3c504c30ca99da41af566d"
+WRONG_KEY = "BAh7BkkiC19yYWlscwY6BkVUewdJIglkYXRhBjsAVHsHOg9zZXNzaW9uX2lkSSILc2Vzcy00BjsAVDoMdXNlcl9pZGkOSSIIZXhwBjsAVEkiHTIwOTktMDEtMDFUMDA6MDA6MDAuMDAwWgY7AFQ=--2a4f7f718fbbe1685e876a45cc8c8abf43d28a72"
+NO_METADATA = "BAh7BzoPc2Vzc2lvbl9pZEkiC3Nlc3MtNQY6BkVUOgx1c2VyX2lkaTw=--33ad5a935594d0bec6633543ee378e3a56d47182"
+JSON_SERIALIZER = "eyJfcmFpbHMiOnsiZGF0YSI6eyJzZXNzaW9uX2lkIjoic2Vzcy02IiwidXNlcl9pZCI6NjA2fSwiZXhwIjoiMjA5OS0wMS0wMVQwMDowMDowMC4wMDBaIn19--11fcb8d3fcfa855e9f97b458ff756aabcf995ad6"
+SHA256_DIGEST = "BAh7BkkiC19yYWlscwY6BkVUewdJIglkYXRhBjsAVHsHOg9zZXNzaW9uX2lkSSILc2Vzcy03BjsAVDoMdXNlcl9pZGkCCQNJIghleHAGOwBUSSIdMjA5OS0wMS0wMVQwMDowMDowMC4wMDBaBjsAVA==--eb7f34b0ac0f4630195eafa8667f345bd7bc7c1d2c496fbb63e602572b26f0bc"
+SHA256_KEY_DIGEST = "BAh7BkkiC19yYWlscwY6BkVUewdJIglkYXRhBjsAVHsHOg9zZXNzaW9uX2lkSSILc2Vzcy04BjsAVDoMdXNlcl9pZGkCeANJIghleHAGOwBUSSIdMjA5OS0wMS0wMVQwMDowMDowMC4wMDBaBjsAVA==--c300e6e463d9bf5da6d1e56bdebecf8807b87167"
+TAMPERED = "CAh7BkkiC19yYWlscwY6BkVUewdJIglkYXRhBjsAVHsHOg9zZXNzaW9uX2lkSSILc2Vzcy0xBjsAVDoMdXNlcl9pZGkCkhBJIghleHAGOwBUSSIdMjA5OS0wMS0wMVQwMDowMDowMC4wMDBaBjsAVA==--7ee6f04c9464123fdf2d64a87fe24460abc3c2f2"

--- a/app/tests/test_bash_exec_env_scrub.py
+++ b/app/tests/test_bash_exec_env_scrub.py
@@ -137,3 +137,57 @@ def test_the_allowlist_holds_no_llm_provider_keys():
     """A provider key on the allowlist would silently undo the whole fix."""
     for name in tools._EXEC_ENV_ALLOWLIST:
         assert "API_KEY" not in name or name in ("AWS_KEY",), name
+
+
+# ---------------------------------------------------------------------------
+# The substring blocklist is gone (2026-08-23)
+# ---------------------------------------------------------------------------
+#
+# It blocked ordinary Ruby — `Rails.env` contains ".env", and the beginner prompt
+# instructs `rails runner "puts ENV['HOSTED_DOMAIN']"`, which the `ENV[` rule then
+# refused. Two friction reports, both false positives. The allowlist scrub above
+# is the actual control; a substring match never was one.
+
+class TestNoSubstringBlocklist:
+    class _Runtime:
+        tool_call_id = "call_1"
+
+    def _run(self, monkeypatch, command):
+        from app.agents.leonardo.rails_agent import tools
+
+        seen = []
+        monkeypatch.setattr(
+            tools, "rails_api_sh",
+            lambda snippet, *a, **k: seen.append(snippet) or "ok",
+        )
+        content = tools.bash_command.func(
+            command=command, runtime=self._Runtime(),
+        ).update["messages"][0].content
+        return seen, content
+
+    def test_rails_env_is_not_blocked(self, monkeypatch):
+        seen, content = self._run(
+            monkeypatch, 'bundle exec rails runner "puts Rails.env"'
+        )
+        assert seen, "Rails.env was blocked because it contains the substring '.env'"
+        assert "Blocked" not in content
+
+    def test_the_documented_hosted_domain_command_is_not_blocked(self, monkeypatch):
+        seen, content = self._run(
+            monkeypatch, "bundle exec rails runner \"puts ENV['HOSTED_DOMAIN']\""
+        )
+        assert seen, "the prompt tells the agent to run exactly this command"
+        assert "Blocked" not in content
+
+    def test_hosted_domain_survives_the_env_scrub(self):
+        """Blocking it is one failure; blanking it is the other."""
+        from app.agents.leonardo.rails_agent.tools import _EXEC_ENV_ALLOWLIST
+
+        assert "HOSTED_DOMAIN" in _EXEC_ENV_ALLOWLIST
+
+    def test_secrets_are_still_scrubbed(self):
+        from app.agents.leonardo.rails_agent.tools import _EXEC_ENV_ALLOWLIST
+
+        for secret in ("OPENAI_API_KEY", "DEEPSEEK_API_KEY", "ANTHROPIC_API_KEY",
+                       "VSCODE_PASSWORD", "SSO_SHARED_SECRET"):
+            assert secret not in _EXEC_ENV_ALLOWLIST

--- a/app/tests/test_batched_questions.py
+++ b/app/tests/test_batched_questions.py
@@ -1,0 +1,287 @@
+"""
+Tests for batching ask_user_question (0.7.4):
+- normalize_questions folds the batch form and the legacy single form into one list
+- the 4-question cap truncates loudly (the model is told what was dropped) rather than
+  silently, and rather than rendering a wall of questions
+- the interrupt payload carries `questions` AND mirrors the first one into the legacy
+  top-level fields, so a stale cached frontend still renders a question
+- _check_and_send_interrupts forwards `questions` to the frontend
+
+The answer FORMAT (mapping answers back to questions, the per-question visual-options
+directive) is the frontend's contract and is covered by tests/js/batched_questions.test.mjs.
+"""
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from langchain_core.messages import ToolMessage
+from langgraph.types import Command
+
+
+class TestNormalizeQuestions:
+    """The pure fold — tested directly so no graph/event loop is needed."""
+
+    def test_batch_form_is_normalized(self):
+        from app.agents.leonardo.rails_plan_mode_agent.nodes import normalize_questions
+
+        batch, dropped = normalize_questions([
+            {"question": "Which pages?", "options": ["All", "Checkout"]},
+            {"question": "What style?", "ui_related": True},
+        ])
+
+        assert dropped == 0
+        assert batch == [
+            {"question": "Which pages?", "options": ["All", "Checkout"], "ui_related": False},
+            {"question": "What style?", "options": [], "ui_related": True},
+        ]
+
+    def test_legacy_single_question_form_still_works(self):
+        """The old flat call signature folds into a one-item batch."""
+        from app.agents.leonardo.rails_plan_mode_agent.nodes import normalize_questions
+
+        batch, dropped = normalize_questions(None, "Which pages?", ["All"], True)
+
+        assert dropped == 0
+        assert batch == [{"question": "Which pages?", "options": ["All"], "ui_related": True}]
+
+    def test_blank_and_malformed_questions_are_dropped(self):
+        from app.agents.leonardo.rails_plan_mode_agent.nodes import normalize_questions
+
+        batch, _ = normalize_questions([
+            {"question": "Real?"},
+            {"question": "   "},
+            {"options": ["no question here"]},
+            "not a dict",
+        ])
+
+        assert [q["question"] for q in batch] == ["Real?"]
+
+    def test_cap_truncates_and_reports_the_drop(self):
+        """More than 4 questions is a wall, not a card — cap it but say so."""
+        from app.agents.leonardo.rails_plan_mode_agent.nodes import (
+            normalize_questions, MAX_BATCHED_QUESTIONS,
+        )
+
+        batch, dropped = normalize_questions([{"question": f"Q{i}?"} for i in range(7)])
+
+        assert len(batch) == MAX_BATCHED_QUESTIONS
+        assert dropped == 7 - MAX_BATCHED_QUESTIONS
+
+
+class TestAskUserQuestionTool:
+    """The tool's interrupt payload."""
+
+    def _runtime(self):
+        runtime = MagicMock()
+        runtime.tool_call_id = "tool_call_abc"
+        return runtime
+
+    def test_batch_interrupt_carries_questions_and_legacy_mirror(self):
+        from app.agents.leonardo.rails_plan_mode_agent.nodes import ask_user_question
+
+        with patch(
+            "app.agents.leonardo.rails_plan_mode_agent.nodes.interrupt"
+        ) as mock_interrupt:
+            mock_interrupt.return_value = "answers"
+
+            ask_user_question.func(
+                runtime=self._runtime(),
+                questions=[
+                    {"question": "Which pages?", "options": ["All"]},
+                    {"question": "What style?", "ui_related": True},
+                ],
+                context="Phase 1: Clarify",
+            )
+
+            payload = mock_interrupt.call_args[0][0]
+            assert payload["type"] == "user_question"
+            assert len(payload["questions"]) == 2
+            assert payload["questions"][1]["ui_related"] is True
+            # Legacy mirror of the FIRST question, so an old cached frontend that
+            # doesn't know about `questions` still shows something real.
+            assert payload["question"] == "Which pages?"
+            assert payload["options"] == ["All"]
+            assert payload["ui_related"] is False
+
+    def test_legacy_single_call_still_fires_the_same_shape(self):
+        from app.agents.leonardo.rails_plan_mode_agent.nodes import ask_user_question
+
+        with patch(
+            "app.agents.leonardo.rails_plan_mode_agent.nodes.interrupt"
+        ) as mock_interrupt:
+            mock_interrupt.return_value = "Checkout"
+
+            result = ask_user_question.func(
+                runtime=self._runtime(),
+                question="Which pages?",
+                options=["All", "Checkout"],
+                ui_related=True,
+            )
+
+            payload = mock_interrupt.call_args[0][0]
+            assert payload["question"] == "Which pages?"
+            assert payload["ui_related"] is True
+            assert payload["questions"] == [
+                {"question": "Which pages?", "options": ["All", "Checkout"], "ui_related": True}
+            ]
+
+            assert isinstance(result, Command)
+            assert "Checkout" in result.update["messages"][0].content
+
+    def test_overflow_note_reaches_the_model(self):
+        """Dropped questions must be visible to the agent, or they're silently lost."""
+        from app.agents.leonardo.rails_plan_mode_agent.nodes import ask_user_question
+
+        with patch(
+            "app.agents.leonardo.rails_plan_mode_agent.nodes.interrupt"
+        ) as mock_interrupt:
+            mock_interrupt.return_value = "ok"
+
+            result = ask_user_question.func(
+                runtime=self._runtime(),
+                questions=[{"question": f"Q{i}?"} for i in range(6)],
+            )
+
+            content = result.update["messages"][0].content
+            assert "not shown to the user" in content
+            assert "next turn" in content
+
+    def test_empty_questions_does_not_hang_the_graph(self):
+        """No question at all must return a ToolMessage, never a live interrupt."""
+        from app.agents.leonardo.rails_plan_mode_agent.nodes import ask_user_question
+
+        with patch(
+            "app.agents.leonardo.rails_plan_mode_agent.nodes.interrupt"
+        ) as mock_interrupt:
+            result = ask_user_question.func(runtime=self._runtime(), questions=[])
+
+            mock_interrupt.assert_not_called()
+            message = result.update["messages"][0]
+            assert isinstance(message, ToolMessage)
+            assert message.tool_call_id == "tool_call_abc"
+            assert "ask_user_question" in message.content
+
+
+class TestCheckAndSendInterruptsBatched:
+    """The WebSocket frame the frontend actually receives."""
+
+    async def _send(self, interrupt_value):
+        from app.websocket.request_handler import RequestHandler
+
+        handler = RequestHandler.__new__(RequestHandler)
+        handler._connection_locks = {}
+        handler._is_websocket_open = MagicMock(return_value=True)
+
+        mock_interrupt = MagicMock()
+        mock_interrupt.value = interrupt_value
+
+        mock_task = MagicMock()
+        mock_task.interrupts = [mock_interrupt]
+
+        mock_state_snapshot = MagicMock()
+        mock_state_snapshot.tasks = [mock_task]
+
+        mock_app = AsyncMock()
+        mock_app.aget_state = AsyncMock(return_value=mock_state_snapshot)
+
+        mock_websocket = AsyncMock()
+        message_data = {"thread_id": "thread_123", "agent_name": "rails_plan_mode_agent"}
+
+        result = await handler._check_and_send_interrupts(
+            mock_app, {}, message_data, mock_websocket
+        )
+        return result, mock_websocket.send_json.call_args[0][0]
+
+    @pytest.mark.asyncio
+    async def test_questions_batch_is_forwarded(self):
+        questions = [
+            {"question": "Which pages?", "options": ["All"], "ui_related": False},
+            {"question": "What style?", "options": [], "ui_related": True},
+        ]
+
+        handled, sent = await self._send({
+            "type": "user_question",
+            "questions": questions,
+            "question": "Which pages?",
+            "options": ["All"],
+            "ui_related": False,
+            "context": "Phase 1: Clarify",
+        })
+
+        assert handled is True
+        assert sent["type"] == "question_request"
+        assert sent["questions"] == questions
+        assert sent["question"] == "Which pages?"
+        assert sent["thread_id"] == "thread_123"
+
+    @pytest.mark.asyncio
+    async def test_missing_questions_defaults_to_empty_list(self):
+        """An interrupt written before batching existed must still render."""
+        handled, sent = await self._send({
+            "type": "user_question",
+            "question": "Which pages?",
+            "options": ["All"],
+        })
+
+        assert handled is True
+        assert sent["questions"] == []
+        assert sent["question"] == "Which pages?"
+
+
+class TestBatchingSurvivesMothershipPromptOverride:
+    """The bug that made batching look broken on a live box.
+
+    The mothership ships its own copy of the plan-mode prompts, and
+    resolve_base_prompt prefers it over the constant in prompts.py. That cached copy
+    still says "CRITICAL: One question per turn. Do NOT ask multiple questions at
+    once." — so editing prompts.py alone changed nothing the model ever saw.
+
+    The batching directive is appended AFTER the resolved base prompt, so it lands
+    after a mothership override too. These tests fail if anyone moves it back into
+    the constant.
+    """
+
+    MODES = [
+        ("app.agents.leonardo.rails_plan_mode_agent.nodes", "rails_plan_mode_agent"),
+        ("app.agents.leonardo.rails_engineer_plan_mode_agent.nodes", "rails_engineer_plan_mode_agent"),
+        ("app.agents.leonardo.rails_ticket_plan_mode_agent.nodes", "rails_ticket_plan_mode_agent"),
+    ]
+
+    @pytest.mark.parametrize("module_path,agent_mode", MODES)
+    def test_directive_survives_a_stale_mothership_prompt(self, module_path, agent_mode):
+        import importlib
+
+        module = importlib.import_module(module_path)
+
+        # A mothership override that actively forbids batching — the real situation.
+        stale = (
+            "You are Leo.\n\n**CRITICAL: One question per turn.** Do NOT ask multiple "
+            "questions at once. Ask one, wait for the answer, then ask the next one.\n"
+        ) + ("filler to clear the minimum-length guard. " * 200)
+
+        with patch(
+            "app.agents.leonardo.project_context.system_prompt_cache.get_cached",
+            return_value=stale,
+        ):
+            prompt = module.get_cached_system_prompt().content[0]["text"]
+
+        # The stale override really is in play (otherwise this test proves nothing).
+        assert "One question per turn" in prompt
+
+        # ...and the batching directive still reaches the model, after it.
+        assert "questions` list and shows 2-4 questions on a single card" in prompt
+        assert "supersedes any instruction above" in prompt
+        assert prompt.index("One question per turn") < prompt.index("supersedes any instruction above")
+
+    @pytest.mark.parametrize("module_path,agent_mode", MODES)
+    def test_directive_present_without_an_override(self, module_path, agent_mode):
+        import importlib
+
+        module = importlib.import_module(module_path)
+
+        with patch(
+            "app.agents.leonardo.project_context.system_prompt_cache.get_cached",
+            return_value=None,
+        ):
+            prompt = module.get_cached_system_prompt().content[0]["text"]
+
+        assert "Default to batching" in prompt
+        assert "do not re-ask those" in prompt

--- a/app/tests/test_beginner_agent_transient_retry.py
+++ b/app/tests/test_beginner_agent_transient_retry.py
@@ -54,7 +54,7 @@ def _no_backoff(monkeypatch):
     monkeypatch.setattr(res.time, "sleep", lambda *_: None)
     # Isolate the retry behavior from prompt/brand/skill machinery.
     monkeypatch.setattr(nb, "get_sys_msg", lambda: {"role": "system", "content": "sys"})
-    monkeypatch.setattr(nb, "repair_orphaned_tool_calls_in_messages", lambda m: m)
+    monkeypatch.setattr(nb, "normalize_messages_for_provider", lambda m: m)
 
 
 def test_beginner_node_retries_transient_then_succeeds(monkeypatch):

--- a/app/tests/test_context_management_all_agents.py
+++ b/app/tests/test_context_management_all_agents.py
@@ -1,0 +1,270 @@
+"""Backstop tests for context management across ALL Leonardo agents.
+
+2026-08-23 fleet telemetry: `rails_beginner_agent` was the ONLY Rails mode whose
+`nodes.py` never wired `make_summarization_middleware`. It is a raw `StateGraph`
+node that calls `llm_with_tools.invoke(messages)` directly, so no
+`AgentMiddleware` ever runs and nothing trims or summarizes. Measured
+consequences over 14 days: p90 input tokens 655k (every other mode sits under
+210k), 24.1% of its turns over 400k, 32 of 33 all-time
+`maximum context length is 1048576 tokens` crashes, and 63% of fleet input token
+spend from 44% of turns.
+
+These tests assert two things:
+
+1. STRUCTURAL backstop (the real guarantee): every Leonardo agent `nodes.py`
+   that builds a customer-facing workflow is wired for context management —
+   either through `build_leonardo_agent` (which carries the summarization
+   middleware the mode passes it) or through the shared
+   `compact_messages_if_needed()` helper for raw `StateGraph` nodes. The
+   property is asserted over an enumerated glob, never a hard-coded pass list,
+   so the *next* mode we add cannot repeat this.
+2. BEHAVIOUR: the compaction the raw nodes call actually brings an oversized
+   history back under the threshold, and the node persists that compaction
+   instead of paying for it again on every model call.
+
+Note on the fix that was chosen: the ticket offered (a) rebuild beginner mode on
+`create_agent`, or (b) call the same summarization code path from the raw node.
+(b) shipped, because its objection to (b) — "a second implementation of the same
+rule" — does not apply to `compact_messages_if_needed()`: that is a thin adapter
+over the very same `RailsSummarizationMiddleware` instance the create_agent modes
+run, and it fixes all THREE raw-node modes rather than only beginner. Rebuilding
+the mode 44% of customer turns live in, one release before shipping, bought
+nothing extra for THIS bug.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+from langchain_core.language_models.chat_models import BaseChatModel
+from langchain_core.messages import AIMessage, HumanMessage
+from langchain_core.outputs import ChatGeneration, ChatResult
+
+from app.agents.leonardo.summarization import RailsSummarizationMiddleware
+from app.agents.utils.token_counter import SUMMARIZATION_TOKEN_THRESHOLD
+
+LEONARDO_DIR = Path(__file__).resolve().parents[1] / "agents" / "leonardo"
+
+# Every Leonardo graph registered in app/langgraph.json. Guards the glob below
+# against silently scanning nothing.
+LEONARDO_GRAPH_KEYS = [
+    "rails_agent",
+    "rails_ai_builder_agent",
+    "rails_testing_agent",
+    "rails_ticket_mode_agent",
+    "rails_ticket_plan_mode_agent",
+    "rails_user_mode_agent",
+    "rails_beginner_agent",
+    "rails_plan_mode_agent",
+    "rails_engineer_plan_mode_agent",
+    "pyxl_agent",
+]
+
+
+def _agent_nodes_files():
+    return sorted(LEONARDO_DIR.glob("*/nodes.py"))
+
+
+# --------------------------------------------------------------------------
+# 1. Structural backstop
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "nodes_file", _agent_nodes_files(), ids=lambda p: p.parent.name
+)
+def test_every_leonardo_agent_has_context_management(nodes_file):
+    """A mode with no ceiling on its history reaches the provider's wall."""
+    text = nodes_file.read_text()
+    code = "\n".join(line.split("#", 1)[0] for line in text.splitlines())
+
+    uses_factory = "build_leonardo_agent(" in code
+    uses_raw_create_agent = bool(re.search(r"\bcreate_agent\(", code))
+    uses_stategraph = "StateGraph(" in code
+
+    if not (uses_factory or uses_raw_create_agent or uses_stategraph):
+        pytest.skip(f"{nodes_file.parent.name} does not construct an agent")
+
+    if uses_raw_create_agent and not uses_factory:
+        pytest.fail(
+            f"{nodes_file.parent.name} calls create_agent() directly — use "
+            f"build_leonardo_agent() so the cross-cutting middleware is wired."
+        )
+
+    if uses_factory:
+        assert "make_summarization_middleware" in code, (
+            f"{nodes_file.parent.name} builds an agent through the factory but "
+            f"passes no summarization middleware, so its history has no ceiling."
+        )
+        return
+
+    # Raw StateGraph path: must compact before handing messages to the model.
+    assert "compact_messages_if_needed" in code, (
+        f"{nodes_file.parent.name} is a raw StateGraph agent that invokes the "
+        f"model directly but never calls compact_messages_if_needed() — nothing "
+        f"trims or summarizes it, so it climbs to the provider's context wall."
+    )
+
+
+def test_scan_covers_all_registered_leonardo_graphs():
+    present = {p.parent.name for p in _agent_nodes_files()}
+    missing = [k for k in LEONARDO_GRAPH_KEYS if k not in present]
+    assert not missing, f"registered Leonardo graphs missing a nodes.py: {missing}"
+
+
+# --------------------------------------------------------------------------
+# 2. Behaviour — beginner mode actually compacts
+# --------------------------------------------------------------------------
+
+class _FakeSummaryModel(BaseChatModel):
+    @property
+    def _llm_type(self):
+        return "fake-summary"
+
+    def _generate(self, messages, stop=None, run_manager=None, **kwargs):
+        return ChatResult(
+            generations=[ChatGeneration(message=AIMessage(content="SUMMARY"))]
+        )
+
+
+def _tokens_of(n_tokens: int) -> str:
+    # The production counter is roughly 4 chars/token for plain ASCII.
+    return "word " * (n_tokens // 2)
+
+
+def _oversized_history(total_tokens=400_000, per_message=20_000):
+    msgs = [HumanMessage(content="Build me a booking site", id="h1")]
+    for i in range(total_tokens // per_message):
+        msgs.append(AIMessage(content=_tokens_of(per_message), id=f"a{i}"))
+    return msgs
+
+
+@pytest.fixture
+def fake_compactor(monkeypatch):
+    """The real middleware, with only the summarizing LLM faked out."""
+    import app.agents.leonardo.summarization as summ
+
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "k")
+    summ._COMPACTOR_CACHE.clear()
+    real = summ.make_summarization_middleware
+
+    built = []
+
+    def _build(**kwargs):
+        mw = real(**kwargs)
+        mw.model = _FakeSummaryModel()
+        built.append(mw)
+        return mw
+
+    monkeypatch.setattr(summ, "make_summarization_middleware", _build)
+    yield built
+    summ._COMPACTOR_CACHE.clear()
+
+
+class TestCompactMessagesIfNeeded:
+    def test_it_is_a_no_op_under_the_threshold(self, fake_compactor):
+        from app.agents.leonardo.summarization import compact_messages_if_needed
+
+        history = [HumanMessage(content="hi"), AIMessage(content="hello")]
+        out, ops = compact_messages_if_needed(history, summary_prompt="S {messages}")
+
+        assert out == history
+        assert ops == [], "a short thread must never write a compaction to state"
+
+    def test_it_brings_an_oversized_history_under_the_threshold(self, fake_compactor):
+        from app.agents.leonardo.summarization import compact_messages_if_needed
+
+        history = _oversized_history()
+        out, ops = compact_messages_if_needed(history, summary_prompt="S {messages}")
+
+        counter = fake_compactor[0]
+        assert counter._count(history) > SUMMARIZATION_TOKEN_THRESHOLD
+        after = counter._count(out)
+        assert after < SUMMARIZATION_TOKEN_THRESHOLD, (
+            f"history still {after} tokens after compaction "
+            f"(threshold {SUMMARIZATION_TOKEN_THRESHOLD}) — the turn would reach "
+            f"the provider oversized"
+        )
+
+    def test_it_returns_ops_that_persist_the_compaction(self, fake_compactor):
+        """Without persisting, the node re-summarizes on every model call."""
+        from langchain_core.messages import RemoveMessage
+        from langgraph.graph.message import REMOVE_ALL_MESSAGES
+        from app.agents.leonardo.summarization import compact_messages_if_needed
+
+        _, ops = compact_messages_if_needed(
+            _oversized_history(), summary_prompt="S {messages}"
+        )
+        assert ops, "compaction produced no state write"
+        assert isinstance(ops[0], RemoveMessage)
+        assert ops[0].id == REMOVE_ALL_MESSAGES
+        assert [m for m in ops if not isinstance(m, RemoveMessage)]
+
+    def test_a_broken_compaction_never_kills_the_turn(self, monkeypatch):
+        import app.agents.leonardo.summarization as summ
+
+        summ._COMPACTOR_CACHE.clear()
+        monkeypatch.setattr(
+            summ, "make_summarization_middleware",
+            lambda **kw: (_ for _ in ()).throw(RuntimeError("no provider key")),
+        )
+        history = _oversized_history()
+        out, ops = summ.compact_messages_if_needed(history, summary_prompt="S")
+        assert out == history and ops == []
+        summ._COMPACTOR_CACHE.clear()
+
+
+class TestBeginnerNodeCompacts:
+    """The mode 44% of customer turns live in, end to end through the node."""
+
+    def _run(self, monkeypatch, history):
+        import app.agents.leonardo.rails_beginner_agent.nodes as nb
+
+        captured = {}
+
+        class _Bound:
+            def invoke(self, messages, **kw):
+                captured["messages"] = messages
+                return AIMessage(content="ok")
+
+        class _Model:
+            def bind_tools(self, *a, **k):
+                return _Bound()
+
+            def invoke(self, messages, **kw):
+                return _Bound().invoke(messages)
+
+        monkeypatch.setattr(nb, "get_llm", lambda name: _Model())
+        monkeypatch.setattr(nb, "get_sys_msg", lambda: {"role": "system", "content": "sys"})
+        monkeypatch.setattr(nb, "normalize_messages_for_provider", lambda m: m)
+
+        out = nb.leonardo_beginner({"messages": history})
+        return captured["messages"], out
+
+    def test_the_model_never_sees_an_oversized_history(self, monkeypatch, fake_compactor):
+        history = _oversized_history()
+        sent, _ = self._run(monkeypatch, history)
+
+        counter = fake_compactor[0]
+        assert counter._count(history) > SUMMARIZATION_TOKEN_THRESHOLD
+        # The system message rides along; count only the conversation.
+        conversation = [m for m in sent if not isinstance(m, dict)]
+        after = counter._count(conversation)
+        assert after < SUMMARIZATION_TOKEN_THRESHOLD, (
+            f"beginner mode handed the provider {after} tokens"
+        )
+
+    def test_the_compaction_is_written_back_to_state(self, monkeypatch, fake_compactor):
+        from langchain_core.messages import RemoveMessage
+
+        _, out = self._run(monkeypatch, _oversized_history())
+        assert any(isinstance(m, RemoveMessage) for m in out["messages"]), (
+            "the compaction was not persisted, so the next model call pays for "
+            "the whole summarization again"
+        )
+        assert out["messages"][-1].content == "ok"
+
+    def test_a_short_thread_is_left_completely_alone(self, monkeypatch, fake_compactor):
+        history = [HumanMessage(content="build me a page")]
+        _, out = self._run(monkeypatch, history)
+        assert len(out["messages"]) == 1
+        assert out["messages"][0].content == "ok"

--- a/app/tests/test_delegate_hang_reproduction.py
+++ b/app/tests/test_delegate_hang_reproduction.py
@@ -18,6 +18,13 @@ def _run_ticket_delegation(result_queue):
         async def ainvoke(self, *_args, **_kwargs):
             await asyncio.Event().wait()
 
+        # run_delegation streams (so a timeout can report partial work), so the
+        # stall has to happen inside astream — with only ainvoke here the tool
+        # fails on a missing attribute instead of reproducing the hang.
+        async def astream(self, *_args, **_kwargs):
+            await asyncio.Event().wait()
+            yield {}
+
     sub_agents.create_sub_agent = lambda **_kwargs: BlockingSubAgent()
 
     # The fixed tool delegates timeout ownership to the shared runtime. Keep the
@@ -82,8 +89,12 @@ def test_ticket_delegate_task_recovers_from_a_blocked_sub_agent():
     while result is None:
         item = result_queue.get(timeout=1)
         result = item.get("result")
-    assert "[DELEGATED TASK FAILED]" in result["content"]
-    assert "Timed out" in result["content"]
+    # A deadline is its own outcome, not a generic failure: the tool has to say
+    # the run ran out of time AND hand back whatever the sub-agent finished, so
+    # the caller picks up from there instead of redoing the work.
+    assert "[DELEGATED TASK TIMED OUT]" in result["content"]
+    assert "ran out of time" in result["content"]
+    assert "No record of what the sub-agent did" in result["content"]
     assert result["failed_tool_calls_count"] == 1
 
 

--- a/app/tests/test_delegate_runtime.py
+++ b/app/tests/test_delegate_runtime.py
@@ -1,17 +1,37 @@
-"""Regression coverage for cancellable, observable sub-agent delegation."""
+"""Regression coverage for cancellable, observable sub-agent delegation.
+
+2026-08-23 (P1-5): the timeout itself was never the damage — the silence was.
+`delegate_task` returned "Timed out after 240s — you may retry delegate_task
+once" and nothing else, with no changed-file list, so the parent agent had to
+re-read the tree or retry and edit the same files twice. 6 reports, 3 boxes,
+three of them in one session on one box.
+
+The run is streamed rather than `ainvoke`d for exactly this reason: whatever the
+last completed step left behind is still in hand when the deadline fires.
+"""
 
 import asyncio
 
 import pytest
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 
-from app.agents.leonardo.delegation import DelegationTimedOut, run_delegation
+from app.agents.leonardo.delegation import (
+    DelegationTimedOut,
+    run_delegation,
+    summarize_partial_work,
+)
 
 
 class _BlockingAgent:
-    def __init__(self):
-        self.cancelled = False
+    """Emits some state, then hangs — the shape of a real timeout."""
 
-    async def ainvoke(self, input_data, config=None):
+    def __init__(self, chunks=()):
+        self.cancelled = False
+        self.chunks = list(chunks)
+
+    async def astream(self, input_data, config=None, stream_mode=None):
+        for chunk in self.chunks:
+            yield chunk
         try:
             await asyncio.Event().wait()
         except asyncio.CancelledError:
@@ -20,8 +40,8 @@ class _BlockingAgent:
 
 
 class _SuccessfulAgent:
-    async def ainvoke(self, input_data, config=None):
-        return {"messages": ["done"]}
+    async def astream(self, input_data, config=None, stream_mode=None):
+        yield {"messages": ["done"]}
 
 
 @pytest.mark.asyncio
@@ -67,8 +87,9 @@ async def test_delegation_success_preserves_result_and_emits_completed():
 @pytest.mark.asyncio
 async def test_delegation_failure_emits_failed_and_reraises():
     class _FailingAgent:
-        async def ainvoke(self, input_data, config=None):
+        async def astream(self, input_data, config=None, stream_mode=None):
             raise RuntimeError("provider exploded")
+            yield  # pragma: no cover
 
     events = []
     with pytest.raises(RuntimeError, match="provider exploded"):
@@ -80,3 +101,112 @@ async def test_delegation_failure_emits_failed_and_reraises():
         )
 
     assert events[-1]["phase"] == "failed"
+
+
+# ---------------------------------------------------------------------------
+# The partial report
+# ---------------------------------------------------------------------------
+
+def _work_history():
+    return [
+        HumanMessage(content="add a Lead model with CRUD"),
+        AIMessage(content="", tool_calls=[
+            {"name": "write_file", "id": "c1",
+             "args": {"file_path": "db/migrate/20260823_create_leads.rb", "content": "..."}},
+        ]),
+        ToolMessage(content="Updated file db/migrate/20260823_create_leads.rb", tool_call_id="c1"),
+        AIMessage(content="", tool_calls=[
+            {"name": "bash_command", "id": "c2",
+             "args": {"command": "bin/rails db:migrate"}},
+        ]),
+        ToolMessage(content="Command output:\n== migrated", tool_call_id="c2"),
+        AIMessage(content="", tool_calls=[
+            {"name": "edit_file", "id": "c3",
+             "args": {"file_path": "app/views/leads/index.html.erb",
+                      "old_string": "x", "new_string": "y"}},
+        ]),
+        # No ToolMessage for c3 — this is where the deadline hit.
+    ]
+
+
+class TestSummarizePartialWork:
+    def test_it_lists_the_files_it_touched(self):
+        out = summarize_partial_work(_work_history())
+        assert "db/migrate/20260823_create_leads.rb" in out
+
+    def test_it_lists_the_commands_it_ran(self):
+        out = summarize_partial_work(_work_history())
+        assert "bin/rails db:migrate" in out
+
+    def test_it_names_the_step_that_was_in_flight(self):
+        out = summarize_partial_work(_work_history())
+        assert "In progress" in out
+        assert "app/views/leads/index.html.erb" in out
+
+    def test_a_failed_call_is_flagged_so_the_parent_does_not_trust_it(self):
+        history = [
+            AIMessage(content="", tool_calls=[
+                {"name": "edit_file", "id": "c1", "args": {"file_path": "app/models/x.rb"}},
+            ]),
+            ToolMessage(content="Error: Could not find old_string in file", tool_call_id="c1"),
+        ]
+        out = summarize_partial_work(history)
+        assert "app/models/x.rb" in out
+        assert "reported an error" in out
+
+    def test_it_says_so_when_nothing_had_happened_yet(self):
+        out = summarize_partial_work([HumanMessage(content="go")])
+        assert "had not written any files" in out
+
+    def test_it_survives_an_empty_history(self):
+        assert summarize_partial_work([])
+        assert summarize_partial_work(None)
+
+    def test_it_is_bounded(self):
+        history = []
+        for i in range(200):
+            history.append(AIMessage(content="", tool_calls=[
+                {"name": "write_file", "id": f"c{i}", "args": {"file_path": f"app/models/m{i}.rb"}},
+            ]))
+            history.append(ToolMessage(content="Updated", tool_call_id=f"c{i}"))
+        out = summarize_partial_work(history)
+        assert "and 175 more" in out
+
+
+@pytest.mark.asyncio
+async def test_the_timeout_carries_the_partial_work_to_the_caller():
+    agent = _BlockingAgent(chunks=[{"messages": _work_history()}])
+
+    with pytest.raises(DelegationTimedOut) as excinfo:
+        await run_delegation(
+            agent, {"messages": []}, timeout_seconds=0.02, heartbeat_seconds=0.01,
+        )
+
+    report = summarize_partial_work(excinfo.value.partial_messages)
+    assert "db/migrate/20260823_create_leads.rb" in report
+
+
+@pytest.mark.asyncio
+async def test_delegate_task_returns_the_report_instead_of_nothing(monkeypatch):
+    """End to end through the tool the agent actually calls."""
+    from app.agents.leonardo.rails_agent import sub_agents
+
+    async def _timeout(*a, **k):
+        raise DelegationTimedOut("timed out after 240s", partial_messages=_work_history())
+
+    monkeypatch.setattr(sub_agents, "run_delegation", _timeout)
+    monkeypatch.setattr(sub_agents, "create_sub_agent", lambda llm_model=None: object())
+
+    class _Runtime:
+        tool_call_id = "call_1"
+        state = {"llm_model": "deepseek-v4-flash"}
+        config = {}
+        stream_writer = None
+
+    command = await sub_agents.delegate_task.coroutine(
+        task_description="build it", runtime=_Runtime(),
+    )
+    content = command.update["messages"][0].content
+
+    assert "db/migrate/20260823_create_leads.rb" in content
+    assert "do NOT redo it" in content

--- a/app/tests/test_delegate_tools.py
+++ b/app/tests/test_delegate_tools.py
@@ -2,6 +2,8 @@ from types import SimpleNamespace
 
 import pytest
 
+from langchain_core.messages import AIMessage, ToolMessage
+
 from app.agents.leonardo.delegation import DelegationTimedOut
 
 
@@ -9,9 +11,9 @@ from app.agents.leonardo.delegation import DelegationTimedOut
 @pytest.mark.parametrize(
     ("module_name", "failure_marker"),
     [
-        ("app.agents.leonardo.rails_agent.sub_agents", "[DELEGATED TASK FAILED]"),
-        ("app.agents.leonardo.rails_ticket_mode_agent.sub_agents", "[DELEGATED TASK FAILED]"),
-        ("app.agents.leonardo.rails_user_feedback_agent.sub_agents", "[DELEGATED RESEARCH FAILED]"),
+        ("app.agents.leonardo.rails_agent.sub_agents", "[DELEGATED TASK TIMED OUT]"),
+        ("app.agents.leonardo.rails_ticket_mode_agent.sub_agents", "[DELEGATED TASK TIMED OUT]"),
+        ("app.agents.leonardo.rails_user_feedback_agent.sub_agents", "[DELEGATED RESEARCH TIMED OUT]"),
     ],
 )
 async def test_delegate_task_timeout_returns_recoverable_tool_message(
@@ -20,7 +22,13 @@ async def test_delegate_task_timeout_returns_recoverable_tool_message(
     module = __import__(module_name, fromlist=["sub_agents"])
 
     async def time_out(*args, **kwargs):
-        raise DelegationTimedOut("timed out after 240s")
+        raise DelegationTimedOut("timed out after 240s", partial_messages=[
+            AIMessage(content="", tool_calls=[
+                {"name": "write_file", "id": "c1",
+                 "args": {"file_path": "app/models/lead.rb", "content": "..."}},
+            ]),
+            ToolMessage(content="Updated file app/models/lead.rb", tool_call_id="c1"),
+        ])
 
     monkeypatch.setattr(module, "create_sub_agent", lambda **_: object())
     monkeypatch.setattr(module, "run_delegation", time_out)
@@ -38,6 +46,8 @@ async def test_delegate_task_timeout_returns_recoverable_tool_message(
     assert command.update["failed_tool_calls_count"] == 1
     message = command.update["messages"][0]
     assert failure_marker in message.content
-    assert "Timed out after 240s" in message.content
-    assert "retry" in message.content
+    assert "ran out of time after 240s" in message.content
+    # A timeout must hand back what the sub-agent DID, not just that it stopped:
+    # otherwise the parent re-reads the tree or edits the same files twice.
+    assert "app/models/lead.rb" in message.content
     assert message.tool_call_id == "call-1"

--- a/app/tests/test_delegation_progress_stream.py
+++ b/app/tests/test_delegation_progress_stream.py
@@ -55,6 +55,9 @@ async def test_real_langgraph_progress_reaches_thread_scoped_websocket():
         async def ainvoke(self, _input, config=None):
             return payload_result
 
+        async def astream(self, _input, config=None, stream_mode=None):
+            yield payload_result
+
     async def delegate_node(state):
         await run_delegation(
             SuccessfulNestedAgent(),

--- a/app/tests/test_edit_file_truthfulness.py
+++ b/app/tests/test_edit_file_truthfulness.py
@@ -1,0 +1,197 @@
+"""`edit_file` must never report a success that did not happen.
+
+2026-08-23, 8 friction reports across 6 boxes in 30 days — the most dangerous
+item on /admin/agent_friction, because the agent believes the fix landed, tells
+the customer it landed, and moves on. Verbatim:
+
+  "edit_file reported 'Successfully replaced string' for a batch edit that never
+   actually persisted in the file. The missing code caused a ReferenceError that
+   blanked the Sales Funnel page in the user's browser."
+
+  "reported success ('match type: normalized') but the change did not persist."
+
+  "the resulting file was corrupted (a mid-string truncation in an unrelated
+   method)."
+
+Two distinct bugs, both reproduced here:
+
+1. The `normalized` path replaced the WHITESPACE-NORMALIZED old_string, which by
+   definition is usually not present in the raw file. `str.replace` matched
+   nothing, the unchanged content was written back, and the tool said
+   "Successfully replaced string (match type: normalized)".
+2. Two `fuzzy` rungs accepted difflib's longest common substring when it covered
+   >50-70% of old_string. That is not a match; it lands mid-string in unrelated
+   code and truncates it.
+
+The concurrent-same-file race from the same report set is covered by
+test_file_tool_concurrent_edits.py (fixed 2026-08-12 with a per-path lock).
+"""
+
+import pytest
+
+from app.agents.leonardo.rails_agent import tools
+
+
+class _Runtime:
+    tool_call_id = "call_1"
+
+
+@pytest.fixture
+def rails_root(tmp_path, monkeypatch):
+    root = tmp_path / "rails"
+    (root / "app" / "views").mkdir(parents=True)
+    (root / "db" / "migrate").mkdir(parents=True)
+    monkeypatch.setattr(tools, "RAILS_ROOT", root)
+    monkeypatch.setattr(tools, "PROJECT_ROOT", tmp_path)
+    # No Rails container in the test environment.
+    monkeypatch.setattr(tools, "migration_followup", lambda _p: "")
+    return root
+
+
+def _edit(path, old, new, replace_all=False):
+    return tools.edit_file.func(
+        file_path=path, old_string=old, new_string=new,
+        replace_all=replace_all, runtime=_Runtime(),
+    ).update["messages"][0].content
+
+
+def _write(path, content):
+    return tools.write_file.func(
+        file_path=path, content=content, runtime=_Runtime(),
+    ).update["messages"][0].content
+
+
+# ---------------------------------------------------------------------------
+# The silent no-op
+# ---------------------------------------------------------------------------
+
+class TestNormalizedMatchActuallyEdits:
+    def test_a_whitespace_only_mismatch_edits_the_real_bytes(self, rails_root):
+        target = rails_root / "app" / "views" / "funnel.html.erb"
+        target.write_text('<div>\n  <span   class="a">hi</span>\n</div>\n')
+
+        # Same text, single-spaced — the exact shape that took the normalized path.
+        out = _edit(
+            "app/views/funnel.html.erb",
+            '<span class="a">hi</span>',
+            '<span class="b">bye</span>',
+        )
+
+        assert "Successfully replaced" in out
+        content = target.read_text()
+        assert 'class="b">bye' in content, (
+            "reported success but the file is unchanged — this is the bug that "
+            "blanked a customer's page"
+        )
+        assert 'class="a">hi' not in content
+
+    def test_indentation_differences_still_match(self, rails_root):
+        target = rails_root / "app" / "views" / "a.erb"
+        target.write_text("class Foo\n  def bar\n    puts 'hi'\n  end\nend\n")
+
+        _edit("app/views/a.erb", "def bar\n  puts 'hi'\nend", "def bar\n  puts 'bye'\nend")
+        assert "bye" in target.read_text()
+
+    def test_an_ambiguous_normalized_match_is_refused(self, rails_root):
+        """Two candidate regions: picking one silently edits the wrong method."""
+        target = rails_root / "app" / "views" / "b.erb"
+        target.write_text("<p>hello</p>\n<p>hello</p>\n")
+
+        out = _edit("app/views/b.erb", "<p>hello</p>\n", "<p>bye</p>\n")
+        assert "Could not find" in out or "appears" in out
+        assert target.read_text() == "<p>hello</p>\n<p>hello</p>\n"
+
+
+class TestNoSuccessWithoutAChange:
+    def test_an_edit_that_changes_nothing_is_an_error(self, rails_root):
+        target = rails_root / "app" / "views" / "c.erb"
+        target.write_text("<p>same</p>\n")
+
+        out = _edit("app/views/c.erb", "<p>same</p>", "<p>same</p>")
+        assert "Successfully" not in out
+        assert "would not change" in out
+
+    def test_a_write_that_does_not_persist_is_reported(self, rails_root, monkeypatch):
+        target = rails_root / "app" / "views" / "d.erb"
+        target.write_text("original\n")
+
+        # Simulate the disk not holding what we wrote (permissions, a mount, a
+        # racing writer) — the tool must not claim success.
+        monkeypatch.setattr(
+            tools.Path, "write_text", lambda self, *_a, **_k: None, raising=False
+        )
+        out = _edit("app/views/d.erb", "original", "changed")
+        assert "did NOT persist" in out
+        assert "Successfully" not in out
+
+    def test_write_file_verifies_too(self, rails_root, monkeypatch):
+        monkeypatch.setattr(
+            tools.Path, "write_text", lambda self, *_a, **_k: None, raising=False
+        )
+        out = _write("app/views/e.erb", "hello")
+        assert "did NOT persist" in out
+
+
+# ---------------------------------------------------------------------------
+# The corruption
+# ---------------------------------------------------------------------------
+
+class TestNoFuzzyCorruption:
+    def test_a_string_that_is_not_in_the_file_is_refused(self, rails_root):
+        """Previously: difflib's longest common substring was 'close enough',
+        and the replacement landed in unrelated code."""
+        target = rails_root / "app" / "views" / "f.erb"
+        original = (
+            "def calculate_total(items)\n"
+            "  items.sum(&:price)\n"
+            "end\n"
+            "\n"
+            "def calculate_tax(items)\n"
+            "  items.sum(&:tax)\n"
+            "end\n"
+        )
+        target.write_text(original)
+
+        out = _edit(
+            "app/views/f.erb",
+            "def calculate_total(items)\n  items.map(&:price).reduce(:+)\nend",
+            "def calculate_total(items)\n  0\nend",
+        )
+
+        assert "Could not find old_string" in out
+        assert target.read_text() == original, "the file was modified by a non-match"
+
+    def test_the_failure_message_tells_the_agent_what_to_do(self, rails_root):
+        target = rails_root / "app" / "views" / "g.erb"
+        target.write_text("<p>a</p>\n")
+
+        out = _edit("app/views/g.erb", "<p>totally different</p>", "<p>b</p>")
+        assert "read_file" in out
+
+
+# ---------------------------------------------------------------------------
+# The span mapping itself
+# ---------------------------------------------------------------------------
+
+class TestLocateNormalizedSpan:
+    def test_it_returns_the_raw_bytes_not_the_normalized_text(self):
+        content = 'a\n  <span   class="a">hi</span>\nb\n'
+        span = tools.locate_normalized_span(content, '<span class="a">hi</span>')
+        assert span is not None
+        assert content[span[0]:span[1]] == '<span   class="a">hi</span>'
+
+    def test_crlf_content_maps_back_correctly(self):
+        content = "line one\r\nline two\r\n"
+        span = tools.locate_normalized_span(content, "line one\nline two")
+        assert content[span[0]:span[1]] == "line one\r\nline two"
+
+    def test_blank_line_runs_map_back_correctly(self):
+        content = "top\n\n\n\nbottom\n"
+        span = tools.locate_normalized_span(content, "top\n\nbottom")
+        assert content[span[0]:span[1]] == "top\n\n\n\nbottom"
+
+    def test_no_match_returns_none(self):
+        assert tools.locate_normalized_span("abc", "xyz") is None
+
+    def test_ambiguous_returns_none(self):
+        assert tools.locate_normalized_span("abc abc", "abc") is None

--- a/app/tests/test_engineer_plan_mode.py
+++ b/app/tests/test_engineer_plan_mode.py
@@ -72,7 +72,7 @@ class TestEngineerPlanComposition:
         # Plan-first preamble.
         assert "Engineer Plan Mode" in ENGINEER_PLAN_PROMPT
         assert "6-PHASE WORKFLOW" in ENGINEER_PLAN_PROMPT
-        assert "One question per turn" in ENGINEER_PLAN_PROMPT
+        assert "Batch your questions" in ENGINEER_PLAN_PROMPT
         # Full engineer playbook is composed in (single source of truth).
         assert RAILS_AGENT_PROMPT in ENGINEER_PLAN_PROMPT
         # Therefore the softened voice flows through automatically.

--- a/app/tests/test_frontend_batched_questions_js.py
+++ b/app/tests/test_frontend_batched_questions_js.py
@@ -1,0 +1,23 @@
+"""Run the dependency-free Node test for the batched ask_user_question card."""
+
+import subprocess
+from pathlib import Path
+
+
+def test_batched_questions_node_suite():
+    app_root = Path(__file__).resolve().parents[1]
+    result = subprocess.run(
+        [
+            "node",
+            "--experimental-default-type=module",
+            "--test",
+            "tests/js/batched_questions.test.mjs",
+        ],
+        cwd=app_root,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode == 0, f"{result.stdout}\n{result.stderr}"

--- a/app/tests/test_frontend_github_autopoll_js.py
+++ b/app/tests/test_frontend_github_autopoll_js.py
@@ -1,0 +1,23 @@
+"""Run the dependency-free Node test for the /gh device-flow auto-poller."""
+
+import subprocess
+from pathlib import Path
+
+
+def test_github_device_autopoll_node_suite():
+    app_root = Path(__file__).resolve().parents[1]
+    result = subprocess.run(
+        [
+            "node",
+            "--experimental-default-type=module",
+            "--test",
+            "tests/js/github_device_autopoll.test.mjs",
+        ],
+        cwd=app_root,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode == 0, f"{result.stdout}\n{result.stderr}"

--- a/app/tests/test_frontend_inactivity_banner_js.py
+++ b/app/tests/test_frontend_inactivity_banner_js.py
@@ -1,0 +1,23 @@
+"""Run the dependency-free Node test for the disabled inactivity banner."""
+
+import subprocess
+from pathlib import Path
+
+
+def test_inactivity_banner_disabled_node_suite():
+    app_root = Path(__file__).resolve().parents[1]
+    result = subprocess.run(
+        [
+            "node",
+            "--experimental-default-type=module",
+            "--test",
+            "tests/js/inactivity_banner_disabled.test.mjs",
+        ],
+        cwd=app_root,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode == 0, f"{result.stdout}\n{result.stderr}"

--- a/app/tests/test_frontend_my_uploads_modal_js.py
+++ b/app/tests/test_frontend_my_uploads_modal_js.py
@@ -1,0 +1,23 @@
+"""Run the dependency-free Node test for the My Uploads / spreadsheet preview."""
+
+import subprocess
+from pathlib import Path
+
+
+def test_my_uploads_node_suite():
+    app_root = Path(__file__).resolve().parents[1]
+    result = subprocess.run(
+        [
+            "node",
+            "--experimental-default-type=module",
+            "--test",
+            "tests/js/my_uploads_opens_modal.test.mjs",
+        ],
+        cwd=app_root,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode == 0, f"{result.stdout}\n{result.stderr}"

--- a/app/tests/test_frontend_overlay_ads_js.py
+++ b/app/tests/test_frontend_overlay_ads_js.py
@@ -1,0 +1,23 @@
+"""Run the dependency-free Node test for the building-overlay promo slot."""
+
+import subprocess
+from pathlib import Path
+
+
+def test_overlay_ads_node_suite():
+    app_root = Path(__file__).resolve().parents[1]
+    result = subprocess.run(
+        [
+            "node",
+            "--experimental-default-type=module",
+            "--test",
+            "tests/js/overlay_ads.test.mjs",
+        ],
+        cwd=app_root,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode == 0, f"{result.stdout}\n{result.stderr}"

--- a/app/tests/test_frontend_overlay_chrome_js.py
+++ b/app/tests/test_frontend_overlay_chrome_js.py
@@ -1,0 +1,23 @@
+"""Run the dependency-free Node test for the building overlay's ad-vs-no-ad chrome."""
+
+import subprocess
+from pathlib import Path
+
+
+def test_overlay_chrome_node_suite():
+    app_root = Path(__file__).resolve().parents[1]
+    result = subprocess.run(
+        [
+            "node",
+            "--experimental-default-type=module",
+            "--test",
+            "tests/js/overlay_chrome_without_ads.test.mjs",
+        ],
+        cwd=app_root,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode == 0, f"{result.stdout}\n{result.stderr}"

--- a/app/tests/test_frontend_overlay_devtools_js.py
+++ b/app/tests/test_frontend_overlay_devtools_js.py
@@ -1,0 +1,23 @@
+"""Run the dependency-free Node test for the window.leoAds console helper."""
+
+import subprocess
+from pathlib import Path
+
+
+def test_overlay_devtools_node_suite():
+    app_root = Path(__file__).resolve().parents[1]
+    result = subprocess.run(
+        [
+            "node",
+            "--experimental-default-type=module",
+            "--test",
+            "tests/js/overlay_devtools.test.mjs",
+        ],
+        cwd=app_root,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode == 0, f"{result.stdout}\n{result.stderr}"

--- a/app/tests/test_frontend_rails_error_poll_js.py
+++ b/app/tests/test_frontend_rails_error_poll_js.py
@@ -1,0 +1,23 @@
+"""Run the dependency-free Node test for the Rails crash poller."""
+
+import subprocess
+from pathlib import Path
+
+
+def test_rails_error_poll_node_suite():
+    app_root = Path(__file__).resolve().parents[1]
+    result = subprocess.run(
+        [
+            "node",
+            "--experimental-default-type=module",
+            "--test",
+            "tests/js/rails_error_poll.test.mjs",
+        ],
+        cwd=app_root,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode == 0, f"{result.stdout}\n{result.stderr}"

--- a/app/tests/test_frontend_ws_attach_waits_for_auth_js.py
+++ b/app/tests/test_frontend_ws_attach_waits_for_auth_js.py
@@ -1,0 +1,23 @@
+"""Run the dependency-free Node test for the attach/auth handshake ordering."""
+
+import subprocess
+from pathlib import Path
+
+
+def test_ws_attach_waits_for_auth_node_suite():
+    app_root = Path(__file__).resolve().parents[1]
+    result = subprocess.run(
+        [
+            "node",
+            "--experimental-default-type=module",
+            "--test",
+            "tests/js/ws_attach_waits_for_auth.test.mjs",
+        ],
+        cwd=app_root,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode == 0, f"{result.stdout}\n{result.stderr}"

--- a/app/tests/test_message_invariants.py
+++ b/app/tests/test_message_invariants.py
@@ -55,7 +55,11 @@ class TestContentTypes:
         assert "weird_block" in blocks[0]["text"]
 
     def test_a_bare_object_in_a_content_list_becomes_text(self):
-        msgs = [HumanMessage(content=[{"type": "text", "text": "hi"}, 42])]
+        # model_construct, because pydantic refuses to BUILD this message — which
+        # is the point: the shape only ever arrives from state we did not
+        # construct (a checkpoint, a provider echo), and it still has to be fixed
+        # rather than raise on the way to the model.
+        msgs = [HumanMessage.model_construct(content=[{"type": "text", "text": "hi"}, 42])]
         out = normalize_messages_for_provider(msgs)
         assert [b["type"] for b in out[0].content] == ["text", "text"]
 

--- a/app/tests/test_message_invariants.py
+++ b/app/tests/test_message_invariants.py
@@ -1,0 +1,224 @@
+"""One validator every provider call passes through (P1-4, 2026-08-23).
+
+Three malformed-history shapes were still killing turns on customer boxes in 30
+days, and only one of them had a fix — implemented twice, once as a middleware
+and once by hand inside the raw StateGraph nodes. Two implementations of one rule
+means every new path starts out missing it, which is how the question-card resume
+path ended up unprotected.
+
+Also covers P1-3: our own default model returns a bare 400 with `'param': None`
+(32 occurrences, 7 boxes, 7 days) and we logged nothing about the request we sent.
+"""
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
+
+from app.agents.leonardo.message_invariants import (
+    describe_message_shape,
+    log_bad_request_shape,
+    looks_like_bad_request,
+    normalize_messages_for_provider,
+)
+
+
+class TestAtLeastOneUserOrToolMessage:
+    """`messages` must contain at least one message with role `user` or `tool` — 4 boxes."""
+
+    def test_a_history_of_only_system_and_assistant_gets_one(self):
+        out = normalize_messages_for_provider(
+            [SystemMessage(content="you are leo"), AIMessage(content="hi")]
+        )
+        assert any(m.type in ("human", "tool") for m in out)
+
+    def test_a_history_that_already_has_one_is_untouched(self):
+        msgs = [SystemMessage(content="s"), HumanMessage(content="hi")]
+        assert normalize_messages_for_provider(msgs) is msgs
+
+    def test_a_tool_message_counts(self):
+        msgs = [
+            AIMessage(content="", tool_calls=[{"name": "ls", "id": "c1", "args": {}}]),
+            ToolMessage(content="ok", tool_call_id="c1"),
+        ]
+        assert normalize_messages_for_provider(msgs) is msgs
+
+    def test_an_empty_history_is_left_alone(self):
+        assert normalize_messages_for_provider([]) == []
+
+
+class TestContentTypes:
+    """`messages[33].content` did not match any supported type."""
+
+    def test_an_unsupported_block_type_is_stringified_not_dropped(self):
+        msgs = [HumanMessage(content=[{"type": "weird_block", "payload": {"a": 1}}])]
+        out = normalize_messages_for_provider(msgs)
+        blocks = out[0].content
+        assert all(b["type"] == "text" for b in blocks)
+        assert "weird_block" in blocks[0]["text"]
+
+    def test_a_bare_object_in_a_content_list_becomes_text(self):
+        msgs = [HumanMessage(content=[{"type": "text", "text": "hi"}, 42])]
+        out = normalize_messages_for_provider(msgs)
+        assert [b["type"] for b in out[0].content] == ["text", "text"]
+
+    def test_supported_blocks_are_left_exactly_as_they_are(self):
+        blocks = [
+            {"type": "text", "text": "hi"},
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAA"}},
+        ]
+        msgs = [HumanMessage(content=list(blocks))]
+        out = normalize_messages_for_provider(msgs)
+        assert out[0].content == blocks
+
+    def test_a_plain_string_content_is_left_alone(self):
+        msgs = [HumanMessage(content="hello"), AIMessage(content="hi")]
+        assert normalize_messages_for_provider(msgs) is msgs
+
+
+class TestEmptyContent:
+    def test_an_empty_user_message_is_filled_in(self):
+        out = normalize_messages_for_provider([HumanMessage(content="")])
+        assert out[0].content.strip()
+
+    def test_an_assistant_turn_that_is_only_tool_calls_may_stay_empty(self):
+        msgs = [
+            HumanMessage(content="go"),
+            AIMessage(content="", tool_calls=[{"name": "ls", "id": "c1", "args": {}}]),
+            ToolMessage(content="ok", tool_call_id="c1"),
+        ]
+        out = normalize_messages_for_provider(msgs)
+        assert out[1].content == ""
+
+    def test_an_empty_tool_result_says_so(self):
+        msgs = [
+            HumanMessage(content="go"),
+            AIMessage(content="", tool_calls=[{"name": "ls", "id": "c1", "args": {}}]),
+            ToolMessage(content="", tool_call_id="c1"),
+        ]
+        out = normalize_messages_for_provider(msgs)
+        assert out[2].content.strip()
+
+
+class TestToolCallPairingStillWorks:
+    """The rule that already had a fix must survive being moved behind one door."""
+
+    def test_an_unanswered_tool_call_gets_a_placeholder(self):
+        msgs = [
+            HumanMessage(content="go"),
+            AIMessage(content="", tool_calls=[{"name": "ls", "id": "c1", "args": {}}]),
+        ]
+        out = normalize_messages_for_provider(msgs)
+        assert any(isinstance(m, ToolMessage) and m.tool_call_id == "c1" for m in out)
+
+    def test_an_unanchored_tool_message_is_dropped(self):
+        msgs = [HumanMessage(content="go"), ToolMessage(content="?", tool_call_id="nope")]
+        out = normalize_messages_for_provider(msgs)
+        assert not any(isinstance(m, ToolMessage) for m in out)
+
+
+class TestIdempotence:
+    def test_running_it_twice_changes_nothing_the_second_time(self):
+        msgs = [SystemMessage(content="s"), AIMessage(content="", tool_calls=[
+            {"name": "ls", "id": "c1", "args": {}}])]
+        once = normalize_messages_for_provider(msgs)
+        twice = normalize_messages_for_provider(once)
+        assert twice is once
+
+
+class TestEveryModelCallBoundaryUsesIt:
+    def test_the_middleware_routes_through_the_validator(self):
+        from app.agents.leonardo.agent_factory import RepairOrphanedToolCallsMiddleware
+
+        class _Req:
+            def __init__(self, messages):
+                self.messages = messages
+                self.overridden = None
+
+            def override(self, messages):
+                self.overridden = messages
+                return self
+
+        req = _Req([SystemMessage(content="s"), AIMessage(content="hi")])
+        RepairOrphanedToolCallsMiddleware().wrap_model_call(req, lambda r: "ok")
+        assert req.overridden is not None
+        assert any(m.type == "human" for m in req.overridden)
+
+    @pytest.mark.parametrize("mode", [
+        "rails_beginner_agent", "rails_ai_builder_agent", "rails_plain_chat_mode",
+    ])
+    def test_every_raw_node_calls_it(self, mode):
+        from pathlib import Path
+
+        nodes = (Path(__file__).resolve().parents[1] / "agents" / "leonardo"
+                 / mode / "nodes.py").read_text()
+        assert "normalize_messages_for_provider" in nodes
+
+
+# ---------------------------------------------------------------------------
+# P1-3: describe the request a provider rejected
+# ---------------------------------------------------------------------------
+
+class _BadRequestError(Exception):
+    pass
+
+
+_BadRequestError.__name__ = "BadRequestError"
+
+
+class TestBadRequestDiagnosis:
+    def _history(self):
+        return [
+            SystemMessage(content="you are leo"),
+            HumanMessage(content=[{"type": "text", "text": "hello there"}]),
+            AIMessage(content="", tool_calls=[{"name": "ls", "id": "c1", "args": {}}]),
+        ]
+
+    def test_it_recognises_a_provider_400(self):
+        assert looks_like_bad_request(_BadRequestError("400"))
+        assert not looks_like_bad_request(ConnectionError("reset"))
+
+    def test_the_shape_names_roles_content_kinds_and_block_types(self):
+        shape = describe_message_shape(self._history(), model="muse-spark-1.2-contributor")
+        roles = [m["role"] for m in shape["messages"]]
+        assert roles == ["system", "human", "ai"]
+        assert shape["messages"][1]["blocks"] == ["text"]
+        assert shape["model"] == "muse-spark-1.2-contributor"
+
+    def test_it_reports_tool_call_pairing(self):
+        shape = describe_message_shape(self._history())
+        assert shape["unanswered_tool_call_ids"] == ["c1"]
+
+    def test_it_reports_whether_a_user_or_tool_message_is_present(self):
+        assert describe_message_shape(self._history())["has_user_or_tool"] is True
+        assert describe_message_shape(
+            [SystemMessage(content="s"), AIMessage(content="x")]
+        )["has_user_or_tool"] is False
+
+    def test_it_reports_empty_content(self):
+        shape = describe_message_shape([HumanMessage(content="")])
+        assert shape["messages"][0]["empty"] is True
+
+    def test_it_never_includes_the_actual_text(self):
+        """We need the SHAPE, not the customer's content."""
+        import json
+
+        secret = "the user's private business plan"
+        rendered = json.dumps(describe_message_shape([HumanMessage(content=secret)]))
+        assert secret not in rendered
+
+    def test_it_is_attached_to_the_exception_for_the_error_report(self):
+        exc = _BadRequestError("400")
+        log_bad_request_shape(exc, self._history(), model="muse-spark-1.2-contributor")
+        assert getattr(exc, "llamabot_request_shape", None)
+
+    def test_the_error_report_carries_it(self):
+        from app.websocket.request_handler import _prepend_request_shape
+
+        exc = _BadRequestError("400")
+        log_bad_request_shape(exc, self._history())
+        out = _prepend_request_shape(exc, "Traceback (most recent call last): ...")
+        assert out.startswith("[llamabot request shape]")
+        assert "unanswered_tool_call_ids" in out
+
+    def test_an_ordinary_error_report_is_unchanged(self):
+        from app.websocket.request_handler import _prepend_request_shape
+
+        assert _prepend_request_shape(ValueError("x"), "tb") == "tb"

--- a/app/tests/test_my_uploads_menu_label.py
+++ b/app/tests/test_my_uploads_menu_label.py
@@ -1,0 +1,29 @@
+"""Guard: the file-attach menu's browse entry reads "My Uploads".
+
+"Browse and attach" described the mechanics, not the thing — the menu item
+opens the panel listing files this user already uploaded. Renamed 2026-08-21.
+"""
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CHAT_HTML = REPO_ROOT / "app/frontend/chat.html"
+
+BROWSE_BUTTON = re.compile(
+    r'<button[^>]*data-llamabot="browse-files-btn".*?</button>',
+    re.IGNORECASE | re.DOTALL,
+)
+
+
+def browse_button():
+    match = BROWSE_BUTTON.search(CHAT_HTML.read_text())
+    assert match, "chat.html no longer has a browse-files-btn menu item"
+    return match.group(0)
+
+
+def test_browse_menu_item_is_labelled_my_uploads():
+    assert "My Uploads" in browse_button()
+
+
+def test_old_browse_and_attach_label_is_gone():
+    assert "Browse and attach" not in CHAT_HTML.read_text()

--- a/app/tests/test_orphaned_toolcall_repair_all_agents.py
+++ b/app/tests/test_orphaned_toolcall_repair_all_agents.py
@@ -194,10 +194,18 @@ def test_every_leonardo_agent_is_wired_for_repair(nodes_file):
             f"build_leonardo_agent() so orphaned tool calls are repaired (SI#112)."
         )
 
-    # raw StateGraph path: must call the pure repair fn before .invoke().
-    assert "repair_orphaned_tool_calls_in_messages" in text, (
-        f"{nodes_file.parent.name} is a raw StateGraph agent but never calls "
-        f"repair_orphaned_tool_calls_in_messages() before .invoke() (SI#112)."
+    # raw StateGraph path: must run the messages through the shared validator
+    # before .invoke(). `normalize_messages_for_provider` is the single entry
+    # point (2026-08-23); it owns tool-call pairing plus the other invariants the
+    # providers enforce. The older `repair_orphaned_tool_calls_in_messages` is
+    # still accepted — it is the same rule, one layer down.
+    assert (
+        "normalize_messages_for_provider" in text
+        or "repair_orphaned_tool_calls_in_messages" in text
+    ), (
+        f"{nodes_file.parent.name} is a raw StateGraph agent but never runs its "
+        f"messages through normalize_messages_for_provider() before .invoke() "
+        f"(SI#112 + the 2026-08-23 malformed-history set)."
     )
 
 

--- a/app/tests/test_overlay_ads.py
+++ b/app/tests/test_overlay_ads.py
@@ -1,0 +1,417 @@
+"""Building-overlay promo slot ("jumbotron").
+
+The creative is mothership-owned, so the properties worth pinning here are the
+defensive ones: a remote payload can't hand the browser an unbounded number of
+snippets, an oversized snippet, a silly slot height or a 1-second rotation; and
+every failure mode (no mothership, old mothership, timeout, garbage JSON)
+degrades to "no promos" rather than a broken overlay.
+
+Run with: pytest app/tests/test_overlay_ads.py -v
+"""
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.services import overlay_ads
+
+
+@pytest.fixture(autouse=True)
+def _isolated(monkeypatch):
+    """No cache carryover, and no dependence on the box's real .leonardo/.
+
+    The override file wins over the mothership by design, so a QA/preview
+    `overlay_ads.json` sitting on the dev box would silently hijack every
+    endpoint test below. Point the path somewhere that cannot exist; the tests
+    that DO exercise the override re-patch it to a tmp_path.
+    """
+    monkeypatch.setattr(overlay_ads, "LOCAL_OVERRIDE_PATH", "/nonexistent/overlay_ads.json")
+    overlay_ads.clear_cache()
+    yield
+    overlay_ads.clear_cache()
+
+
+@pytest.fixture
+def client():
+    from app.routers.api import router
+
+    app = FastAPI()
+    app.include_router(router)
+    return TestClient(app)
+
+
+def _mothership(enabled=True, payload=None):
+    """Patch MothershipClient as seen from inside the endpoint."""
+    fake = AsyncMock()
+    fake.enabled = enabled
+    fake.fetch_overlay_ads = AsyncMock(return_value=payload)
+    return patch("app.services.mothership_client.MothershipClient", return_value=fake), fake
+
+
+# --------------------------------------------------------------------------
+# normalize()
+# --------------------------------------------------------------------------
+
+def test_normalize_keeps_good_ads_and_fills_defaults():
+    out = overlay_ads.normalize({"ads": [{"id": "spring", "html": "<b>hi</b>"}]})
+
+    assert out["ads"] == [
+        {"id": "spring", "html": "<b>hi</b>", "height": overlay_ads.DEFAULT_AD_HEIGHT}
+    ]
+    assert out["rotate_seconds"] == overlay_ads.DEFAULT_ROTATE_SECONDS
+
+
+def test_normalize_drops_bad_entries_without_dropping_good_ones():
+    out = overlay_ads.normalize({"ads": [
+        {"html": "   "},              # blank
+        {"id": "no-html"},            # missing html
+        "not-a-dict",
+        {"id": "keep", "html": "<p>ok</p>"},
+    ]})
+
+    assert [a["id"] for a in out["ads"]] == ["keep"]
+
+
+def test_normalize_drops_oversized_snippet_rather_than_truncating():
+    big = "x" * (overlay_ads.MAX_AD_BYTES + 1)
+    out = overlay_ads.normalize({"ads": [{"id": "huge", "html": big}]})
+
+    assert out["ads"] == []
+
+
+def test_normalize_caps_the_number_of_ads():
+    many = [{"id": f"a{i}", "html": "<b>x</b>"} for i in range(overlay_ads.MAX_ADS + 5)]
+    out = overlay_ads.normalize({"ads": many})
+
+    assert len(out["ads"]) == overlay_ads.MAX_ADS
+
+
+@pytest.mark.parametrize("sent,expected", [
+    (1, overlay_ads.MIN_ROTATE_SECONDS),
+    (999999, overlay_ads.MAX_ROTATE_SECONDS),
+    ("banana", overlay_ads.DEFAULT_ROTATE_SECONDS),
+    (None, overlay_ads.DEFAULT_ROTATE_SECONDS),
+    (180, 180),
+])
+def test_normalize_clamps_rotation(sent, expected):
+    out = overlay_ads.normalize({"ads": [], "rotate_seconds": sent})
+    assert out["rotate_seconds"] == expected
+
+
+@pytest.mark.parametrize("sent,expected", [
+    (5, overlay_ads.MIN_AD_HEIGHT),
+    (5000, overlay_ads.MAX_AD_HEIGHT),
+    ("tall", overlay_ads.DEFAULT_AD_HEIGHT),
+])
+def test_normalize_clamps_height(sent, expected):
+    out = overlay_ads.normalize({"ads": [{"id": "a", "html": "<b>x</b>", "height": sent}]})
+    assert out["ads"][0]["height"] == expected
+
+
+@pytest.mark.parametrize("payload", [None, "nope", {"ads": "not-a-list"}, {}])
+def test_normalize_never_raises_on_garbage(payload):
+    assert overlay_ads.normalize(payload) == overlay_ads.EMPTY
+
+
+# --------------------------------------------------------------------------
+# GET /api/overlay-ads
+# --------------------------------------------------------------------------
+
+def test_endpoint_returns_empty_when_mothership_not_configured(client):
+    patcher, fake = _mothership(enabled=False)
+    with patcher:
+        body = client.get("/api/overlay-ads").json()
+
+    assert body == overlay_ads.EMPTY
+    fake.fetch_overlay_ads.assert_not_awaited()
+
+
+def test_endpoint_returns_empty_when_mothership_call_fails(client):
+    # fetch_overlay_ads swallows its own errors and returns None (old mothership,
+    # timeout, 404). The endpoint must not turn that into a 500.
+    patcher, _ = _mothership(payload=None)
+    with patcher:
+        response = client.get("/api/overlay-ads")
+
+    assert response.status_code == 200
+    assert response.json() == overlay_ads.EMPTY
+
+
+def test_endpoint_serves_normalized_ads(client):
+    patcher, _ = _mothership(payload={
+        "ads": [{"id": "promo", "html": "<h1>Try Pro</h1>", "height": 5000}],
+        "rotate_seconds": 1,
+    })
+    with patcher:
+        body = client.get("/api/overlay-ads").json()
+
+    assert body["ads"][0]["html"] == "<h1>Try Pro</h1>"
+    assert body["ads"][0]["height"] == overlay_ads.MAX_AD_HEIGHT
+    assert body["rotate_seconds"] == overlay_ads.MIN_ROTATE_SECONDS
+
+
+def test_second_request_is_served_from_cache(client):
+    patcher, fake = _mothership(payload={"ads": [{"id": "p", "html": "<b>x</b>"}]})
+    with patcher:
+        first = client.get("/api/overlay-ads").json()
+        second = client.get("/api/overlay-ads").json()
+
+    assert first == second
+    assert fake.fetch_overlay_ads.await_count == 1
+
+
+def test_a_failed_fetch_is_also_cached(client):
+    """An unreachable mothership must not be re-dialed on every build."""
+    patcher, fake = _mothership(payload=None)
+    with patcher:
+        client.get("/api/overlay-ads")
+        client.get("/api/overlay-ads")
+
+    assert fake.fetch_overlay_ads.await_count == 1
+
+
+# --------------------------------------------------------------------------
+# .leonardo/overlay_ads.json override
+# --------------------------------------------------------------------------
+
+def test_local_override_wins_over_the_mothership(client, tmp_path, monkeypatch):
+    override = tmp_path / "overlay_ads.json"
+    override.write_text('{"ads": [{"id": "local", "html": "<b>local</b>"}]}')
+    monkeypatch.setattr(overlay_ads, "LOCAL_OVERRIDE_PATH", str(override))
+
+    patcher, fake = _mothership(payload={"ads": [{"id": "remote", "html": "<b>remote</b>"}]})
+    with patcher:
+        body = client.get("/api/overlay-ads").json()
+
+    assert [a["id"] for a in body["ads"]] == ["local"]
+    fake.fetch_overlay_ads.assert_not_awaited()
+
+
+def test_local_override_is_re_read_every_request(client, tmp_path, monkeypatch):
+    """Editing the file and reloading must show the new promo — no cache in the way."""
+    override = tmp_path / "overlay_ads.json"
+    override.write_text('{"ads": [{"id": "v1", "html": "<b>v1</b>"}]}')
+    monkeypatch.setattr(overlay_ads, "LOCAL_OVERRIDE_PATH", str(override))
+
+    patcher, _ = _mothership(payload=None)
+    with patcher:
+        assert client.get("/api/overlay-ads").json()["ads"][0]["id"] == "v1"
+        override.write_text('{"ads": [{"id": "v2", "html": "<b>v2</b>"}]}')
+        assert client.get("/api/overlay-ads").json()["ads"][0]["id"] == "v2"
+
+
+def test_unreadable_override_falls_back_to_the_mothership(client, tmp_path, monkeypatch):
+    override = tmp_path / "overlay_ads.json"
+    override.write_text("{ this is not json")
+    monkeypatch.setattr(overlay_ads, "LOCAL_OVERRIDE_PATH", str(override))
+
+    patcher, _ = _mothership(payload={"ads": [{"id": "remote", "html": "<b>remote</b>"}]})
+    with patcher:
+        body = client.get("/api/overlay-ads").json()
+
+    assert [a["id"] for a in body["ads"]] == ["remote"]
+
+
+def test_missing_override_file_is_not_an_error(client, monkeypatch):
+    monkeypatch.setattr(overlay_ads, "LOCAL_OVERRIDE_PATH", "/nope/does/not/exist.json")
+
+    patcher, _ = _mothership(payload={"ads": [{"id": "remote", "html": "<b>remote</b>"}]})
+    with patcher:
+        assert client.get("/api/overlay-ads").status_code == 200
+
+
+# --------------------------------------------------------------------------
+# Display policy — WHEN the jumbotron shows
+#
+# The whole point is that the mothership decides, so these pin two things: that
+# a partial policy overrides only what it names, and that no policy value can
+# push the instance outside its clamps or override the never-during-a-question
+# guarantee.
+# --------------------------------------------------------------------------
+
+def test_missing_policy_gives_the_baked_in_defaults():
+    out = overlay_ads.normalize({"ads": []})
+    assert out["policy"] == overlay_ads.DEFAULT_POLICY
+
+
+@pytest.mark.parametrize("raw", [None, "nope", 42, []])
+def test_unusable_policy_gives_the_defaults(raw):
+    assert overlay_ads.normalize_policy(raw) == overlay_ads.DEFAULT_POLICY
+
+
+def test_policy_fields_override_independently():
+    """Sending one field must not reset the others to defaults."""
+    policy = overlay_ads.normalize_policy({"show_after_seconds": 20})
+
+    assert policy["show_after_seconds"] == 20
+    assert policy["enabled"] is overlay_ads.DEFAULT_POLICY["enabled"]
+    assert policy["modes"] == overlay_ads.DEFAULT_POLICY["modes"]
+    assert policy["min_interval_seconds"] == overlay_ads.DEFAULT_POLICY["min_interval_seconds"]
+
+
+def test_policy_can_switch_the_whole_feature_off():
+    assert overlay_ads.normalize_policy({"enabled": False})["enabled"] is False
+
+
+@pytest.mark.parametrize("sent,expected", [
+    (-5, 0),
+    (99999, overlay_ads.MAX_SHOW_AFTER_SECONDS),
+    ("soon", overlay_ads.DEFAULT_SHOW_AFTER_SECONDS),
+    (0, 0),
+    (30, 30),
+])
+def test_show_after_seconds_is_clamped(sent, expected):
+    assert overlay_ads.normalize_policy({"show_after_seconds": sent})["show_after_seconds"] == expected
+
+
+@pytest.mark.parametrize("sent,expected", [
+    (-1, 0),
+    (10 ** 9, overlay_ads.MAX_MIN_INTERVAL_SECONDS),
+    ("often", overlay_ads.DEFAULT_MIN_INTERVAL_SECONDS),
+    (1800, 1800),
+])
+def test_min_interval_seconds_is_clamped(sent, expected):
+    got = overlay_ads.normalize_policy({"min_interval_seconds": sent})["min_interval_seconds"]
+    assert got == expected
+
+
+def test_modes_can_be_narrowed_to_one_layout():
+    assert overlay_ads.normalize_policy({"modes": ["building"]})["modes"] == ["building"]
+
+
+def test_question_can_never_be_selected_as_a_mode():
+    """Leo is blocked on the user during a question; nothing competes with that.
+
+    This is the one guarantee the mothership cannot buy its way out of, so it is
+    dropped even when explicitly requested.
+    """
+    policy = overlay_ads.normalize_policy({"modes": ["building", "plan", "question"]})
+    assert policy["modes"] == ["building", "plan"]
+    assert "question" not in policy["modes"]
+
+
+def test_unknown_modes_are_dropped_not_passed_through():
+    assert overlay_ads.normalize_policy({"modes": ["building", "jumbotron"]})["modes"] == ["building"]
+
+
+def test_empty_modes_list_means_never_show():
+    assert overlay_ads.normalize_policy({"modes": []})["modes"] == []
+
+
+def test_variant_is_echoed_for_experiment_attribution():
+    out = overlay_ads.normalize({"ads": [], "variant": "exp-delay-8s"})
+    assert out["variant"] == "exp-delay-8s"
+
+
+def test_endpoint_serves_the_policy(client):
+    patcher, _ = _mothership(payload={
+        "ads": [{"id": "p", "html": "<b>x</b>"}],
+        "policy": {"show_after_seconds": 12, "modes": ["building"]},
+        "variant": "arm-b",
+    })
+    with patcher:
+        body = client.get("/api/overlay-ads").json()
+
+    assert body["policy"]["show_after_seconds"] == 12
+    assert body["policy"]["modes"] == ["building"]
+    assert body["variant"] == "arm-b"
+
+
+def test_empty_payload_still_carries_a_usable_policy():
+    """The overlay reads policy unconditionally; it must never be absent."""
+    assert overlay_ads.empty()["policy"] == overlay_ads.DEFAULT_POLICY
+
+
+def test_empty_returns_a_fresh_dict_each_time():
+    """Callers mutate what they get back; a shared constant would leak between them."""
+    a = overlay_ads.empty()
+    a["policy"]["enabled"] = False
+    assert overlay_ads.empty()["policy"]["enabled"] is True
+
+
+# --------------------------------------------------------------------------
+# Personalisation — the mothership targets per user, so the cache must too
+# --------------------------------------------------------------------------
+
+def _as_user(user):
+    """Patch the session-cookie resolver the endpoint uses."""
+    return patch("app.dependencies._user_from_session_cookie", return_value=user)
+
+
+class _FakeUser:
+    def __init__(self, id, username, role="user", is_admin=False,
+                 email=None, llamapress_user_guid=None):
+        self.id, self.username, self.role, self.is_admin = id, username, role, is_admin
+        self.email, self.llamapress_user_guid = email, llamapress_user_guid
+
+
+def test_user_context_is_sent_to_the_mothership(client):
+    """The same wire shape the mothership reports use (user_context.describe),
+    so a promo can be targeted by the same guid the telemetry is keyed on."""
+    patcher, fake = _mothership(payload={"ads": []})
+    user = _FakeUser(7, "kody", role="engineer", is_admin=True,
+                     email="kody@llamapress.ai", llamapress_user_guid="guid-7")
+    with patcher, _as_user(user):
+        client.get("/api/overlay-ads")
+
+    sent = fake.fetch_overlay_ads.await_args.kwargs["user"]
+    assert sent == {
+        "id": 7,
+        "username": "kody",
+        "email": "kody@llamapress.ai",
+        "llamapress_user_guid": "guid-7",
+        "role": "engineer",
+        "is_admin": True,
+    }
+
+
+def test_anonymous_request_sends_no_user(client):
+    patcher, fake = _mothership(payload={"ads": []})
+    with patcher, _as_user(None):
+        client.get("/api/overlay-ads")
+
+    assert fake.fetch_overlay_ads.await_args.kwargs["user"] is None
+
+
+def test_one_users_personalised_ads_do_not_leak_to_another(client):
+    """The cache is keyed per user. A shared cache would hand the first
+    requester's targeted promos and policy to everyone else on the box."""
+    calls = []
+
+    async def _per_user(version, user=None):
+        calls.append(user["id"])
+        return {"ads": [{"id": f"for-user-{user['id']}", "html": "<b>x</b>"}]}
+
+    fake = AsyncMock()
+    fake.enabled = True
+    fake.fetch_overlay_ads = _per_user
+
+    with patch("app.services.mothership_client.MothershipClient", return_value=fake):
+        with _as_user(_FakeUser(1, "alice")):
+            first = client.get("/api/overlay-ads").json()
+        with _as_user(_FakeUser(2, "bob")):
+            second = client.get("/api/overlay-ads").json()
+
+    assert first["ads"][0]["id"] == "for-user-1"
+    assert second["ads"][0]["id"] == "for-user-2"
+    assert calls == [1, 2], "each user must get their own fetch, not a cache hit"
+
+
+def test_the_same_user_still_gets_a_cache_hit(client):
+    patcher, fake = _mothership(payload={"ads": [{"id": "p", "html": "<b>x</b>"}]})
+    with patcher, _as_user(_FakeUser(1, "alice")):
+        client.get("/api/overlay-ads")
+        client.get("/api/overlay-ads")
+
+    assert fake.fetch_overlay_ads.await_count == 1
+
+
+def test_endpoint_survives_a_dead_user_lookup(client):
+    """A DB hiccup must not 500 an endpoint whose contract is to fail open."""
+    patcher, _ = _mothership(payload={"ads": [{"id": "p", "html": "<b>x</b>"}]})
+    with patcher, patch("app.dependencies._user_from_session_cookie", side_effect=RuntimeError("db down")):
+        response = client.get("/api/overlay-ads")
+
+    assert response.status_code == 200
+    assert response.json()["ads"][0]["id"] == "p"

--- a/app/tests/test_overlay_ads.py
+++ b/app/tests/test_overlay_ads.py
@@ -8,6 +8,7 @@ degrades to "no promos" rather than a broken overlay.
 
 Run with: pytest app/tests/test_overlay_ads.py -v
 """
+from contextlib import contextmanager
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -334,9 +335,31 @@ def test_empty_returns_a_fresh_dict_each_time():
 # Personalisation — the mothership targets per user, so the cache must too
 # --------------------------------------------------------------------------
 
+@contextmanager
 def _as_user(user):
-    """Patch the session-cookie resolver the endpoint uses."""
-    return patch("app.dependencies._user_from_session_cookie", return_value=user)
+    """Sign a request in as ``user`` (or nobody, for ``None``).
+
+    The endpoint resolves the user by hand rather than through a FastAPI
+    dependency (a DB hiccup must not 500 an endpoint whose contract is to fail
+    open), so the stub has to cover the whole path: an engine to open a session
+    on, a session that touches no database, and the cookie resolver itself.
+    Patching only the resolver passes on a box that HAS an auth DB and fails in
+    CI, which has none — ``engine is None`` there, so no user is ever resolved.
+    """
+    class _NullSession:
+        def __init__(self, _engine):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_exc):
+            return False
+
+    with patch("app.dependencies._user_from_session_cookie", return_value=user), \
+         patch("app.db.engine", object()), \
+         patch("app.routers.api.Session", _NullSession):
+        yield
 
 
 class _FakeUser:

--- a/app/tests/test_page_verifier_and_prompt_gates.py
+++ b/app/tests/test_page_verifier_and_prompt_gates.py
@@ -1,0 +1,336 @@
+"""P0 (2026-08-23): Leo was told to self-verify pages with a tool that is off by default.
+
+`browser_inspect` is gated by the `enable_browser_inspect` site setting, which
+defaults to "false", but both Rails prompts documented it unconditionally. On a
+default box the agent called it and got
+`Error: browser_inspect is not a valid tool` — 8 friction reports across 7 boxes
+— and then shipped the page unverified. The customer-app error stream is
+dominated by failures one page load catches instantly: NoMethodError (16 boxes),
+NameError (13), ActionView::SyntaxErrorInTemplate (10), 422 occurrences in 7 days.
+
+Three properties are asserted here:
+
+1. A gated section never reaches the model when its gate is off, and is
+   untouched when it is on — for EVERY prompt, via the shared choke point.
+2. `check_page`, the always-available verifier, is bound in every Rails mode
+   that can write files, on a default box with the setting unset.
+3. `check_page` reports the truth: 2xx tiny, 3xx as "not proven", non-2xx with
+   the exception off the Rails log.
+"""
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from app.agents.leonardo.prompt_gates import GATES, apply_prompt_gates
+
+LEONARDO_DIR = Path(__file__).resolve().parents[1] / "agents" / "leonardo"
+
+# Every mode that can write a view/controller/route, and therefore has to be
+# able to check what it wrote. rails_user_feedback_agent and rails_user_mode_agent
+# deliberately have no write tools; rails_plain_chat_mode has no tools at all.
+BUILDING_MODES = [
+    "rails_agent",
+    "rails_ai_builder_agent",
+    "rails_beginner_agent",
+    "rails_engineer_plan_mode_agent",
+    "rails_plan_mode_agent",
+    "rails_testing_agent",
+    "rails_ticket_mode_agent",
+    "rails_ticket_plan_mode_agent",
+]
+
+
+# ---------------------------------------------------------------------------
+# 1. Prompt gates
+# ---------------------------------------------------------------------------
+
+SAMPLE = (
+    "intro line\n"
+    "<!--IF:browser_inspect-->\n"
+    "### Self-Checking Pages with browser_inspect\n"
+    "call browser_inspect after every view edit\n"
+    "<!--END:browser_inspect-->\n"
+    "closing line\n"
+)
+
+
+class TestApplyPromptGates:
+    def test_closed_gate_removes_the_whole_block(self, monkeypatch):
+        monkeypatch.setitem(GATES, "browser_inspect", lambda: False)
+        out = apply_prompt_gates(SAMPLE)
+        assert "browser_inspect" not in out
+        assert "intro line" in out and "closing line" in out
+
+    def test_open_gate_keeps_the_content_and_drops_the_markers(self, monkeypatch):
+        monkeypatch.setitem(GATES, "browser_inspect", lambda: True)
+        out = apply_prompt_gates(SAMPLE)
+        assert "call browser_inspect after every view edit" in out
+        assert "<!--IF:" not in out and "<!--END:" not in out
+
+    def test_an_unreadable_gate_fails_closed(self, monkeypatch):
+        """The tool list fails closed too — the two must never disagree."""
+        def _boom():
+            raise RuntimeError("auth DB down")
+
+        monkeypatch.setitem(GATES, "browser_inspect", _boom)
+        assert "browser_inspect" not in apply_prompt_gates(SAMPLE)
+
+    def test_an_unknown_gate_is_left_alone(self):
+        text = "a\n<!--IF:some_future_tool-->\nkeep me\n<!--END:some_future_tool-->\nb\n"
+        assert "keep me" in apply_prompt_gates(text)
+
+    def test_prompts_without_markers_are_returned_untouched(self):
+        text = "just a normal prompt"
+        assert apply_prompt_gates(text) is text
+
+
+class TestGatesAreWiredToTheRealPrompts:
+    """The whole point: the LIVE prompt, through the real choke point."""
+
+    def _prompt(self, mode, base, enabled, cached=None):
+        from app.agents.leonardo import project_context
+
+        # Isolate from whatever the mothership has cached for this box: we are
+        # asserting what the SOURCE prompt resolves to. The override path gets
+        # its own test below — it is gated too, and on a box where an override
+        # exists it is the only prompt that runs.
+        with patch.dict(GATES, {"browser_inspect": lambda: enabled}), \
+             patch.object(project_context.system_prompt_cache, "get_cached",
+                          return_value=cached):
+            return project_context.resolve_base_prompt(base, mode)
+
+    def test_a_mothership_override_is_gated_too(self):
+        """A delivered override is the ONLY prompt that runs on that box."""
+        override = "x" * 3000 + SAMPLE
+        off = self._prompt("rails_agent", "static", enabled=False, cached=override)
+        on = self._prompt("rails_agent", "static", enabled=True, cached=override)
+        assert "browser_inspect" not in off
+        assert "browser_inspect" in on
+
+    @pytest.mark.parametrize(
+        "module,const",
+        [
+            ("rails_beginner_agent", "BEGINNER_AGENT_PROMPT"),
+            ("rails_agent", "RAILS_AGENT_PROMPT"),
+        ],
+    )
+    def test_browser_inspect_is_absent_when_the_setting_is_off(self, module, const):
+        import importlib
+
+        prompts = importlib.import_module(f"app.agents.leonardo.{module}.prompts")
+        base = getattr(prompts, const)
+        assert "browser_inspect" in base, "fixture drifted: prompt no longer mentions it"
+
+        out = self._prompt(module, base, enabled=False)
+        assert "browser_inspect" not in out, (
+            f"{module} still advertises browser_inspect on a default box, so the "
+            f"agent will call a tool the registry does not have"
+        )
+
+    @pytest.mark.parametrize(
+        "module,const",
+        [
+            ("rails_beginner_agent", "BEGINNER_AGENT_PROMPT"),
+            ("rails_agent", "RAILS_AGENT_PROMPT"),
+        ],
+    )
+    def test_browser_inspect_is_present_when_the_setting_is_on(self, module, const):
+        import importlib
+
+        prompts = importlib.import_module(f"app.agents.leonardo.{module}.prompts")
+        out = self._prompt(module, getattr(prompts, const), enabled=True)
+        assert "browser_inspect" in out
+        assert "<!--IF:" not in out
+
+    @pytest.mark.parametrize(
+        "module,const",
+        [
+            ("rails_beginner_agent", "BEGINNER_AGENT_PROMPT"),
+            ("rails_agent", "RAILS_AGENT_PROMPT"),
+        ],
+    )
+    def test_the_always_on_verifier_is_documented_either_way(self, module, const):
+        import importlib
+
+        prompts = importlib.import_module(f"app.agents.leonardo.{module}.prompts")
+        base = getattr(prompts, const)
+        for enabled in (True, False):
+            assert "check_page" in self._prompt(module, base, enabled=enabled)
+
+
+def test_no_prompt_mentions_a_gated_tool_outside_a_gate():
+    """The bug class, not the one instance."""
+    import re
+
+    offenders = []
+    for prompts_file in sorted(LEONARDO_DIR.glob("*/prompts.py")):
+        text = prompts_file.read_text()
+        for gate in GATES:
+            if gate not in text:
+                continue
+            stripped = re.sub(
+                r"<!--\s*IF:%s\s*-->.*?<!--\s*END:%s\s*-->" % (gate, gate),
+                "", text, flags=re.DOTALL,
+            )
+            if gate in stripped:
+                offenders.append(f"{prompts_file.parent.name}: {gate}")
+    assert not offenders, (
+        "these prompts describe a tool that is gated off by default, outside a "
+        f"<!--IF:...--> block: {offenders}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2. check_page is bound everywhere it is needed
+# ---------------------------------------------------------------------------
+
+def _tool_names(tools):
+    return {getattr(t, "name", getattr(t, "__name__", str(t))) for t in tools}
+
+
+@pytest.mark.parametrize("mode", BUILDING_MODES)
+def test_check_page_is_bound_in_every_building_mode(mode):
+    """On a default box, with browser_inspect off, the agent still has a verifier."""
+    import importlib
+
+    nodes = importlib.import_module(f"app.agents.leonardo.{mode}.nodes")
+    names = _tool_names(nodes.default_tools)
+    assert "check_page" in names, (
+        f"{mode} can write views but has no way to load one — this is how a "
+        f"NoMethodError reaches the customer instead of the agent"
+    )
+
+
+def test_beginner_binds_check_page_to_the_model_not_just_the_toolnode():
+    """Beginner mode keeps a second list for what the MODEL sees; a tool in only
+    one of them is executable but invisible."""
+    from app.agents.leonardo.rails_beginner_agent.nodes import beginner_turn_tools
+
+    assert "check_page" in _tool_names(beginner_turn_tools())
+
+
+# ---------------------------------------------------------------------------
+# 3. check_page behaviour
+# ---------------------------------------------------------------------------
+
+RAILS_LOG = """
+Started GET "/comments" for 172.18.0.1 at 2026-08-23 01:00:00 +0000
+Processing by CommentsController#index as HTML
+  Rendering comments/index.html.erb
+
+NoMethodError (undefined method `any?' for nil):
+
+app/views/comments/index.html.erb:67:in `_app_views_comments_index_html_erb'
+app/controllers/comments_controller.rb:8:in `index'
+  actionview (7.1.0) lib/action_view/template.rb:262:in `block in render'
+  actionpack (7.1.0) lib/action_controller/metal/instrumentation.rb:69:in `render'
+"""
+
+
+class TestExtractRailsException:
+    def test_it_finds_the_class_message_and_app_frames(self):
+        from app.agents.leonardo.rails_agent.tools import _rails_exception_from_logs
+
+        out = _rails_exception_from_logs(RAILS_LOG)
+        assert out.startswith("NoMethodError: undefined method `any?' for nil")
+        assert "app/views/comments/index.html.erb:67" in out
+
+    def test_it_stops_before_the_framework_frames(self):
+        from app.agents.leonardo.rails_agent.tools import _rails_exception_from_logs
+
+        out = _rails_exception_from_logs(RAILS_LOG)
+        assert "actionview" not in out and "actionpack" not in out
+
+    def test_it_returns_none_on_a_clean_log(self):
+        from app.agents.leonardo.rails_agent.tools import _rails_exception_from_logs
+
+        assert _rails_exception_from_logs('Started GET "/" for 1.2.3.4\nCompleted 200 OK\n') is None
+
+    def test_it_takes_the_most_recent_exception(self):
+        from app.agents.leonardo.rails_agent.tools import _rails_exception_from_logs
+
+        log = RAILS_LOG + "\nNameError (undefined local variable or method `foo'):\n\napp/controllers/x.rb:3:in `index'\n"
+        assert _rails_exception_from_logs(log).startswith("NameError")
+
+
+class _Runtime:
+    tool_call_id = "call_1"
+
+
+class _Response:
+    def __init__(self, status_code, headers=None):
+        self.status_code = status_code
+        self.headers = headers or {}
+
+
+def _invoke_check_page(monkeypatch, *, response=None, error=None, log=""):
+    import httpx
+
+    import app.agents.leonardo.rails_agent.tools as tools
+
+    def _get(url, **kwargs):
+        if error is not None:
+            raise error
+        return response
+
+    monkeypatch.setattr(httpx, "get", _get)
+    monkeypatch.setattr(tools, "_tail_rails_log_text", lambda *a, **k: log)
+    command = tools.check_page.func(path="/comments", runtime=_Runtime())
+    return command.update["messages"][0].content
+
+
+class TestCheckPage:
+    def test_a_2xx_answer_is_short_and_says_it_rendered(self, monkeypatch):
+        out = _invoke_check_page(monkeypatch, response=_Response(200))
+        assert "200" in out and "rendered" in out
+        assert len(out) < 200, "this runs after every view edit; it must stay tiny"
+
+    def test_a_500_reports_the_exception_from_the_log(self, monkeypatch):
+        out = _invoke_check_page(monkeypatch, response=_Response(500), log=RAILS_LOG)
+        assert "500" in out
+        assert "NoMethodError" in out
+        assert "app/views/comments/index.html.erb:67" in out
+
+    def test_a_redirect_is_reported_as_not_proven_rather_than_broken(self, monkeypatch):
+        out = _invoke_check_page(
+            monkeypatch, response=_Response(302, {"location": "/login"})
+        )
+        assert "302" in out and "/login" in out
+        assert "did NOT render" not in out
+
+    def test_a_500_with_a_clean_log_still_says_something_useful(self, monkeypatch):
+        out = _invoke_check_page(monkeypatch, response=_Response(404), log="")
+        assert "404" in out
+        assert "routes.rb" in out
+
+    def test_an_unreachable_app_is_a_reported_result_not_a_crash(self, monkeypatch):
+        out = _invoke_check_page(
+            monkeypatch, error=ConnectionError("connection refused"), log=RAILS_LOG
+        )
+        assert "Could not reach" in out
+        assert "NoMethodError" in out
+
+    def test_the_output_is_capped(self, monkeypatch):
+        from app.agents.leonardo.rails_agent.tools import CHECK_PAGE_MAX_CHARS
+
+        huge = "\n".join(
+            ["RuntimeError (boom):", ""] + [f"app/models/x{i}.rb:{i}:in `go'" for i in range(500)]
+        )
+        out = _invoke_check_page(monkeypatch, response=_Response(500), log=huge)
+        assert len(out) <= CHECK_PAGE_MAX_CHARS + 200
+
+    def test_it_targets_the_url_that_works_inside_the_container(self):
+        from app.agents.leonardo.rails_agent.tools import _check_page_url
+
+        assert _check_page_url("/leads") == "http://llamapress:3000/leads"
+        assert _check_page_url("leads") == "http://llamapress:3000/leads"
+
+    def test_it_refuses_a_url_outside_the_app(self, monkeypatch):
+        import app.agents.leonardo.rails_agent.tools as tools
+
+        command = tools.check_page.func(
+            path="http://llamabot:8000/api/site_settings", runtime=_Runtime()
+        )
+        content = command.update["messages"][0].content
+        assert "Refused" in content

--- a/app/tests/test_pending_migration_enforcement.py
+++ b/app/tests/test_pending_migration_enforcement.py
@@ -1,0 +1,178 @@
+"""P0 (2026-08-23): a migration Leo writes but never runs takes the whole app down.
+
+`ActiveRecord::PendingMigrationError` is the highest-occurrence error anywhere in
+the fleet — 288 occurrences, 21 customer boxes, 7 days. Rails checks for pending
+migrations on EVERY request, so one unrun migration does not break one page, it
+breaks every page of the customer's app instantly with a stack trace. The
+customer's reading of that is "my app disappeared", and they are right.
+
+Enforced at the WRITE rather than in the prompt: the agent's own write is the
+trigger, a prompt rule is something it can talk past (288 occurrences say it
+did), and the write tools are shared by every mode — including the raw
+StateGraph ones that run no middleware at all.
+"""
+
+import pytest
+
+from app.agents.leonardo.rails_agent import tools
+
+
+class _Runtime:
+    tool_call_id = "call_1"
+
+
+@pytest.fixture
+def rails_root(tmp_path, monkeypatch):
+    root = tmp_path / "rails"
+    (root / "db" / "migrate").mkdir(parents=True)
+    (root / "app" / "models").mkdir(parents=True)
+    monkeypatch.setattr(tools, "RAILS_ROOT", root)
+    monkeypatch.setattr(tools, "PROJECT_ROOT", tmp_path)
+    return root
+
+
+@pytest.fixture
+def rails_sh(monkeypatch):
+    """Capture what would be run in the Rails container."""
+    calls = []
+    box = {"output": "== 20260822190000 CreateRosterCrm: migrated (0.0123s) =="}
+
+    def _fake(snippet, workdir=None, timeout_seconds=None):
+        calls.append(snippet)
+        return box["output"]
+
+    monkeypatch.setattr(tools, "rails_api_sh", _fake)
+    return calls, box
+
+
+MIGRATION = "db/migrate/20260822190000_create_roster_crm.rb"
+MIGRATION_BODY = (
+    "class CreateRosterCrm < ActiveRecord::Migration[7.1]\n"
+    "  def change\n    create_table :roster_crms\n  end\nend\n"
+)
+
+
+def _write(path, content):
+    return tools.write_file.func(
+        file_path=path, content=content, runtime=_Runtime(),
+    ).update["messages"][0].content
+
+
+def _edit(path, old, new):
+    return tools.edit_file.func(
+        file_path=path, old_string=old, new_string=new,
+        replace_all=False, runtime=_Runtime(),
+    ).update["messages"][0].content
+
+
+class TestPathDetection:
+    @pytest.mark.parametrize("path", [
+        "db/migrate/20260822190000_create_roster_crm.rb",
+        "/rails/db/migrate/20260101000000_add_x.rb",
+        "./db/migrate/20260101000000_add_x.rb",
+    ])
+    def test_migration_paths_are_recognised(self, path):
+        assert tools.is_migration_path(path)
+
+    @pytest.mark.parametrize("path", [
+        "app/models/roster_crm.rb",
+        "db/schema.rb",
+        "db/seeds.rb",
+        "app/views/db/migrate/thing.html.erb",
+        "db/migrate/README.md",
+    ])
+    def test_everything_else_is_not(self, path):
+        assert not tools.is_migration_path(path)
+
+
+class TestWritingAMigrationRunsIt:
+    def test_write_file_runs_db_migrate(self, rails_root, rails_sh):
+        calls, _ = rails_sh
+        out = _write(MIGRATION, MIGRATION_BODY)
+
+        assert any("db:migrate" in c for c in calls), (
+            "a migration was written and never run — every page of the app now 500s"
+        )
+        assert "migrated" in out
+
+    def test_edit_file_runs_it_too(self, rails_root, rails_sh):
+        calls, _ = rails_sh
+        (rails_root / MIGRATION).write_text(MIGRATION_BODY)
+
+        _edit(MIGRATION, "create_table :roster_crms", "create_table :rosters")
+        assert any("db:migrate" in c for c in calls)
+
+    def test_an_ordinary_file_does_not_trigger_it(self, rails_root, rails_sh):
+        calls, _ = rails_sh
+        _write("app/models/roster_crm.rb", "class RosterCrm < ApplicationRecord\nend\n")
+        assert not any("db:migrate" in c for c in calls)
+
+
+class TestFailureIsReportedHonestly:
+    def test_a_failed_migration_is_not_reported_as_success(self, rails_root, rails_sh):
+        _, box = rails_sh
+        box["output"] = (
+            "rails aborted!\nStandardError: An error has occurred, this and all later "
+            "migrations canceled:\n\nPG::UndefinedTable: ERROR:  relation \"users\" does not exist"
+        )
+        out = _write(MIGRATION, MIGRATION_BODY)
+
+        assert "FAILED" in out
+        assert "PG::UndefinedTable" in out
+
+    def test_it_says_the_whole_app_is_down_not_just_the_feature(self, rails_root, rails_sh):
+        _, box = rails_sh
+        box["output"] = "rails aborted!\nStandardError: boom"
+        out = _write(MIGRATION, MIGRATION_BODY)
+        assert "EVERY page" in out
+
+    def test_it_forbids_claiming_the_feature_is_ready(self, rails_root, rails_sh):
+        _, box = rails_sh
+        box["output"] = "rails aborted!\nStandardError: boom"
+        out = _write(MIGRATION, MIGRATION_BODY)
+        assert "Do NOT tell the user the feature is ready" in out
+
+    def test_it_forbids_writing_a_second_migration_for_the_same_change(self, rails_root, rails_sh):
+        """ActiveRecord::DuplicateMigrationNameError, same 7 days, same root cause."""
+        _, box = rails_sh
+        box["output"] = "rails aborted!\nStandardError: boom"
+        out = _write(MIGRATION, MIGRATION_BODY)
+        assert "do not write a second migration" in out
+
+    def test_an_unreachable_container_is_reported_not_swallowed(self, rails_root, monkeypatch):
+        def _boom(*a, **k):
+            raise RuntimeError("no docker socket")
+
+        monkeypatch.setattr(tools, "rails_api_sh", _boom)
+        out = _write(MIGRATION, MIGRATION_BODY)
+        assert "FAILED" in out
+        assert "no docker socket" in out
+
+    def test_empty_output_counts_as_failure(self, rails_root, rails_sh):
+        _, box = rails_sh
+        box["output"] = ""
+        out = _write(MIGRATION, MIGRATION_BODY)
+        assert "FAILED" in out
+
+    def test_the_report_is_bounded(self, rails_root, rails_sh):
+        _, box = rails_sh
+        box["output"] = "rails aborted!\n" + ("x" * 50_000)
+        out = _write(MIGRATION, MIGRATION_BODY)
+        assert len(out) < 6000
+
+
+class TestPromptRule:
+    """Every mode that can write a migration must also be told the rule."""
+
+    MODES = [
+        ("rails_agent", "RAILS_AGENT_PROMPT"),
+        ("rails_beginner_agent", "BEGINNER_AGENT_PROMPT"),
+    ]
+
+    @pytest.mark.parametrize("module,const", MODES)
+    def test_the_prompt_says_run_it_in_the_same_turn(self, module, const):
+        import importlib
+
+        prompts = importlib.import_module(f"app.agents.leonardo.{module}.prompts")
+        text = getattr(prompts, const).lower()
+        assert "never end a turn with an unrun migration" in text

--- a/app/tests/test_rails_error_feed_client.py
+++ b/app/tests/test_rails_error_feed_client.py
@@ -1,0 +1,278 @@
+"""The HTTP half of mid-turn Rails auto-recovery.
+
+Driven entirely by ``httpx.MockTransport`` — no network, no Rails. The single
+behaviour that matters most here is the one repeated in almost every test: when
+anything at all goes wrong, ``fetch`` returns None and the turn carries on. This
+runs on every model call in the product; it is not allowed to be the reason a
+turn fails.
+
+See docs/dev/rails_auto_recovery.md.
+"""
+import httpx
+import pytest
+
+from app.services.rails_error_feed import RailsErrorFeedClient
+
+
+def client_with(handler, token="tok_abc"):
+    transport = httpx.MockTransport(handler)
+    return RailsErrorFeedClient(
+        base_url="http://llamapress:3000",
+        token=token,
+        client_factory=lambda timeout: httpx.AsyncClient(
+            transport=transport, timeout=timeout
+        ),
+    )
+
+
+def json_response(payload, status=200):
+    return lambda request: httpx.Response(status, json=payload)
+
+
+@pytest.mark.asyncio
+class TestHappyPath:
+    async def test_returns_the_cursor_and_the_entries(self):
+        feed = client_with(json_response({
+            "seq": 42,
+            "errors": [{"seq": 42, "fingerprint": "f", "error_class": "TypeError"}],
+        }))
+
+        result = await feed.fetch(since=41)
+
+        assert result is not None
+        seq, errors = result
+        assert seq == 42
+        assert errors[0]["error_class"] == "TypeError"
+
+    async def test_sends_the_box_feed_credential(self, monkeypatch):
+        # On a real box SECRET_KEY_BASE is always set, so this is the header
+        # Rails actually sees. The per-user fallback is pinned separately in
+        # TestCredentialChoice.
+        monkeypatch.setenv("SECRET_KEY_BASE", "s3cret")
+        seen = {}
+
+        def handler(request):
+            seen["auth"] = request.headers.get("Authorization")
+            return httpx.Response(200, json={"seq": 0, "errors": []})
+
+        await client_with(handler).fetch(since=0)
+
+        assert seen["auth"].startswith("LlamaBotFeed ")
+
+    async def test_hits_the_engine_endpoint(self):
+        seen = {}
+
+        def handler(request):
+            seen["url"] = str(request.url)
+            return httpx.Response(200, json={"seq": 0, "errors": []})
+
+        await client_with(handler).fetch(since=0)
+
+        assert seen["url"].startswith("http://llamapress:3000/llama_bot/errors")
+
+    async def test_a_probe_sends_no_since_param(self):
+        # Priming the turn's cursor: ask where the log is, take nothing.
+        seen = {}
+
+        def handler(request):
+            seen["query"] = request.url.params
+            return httpx.Response(200, json={"seq": 7, "errors": []})
+
+        result = await client_with(handler).fetch(since=None)
+
+        assert "since" not in seen["query"]
+        assert result == (7, [])
+
+    async def test_a_delta_fetch_sends_the_cursor(self):
+        seen = {}
+
+        def handler(request):
+            seen["since"] = request.url.params.get("since")
+            return httpx.Response(200, json={"seq": 9, "errors": []})
+
+        await client_with(handler).fetch(since=7)
+
+        assert seen["since"] == "7"
+
+
+@pytest.mark.asyncio
+class TestDegradesQuietly:
+    async def test_forbidden_returns_none(self):
+        # The per-user Rails token has a 30-minute TTL; an expired one must cost
+        # the feature, not the turn.
+        assert await client_with(json_response({}, status=403)).fetch(since=0) is None
+
+    async def test_not_found_returns_none(self):
+        # A box running a gem older than 0.7.4 has no such endpoint.
+        assert await client_with(json_response({}, status=404)).fetch(since=0) is None
+
+    async def test_server_error_returns_none(self):
+        assert await client_with(json_response({}, status=500)).fetch(since=0) is None
+
+    async def test_a_timeout_returns_none(self):
+        def handler(request):
+            raise httpx.ConnectTimeout("too slow")
+
+        assert await client_with(handler).fetch(since=0) is None
+
+    async def test_a_connection_error_returns_none(self):
+        def handler(request):
+            raise httpx.ConnectError("rails is restarting")
+
+        assert await client_with(handler).fetch(since=0) is None
+
+    async def test_malformed_json_returns_none(self):
+        def handler(request):
+            return httpx.Response(200, content=b"<html>not json</html>")
+
+        assert await client_with(handler).fetch(since=0) is None
+
+    async def test_a_body_without_a_cursor_returns_none(self):
+        assert await client_with(json_response({"errors": []})).fetch(since=0) is None
+
+    async def test_a_body_whose_errors_are_not_a_list_returns_none(self):
+        payload = {"seq": 3, "errors": "everything is fine"}
+        assert await client_with(json_response(payload)).fetch(since=0) is None
+
+    async def test_no_credential_of_any_kind_means_no_request(self, monkeypatch):
+        monkeypatch.delenv("SECRET_KEY_BASE", raising=False)
+        calls = []
+
+        def handler(request):
+            calls.append(request)
+            return httpx.Response(200, json={"seq": 0, "errors": []})
+
+        assert await client_with(handler, token=None).fetch(since=0) is None
+        assert calls == []
+
+
+@pytest.mark.asyncio
+class TestArmingWindow:
+    """`within` is how a turn arms when the app is ALREADY broken.
+
+    A seq cursor alone is silent in that case: the user is parked on the error
+    page, so no NEW request happens and nothing ever lands after the cursor.
+    """
+
+    async def test_a_window_probe_sends_within_and_no_since(self):
+        seen = {}
+
+        def handler(request):
+            seen["params"] = dict(request.url.params)
+            return httpx.Response(200, json={"seq": 4, "errors": [{"seq": 4}]})
+
+        result = await client_with(handler).fetch(since=None, within=120)
+
+        assert seen["params"] == {"within": "120"}
+        assert result[0] == 4
+
+    async def test_a_cursor_fetch_ignores_the_window(self):
+        # Once armed, the cursor is authoritative; sending both would re-deliver
+        # errors the turn has already been told about.
+        seen = {}
+
+        def handler(request):
+            seen["params"] = dict(request.url.params)
+            return httpx.Response(200, json={"seq": 9, "errors": []})
+
+        await client_with(handler).fetch(since=7, within=120)
+
+        assert seen["params"] == {"since": "7"}
+
+
+class TestBoxFeedToken:
+    """The credential that made this feature actually work.
+
+    v1 authenticated as the signed-in Rails user, using the `api_token` the chat
+    frontend mints. That token only exists while the human holds a Devise
+    session in the browser tab, so on 2026-08-24 the whole feature silently
+    no-opped with `no Rails api_token on the frame`. The box reading its own
+    error log must not depend on a browser session.
+    """
+
+    def test_it_derives_the_token_from_the_shared_box_secret(self, monkeypatch):
+        from app.services.rails_error_feed import feed_token
+
+        monkeypatch.setenv("SECRET_KEY_BASE", "s3cret")
+        assert feed_token() == feed_token()
+        assert len(feed_token()) == 64
+
+    def test_a_different_secret_derives_a_different_token(self, monkeypatch):
+        from app.services.rails_error_feed import feed_token
+
+        monkeypatch.setenv("SECRET_KEY_BASE", "one")
+        first = feed_token()
+        monkeypatch.setenv("SECRET_KEY_BASE", "two")
+        assert feed_token() != first
+
+    def test_no_secret_means_no_token(self, monkeypatch):
+        from app.services.rails_error_feed import feed_token
+
+        monkeypatch.delenv("SECRET_KEY_BASE", raising=False)
+        assert feed_token() is None
+
+    def test_a_blank_secret_means_no_token(self, monkeypatch):
+        from app.services.rails_error_feed import feed_token
+
+        monkeypatch.setenv("SECRET_KEY_BASE", "   ")
+        assert feed_token() is None
+
+    def test_it_matches_the_ruby_side_byte_for_byte(self, monkeypatch):
+        # Pinned against OpenSSL::HMAC.hexdigest("SHA256", secret, purpose) —
+        # the two implementations are in different languages and nothing else
+        # would catch them drifting apart.
+        import hashlib
+        import hmac as _hmac
+
+        from app.services.rails_error_feed import feed_token
+
+        monkeypatch.setenv("SECRET_KEY_BASE", "s3cret")
+        expected = _hmac.new(b"s3cret", b"llamabot-error-feed", hashlib.sha256).hexdigest()
+        assert feed_token() == expected
+
+
+@pytest.mark.asyncio
+class TestCredentialChoice:
+    async def test_it_prefers_the_box_token_over_the_user_token(self, monkeypatch):
+        monkeypatch.setenv("SECRET_KEY_BASE", "s3cret")
+        seen = {}
+
+        def handler(request):
+            seen["auth"] = request.headers.get("Authorization")
+            return httpx.Response(200, json={"seq": 0, "errors": []})
+
+        await client_with(handler, token="user-token").fetch(since=0)
+
+        assert seen["auth"].startswith("LlamaBotFeed ")
+
+    async def test_it_works_with_no_user_token_at_all(self, monkeypatch):
+        # The exact case that was broken: nobody signed into Rails.
+        monkeypatch.setenv("SECRET_KEY_BASE", "s3cret")
+
+        def handler(request):
+            return httpx.Response(200, json={"seq": 3, "errors": []})
+
+        assert await client_with(handler, token=None).fetch(since=0) == (3, [])
+
+    async def test_it_falls_back_to_the_user_token_without_a_box_secret(self, monkeypatch):
+        monkeypatch.delenv("SECRET_KEY_BASE", raising=False)
+        seen = {}
+
+        def handler(request):
+            seen["auth"] = request.headers.get("Authorization")
+            return httpx.Response(200, json={"seq": 0, "errors": []})
+
+        await client_with(handler, token="user-token").fetch(since=0)
+
+        assert seen["auth"] == "LlamaBot user-token"
+
+    async def test_no_credential_at_all_makes_no_request(self, monkeypatch):
+        monkeypatch.delenv("SECRET_KEY_BASE", raising=False)
+        calls = []
+
+        def handler(request):
+            calls.append(request)
+            return httpx.Response(200, json={"seq": 0, "errors": []})
+
+        assert await client_with(handler, token=None).fetch(since=0) is None
+        assert calls == []

--- a/app/tests/test_rails_error_tray.py
+++ b/app/tests/test_rails_error_tray.py
@@ -1,0 +1,108 @@
+"""Shaping Rails crash-feed entries for the chat page's error tray.
+
+The tray is a one-line notice above the composer that already carries the
+preview's JavaScript errors. These are the server-side half: the same button
+press that renders a 500 should put a line there too, instead of the user
+staring at a Rails error page wondering whether Leo can see it.
+
+What matters here is that nothing the Rails app can put in an exception message
+can break the browser contract: entries with no usable text are dropped rather
+than rendered blank, the backtrace is trimmed to something a popup can hold, and
+the list is capped so a crash loop cannot hand the page a megabyte of stack.
+"""
+
+from app.lib import rails_error_tray as tray
+
+
+def _entry(**overrides):
+    base = {
+        "seq": 7,
+        "fingerprint": "abc123",
+        "error_class": "NoMethodError",
+        "message": "undefined method `title' for nil",
+        "method": "GET",
+        "path": "/posts/1",
+        "count": 1,
+        "at": "2026-08-23T10:00:00Z",
+        "backtrace": ["app/views/posts/show.html.erb:3", "app/controllers/posts_controller.rb:8"],
+    }
+    base.update(overrides)
+    return base
+
+
+def test_entry_carries_what_the_tray_renders():
+    shaped = tray.tray_entry(_entry())
+
+    assert shaped == {
+        "id": "rails-7",
+        "kind": "rails",
+        "message": "NoMethodError: undefined method `title' for nil",
+        "path": "GET /posts/1",
+        "count": 1,
+        "stack": "app/views/posts/show.html.erb:3\napp/controllers/posts_controller.rb:8",
+    }
+
+
+def test_path_omits_a_missing_method():
+    assert tray.tray_entry(_entry(method=None))["path"] == "/posts/1"
+
+
+def test_path_is_blank_when_rails_recorded_none():
+    # Background jobs crash with no request at all. The tray renders the error
+    # without a "on <path>" line rather than inventing one.
+    assert tray.tray_entry(_entry(method=None, path=None))["path"] == ""
+
+
+def test_message_falls_back_to_the_class_alone():
+    shaped = tray.tray_entry(_entry(message=""))
+    assert shaped["message"] == "NoMethodError"
+
+
+def test_entry_with_no_text_at_all_is_dropped():
+    # Rendering "" in the tray would tell the user something broke and refuse to
+    # say what. Better to have never counted it.
+    assert tray.tray_entry(_entry(error_class="", message="")) is None
+    assert tray.tray_entry("not a dict") is None
+
+
+def test_repeat_count_is_carried_through():
+    assert tray.tray_entry(_entry(count=42))["count"] == 42
+
+
+def test_junk_count_reads_as_one():
+    assert tray.tray_entry(_entry(count="lots"))["count"] == 1
+    assert tray.tray_entry(_entry(count=0))["count"] == 1
+
+
+def test_long_message_is_truncated():
+    shaped = tray.tray_entry(_entry(message="x" * 5000))
+    assert len(shaped["message"]) <= tray.MAX_MESSAGE_CHARS + len("NoMethodError: ")
+
+
+def test_backtrace_is_trimmed_to_the_frames_that_name_the_file():
+    shaped = tray.tray_entry(_entry(backtrace=[f"frame{i}" for i in range(50)]))
+    assert shaped["stack"].count("\n") + 1 == tray.MAX_BACKTRACE_LINES
+
+
+def test_missing_backtrace_gives_no_stack():
+    assert tray.tray_entry(_entry(backtrace=None))["stack"] is None
+    assert tray.tray_entry(_entry(backtrace=[]))["stack"] is None
+
+
+def test_entries_caps_the_list_and_keeps_the_newest():
+    shaped = tray.tray_entries([_entry(seq=i, message=f"boom {i}") for i in range(40)])
+
+    assert len(shaped) == tray.MAX_TRAY_ERRORS
+    # The ring is oldest-first, so the tail is what just happened.
+    assert shaped[-1]["message"].endswith("boom 39")
+
+
+def test_entries_skips_unusable_rows_without_dropping_the_rest():
+    shaped = tray.tray_entries([_entry(seq=1), {"seq": 2}, _entry(seq=3)])
+    assert [e["id"] for e in shaped] == ["rails-1", "rails-3"]
+
+
+def test_entries_tolerates_junk():
+    assert tray.tray_entries(None) == []
+    assert tray.tray_entries("nope") == []
+    assert tray.tray_entries([None, 5, "x"]) == []

--- a/app/tests/test_rails_error_watch.py
+++ b/app/tests/test_rails_error_watch.py
@@ -1,0 +1,305 @@
+"""Per-turn bookkeeping for mid-turn Rails auto-recovery.
+
+Pure logic only: no LangGraph, no HTTP, no event loop. Everything that decides
+whether an error is injected — and everything that stops a fix/break/fix loop —
+lives here so it can be pinned without a model.
+
+See docs/dev/rails_auto_recovery.md.
+"""
+import pytest
+
+from app.lib.rails_error_watch import (
+    MAX_INJECTIONS_PER_TURN,
+    MAX_REPORT_CHARS,
+    RailsErrorWatch,
+    agent_can_auto_recover,
+)
+
+
+def error(
+    seq=1,
+    fingerprint=None,
+    error_class="NoMethodError",
+    message="undefined method `titl' for an instance of Post",
+    path="/posts/3",
+    backtrace=None,
+    count=1,
+):
+    return {
+        "seq": seq,
+        "fingerprint": fingerprint or f"fp-{error_class}-{message}-{path}",
+        "error_class": error_class,
+        "message": message,
+        "method": "GET",
+        "path": path,
+        "context": "rack_middleware",
+        "count": count,
+        "at": "2026-08-22T10:00:00Z",
+        "backtrace": backtrace if backtrace is not None else ["app/views/posts/show.html.erb:4"],
+    }
+
+
+def watch(agent_name="rails_agent", api_token="tok"):
+    return RailsErrorWatch(thread_id="t1", agent_name=agent_name, api_token=api_token)
+
+
+class TestArming:
+    def test_a_working_agent_with_a_token_is_armed(self):
+        assert watch().armed is True
+
+    def test_a_watch_without_an_api_token_is_still_armed(self):
+        # The regression that broke this feature in the field: arming used to
+        # require the per-user Rails token off the WebSocket frame, which only
+        # exists while the human holds a Devise session. The box authenticates
+        # to its own error log with a derived secret instead, so a signed-out
+        # user must NOT disable crash recovery.
+        assert watch(api_token=None).armed is True
+
+    def test_plan_mode_agents_cannot_auto_recover(self):
+        assert agent_can_auto_recover("rails_plan_mode_agent") is False
+        assert agent_can_auto_recover("rails_engineer_plan_mode_agent") is False
+        assert watch(agent_name="rails_plan_mode_agent").armed is False
+
+    def test_editing_agents_can_auto_recover(self):
+        assert agent_can_auto_recover("rails_agent") is True
+        assert agent_can_auto_recover("rails_beginner_agent") is True
+
+    def test_missing_agent_name_cannot_auto_recover(self):
+        assert agent_can_auto_recover(None) is False
+        assert agent_can_auto_recover("") is False
+
+
+class TestPlanInjection:
+    def test_no_errors_means_no_message(self):
+        assert watch().plan_injection([]) is None
+
+    def test_a_new_error_produces_a_report_the_model_can_act_on(self):
+        text = watch().plan_injection([error()])
+
+        assert text is not None
+        assert text.startswith("[automated]")
+        assert "NoMethodError" in text
+        assert "undefined method `titl'" in text
+        assert "/posts/3" in text
+        assert "app/views/posts/show.html.erb:4" in text
+
+    def test_the_same_error_is_only_reported_once_per_turn(self):
+        w = watch()
+        assert w.plan_injection([error(seq=1)]) is not None
+        # A render loop re-raises the identical error; the model already knows.
+        assert w.plan_injection([error(seq=2)]) is None
+        assert w.injections == 1
+
+    def test_two_errors_in_one_poll_become_one_message(self):
+        text = watch().plan_injection([
+            error(seq=1, error_class="NoMethodError", message="one"),
+            error(seq=2, error_class="TypeError", message="two"),
+        ])
+
+        assert text.count("[automated]") == 1
+        assert "NoMethodError" in text and "TypeError" in text
+
+    def test_a_repeat_count_is_surfaced(self):
+        text = watch().plan_injection([error(count=7)])
+        assert "7" in text
+
+    def test_the_budget_allows_three_attempts(self):
+        w = watch()
+        for i in range(MAX_INJECTIONS_PER_TURN):
+            assert w.plan_injection([error(seq=i, message=f"boom {i}")]) is not None
+        assert w.injections == MAX_INJECTIONS_PER_TURN
+
+    def test_the_fourth_error_tells_the_agent_to_stop_and_explain(self):
+        w = watch()
+        for i in range(MAX_INJECTIONS_PER_TURN):
+            w.plan_injection([error(seq=i, message=f"boom {i}")])
+
+        text = w.plan_injection([error(seq=99, message="still broken")])
+
+        assert text is not None
+        assert "stop" in text.lower()
+        # The give-up note is not a repair attempt; the budget stays spent.
+        assert w.injections == MAX_INJECTIONS_PER_TURN
+        assert w.gave_up is True
+
+    def test_nothing_is_injected_after_the_give_up_note(self):
+        w = watch()
+        for i in range(MAX_INJECTIONS_PER_TURN):
+            w.plan_injection([error(seq=i, message=f"boom {i}")])
+        w.plan_injection([error(seq=98, message="give up now")])
+
+        assert w.plan_injection([error(seq=99, message="and another")]) is None
+
+    def test_a_huge_backtrace_cannot_blow_the_context_window(self):
+        giant = [f"app/models/thing.rb:{i}:in `method_{i}'" for i in range(400)]
+        text = watch().plan_injection([error(backtrace=giant)])
+
+        assert len(text) <= MAX_REPORT_CHARS
+        # The instruction survives truncation — a bare stack trace with no ask
+        # is the one shape that reliably produces no action.
+        assert "reload" in text.lower()
+
+    def test_many_errors_at_once_cannot_blow_the_context_window(self):
+        errors = [error(seq=i, message=f"distinct failure number {i}" * 20) for i in range(50)]
+        assert len(watch().plan_injection(errors)) <= MAX_REPORT_CHARS
+
+    def test_a_malformed_entry_does_not_raise(self):
+        # The feed is JSON off another process; a missing key must not take the
+        # turn down with it.
+        text = watch().plan_injection([{"seq": 1, "fingerprint": "x"}])
+        assert text is None or isinstance(text, str)
+
+
+class TestCursor:
+    def test_a_fresh_watch_has_no_cursor(self):
+        assert watch().cursor is None
+
+    def test_priming_records_where_the_log_was_when_the_turn_started(self):
+        w = watch()
+        w.prime(41)
+        assert w.cursor == 41
+
+    def test_priming_twice_does_not_move_the_cursor_backwards(self):
+        w = watch()
+        w.prime(41)
+        w.prime(3)
+        assert w.cursor == 41
+
+    def test_advance_moves_the_cursor_forward(self):
+        w = watch()
+        w.prime(41)
+        w.advance(45)
+        assert w.cursor == 45
+
+
+@pytest.mark.parametrize("agent", ["rails_agent", "leonardo"])
+def test_context_var_round_trip(agent):
+    from app.lib.rails_error_watch import current_error_watch, start_error_watch
+
+    started = start_error_watch(thread_id="t9", agent_name=agent, api_token="tok")
+    assert current_error_watch() is started
+    assert started.thread_id == "t9"
+
+
+class TestRegistry:
+    """A turn is not one WebSocket message.
+
+    Leo's own verify step is a ``browser_command`` interrupt: the graph pauses,
+    the frontend navigates the preview, and the answer arrives as a SEPARATE
+    frame that resumes the run. That navigation is the single most likely moment
+    for a 500 to appear — so the watch, its cursor and its budget have to
+    survive the resume rather than starting over (or vanishing).
+    """
+
+    def setup_method(self):
+        from app.lib.rails_error_watch import _reset_registry
+
+        _reset_registry()
+
+    def test_a_resume_finds_the_watch_the_turn_started_with(self):
+        from app.lib.rails_error_watch import resume_error_watch, start_error_watch
+
+        started = start_error_watch(thread_id="t1", agent_name="rails_agent", api_token="tok")
+        started.prime(41)
+        started.plan_injection([error(seq=42, message="first crash")])
+
+        resumed = resume_error_watch(thread_id="t1")
+
+        assert resumed is started
+        assert resumed.cursor == 41
+        # Budget carries across the resume — three attempts per turn, not three
+        # per WebSocket frame.
+        assert resumed.injections == 1
+
+    def test_resuming_an_unknown_thread_is_not_an_error(self):
+        from app.lib.rails_error_watch import current_error_watch, resume_error_watch
+
+        assert resume_error_watch(thread_id="never-seen") is None
+        assert current_error_watch() is None
+
+    def test_a_new_user_message_starts_a_fresh_budget(self):
+        from app.lib.rails_error_watch import start_error_watch
+
+        first = start_error_watch(thread_id="t1", agent_name="rails_agent", api_token="tok")
+        first.plan_injection([error(message="crash from the previous turn")])
+
+        second = start_error_watch(thread_id="t1", agent_name="rails_agent", api_token="tok")
+
+        assert second is not first
+        assert second.injections == 0
+        assert second.cursor is None
+
+    def test_threads_do_not_share_a_watch(self):
+        from app.lib.rails_error_watch import resume_error_watch, start_error_watch
+
+        a = start_error_watch(thread_id="a", agent_name="rails_agent", api_token="tok")
+        b = start_error_watch(thread_id="b", agent_name="rails_agent", api_token="tok")
+
+        assert resume_error_watch(thread_id="a") is a
+        assert resume_error_watch(thread_id="b") is b
+
+    def test_the_registry_cannot_grow_without_bound(self):
+        from app.lib.rails_error_watch import (
+            MAX_TRACKED_THREADS,
+            _registry_size,
+            start_error_watch,
+        )
+
+        for i in range(MAX_TRACKED_THREADS + 20):
+            start_error_watch(thread_id=f"t{i}", agent_name="rails_agent", api_token="tok")
+
+        assert _registry_size() <= MAX_TRACKED_THREADS
+
+    def test_the_oldest_thread_is_the_one_evicted(self):
+        from app.lib.rails_error_watch import (
+            MAX_TRACKED_THREADS,
+            resume_error_watch,
+            start_error_watch,
+        )
+
+        for i in range(MAX_TRACKED_THREADS + 1):
+            start_error_watch(thread_id=f"t{i}", agent_name="rails_agent", api_token="tok")
+
+        assert resume_error_watch(thread_id="t0") is None
+        assert resume_error_watch(thread_id=f"t{MAX_TRACKED_THREADS}") is not None
+
+
+class TestPreExistingBreakage:
+    """The app was already broken when the user hit send.
+
+    This is the common shape — "it's showing an error, fix it" — and the first
+    build missed it entirely: the cursor was primed to NOW, so a crash that had
+    already happened could never be newer than the cursor and the turn stayed
+    silent while the user stared at the error page.
+    """
+
+    def test_a_pre_existing_crash_is_reported(self):
+        text = watch().plan_injection([error()], pre_existing=True)
+
+        assert text is not None
+        assert "NoMethodError" in text
+
+    def test_it_does_not_blame_the_agent_for_a_pre_existing_crash(self):
+        text = watch().plan_injection([error()], pre_existing=True)
+
+        # The agent has not done anything yet on this turn; telling it "you
+        # probably caused this" invites it to revert work it never did.
+        assert "caused by a change you just made" not in text
+        assert "right now" in text.lower()
+
+    def test_a_mid_turn_crash_still_points_at_the_agent(self):
+        text = watch().plan_injection([error()])
+
+        assert "caused by a change you just made" in text
+
+    def test_a_pre_existing_crash_spends_the_same_budget(self):
+        w = watch()
+        w.plan_injection([error(message="already broken")], pre_existing=True)
+
+        assert w.injections == 1
+
+    def test_a_pre_existing_crash_is_not_re_reported_mid_turn(self):
+        w = watch()
+        w.plan_injection([error()], pre_existing=True)
+
+        assert w.plan_injection([error()]) is None

--- a/app/tests/test_rails_error_watch_middleware.py
+++ b/app/tests/test_rails_error_watch_middleware.py
@@ -1,0 +1,298 @@
+"""The model-call boundary half of mid-turn Rails auto-recovery.
+
+This middleware runs before every single model call in the product, so the tests
+that matter most are the negative ones: with no watch installed, with the feed
+broken, or in a read-only mode, it must be indistinguishable from not being
+there at all.
+
+See docs/dev/rails_auto_recovery.md.
+"""
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+
+from app.agents.leonardo.rails_error_watch_middleware import RailsErrorWatchMiddleware
+from app.lib.rails_error_watch import (
+    ARMING_WINDOW_SECONDS,
+    clear_error_watch,
+    start_error_watch,
+)
+
+
+class FakeRequest:
+    """Stand-in for LangChain's ModelRequest — messages plus override()."""
+
+    def __init__(self, messages):
+        self.messages = list(messages)
+
+    def override(self, **kwargs):
+        return FakeRequest(kwargs.get("messages", self.messages))
+
+
+class FakeFeed:
+    """Records the cursors it was asked for and replays canned answers."""
+
+    def __init__(self, answers):
+        self.answers = list(answers)
+        self.calls = []
+
+    async def fetch(self, *, since, within=None):
+        self.calls.append((since, within))
+        if not self.answers:
+            return None
+        answer = self.answers.pop(0)
+        if isinstance(answer, Exception):
+            raise answer
+        return answer
+
+
+def middleware_with(feed):
+    return RailsErrorWatchMiddleware(feed_factory=lambda watch: feed)
+
+
+def crash(seq=2, message="undefined method `titl'"):
+    return {
+        "seq": seq,
+        "fingerprint": f"fp-{seq}",
+        "error_class": "NoMethodError",
+        "message": message,
+        "method": "GET",
+        "path": "/posts/3",
+        "count": 1,
+        "backtrace": ["app/views/posts/show.html.erb:4"],
+    }
+
+
+async def run(middleware, request):
+    """Call the middleware with a handler that records what it received."""
+    seen = {}
+
+    async def handler(req):
+        seen["request"] = req
+        return "model-response"
+
+    result = await middleware.awrap_model_call(request, handler)
+    return seen["request"], result
+
+
+@pytest.fixture(autouse=True)
+def _no_watch_leaks():
+    clear_error_watch()
+    yield
+    clear_error_watch()
+
+
+@pytest.mark.asyncio
+class TestInert:
+    async def test_no_watch_means_the_request_is_passed_straight_through(self):
+        # Headless runs, tests, and anything that did not go through the chat
+        # request handler have no watch installed.
+        feed = FakeFeed([(9, [crash()])])
+        request = FakeRequest([HumanMessage(content="hi")])
+
+        seen, result = await run(middleware_with(feed), request)
+
+        assert seen is request
+        assert result == "model-response"
+        assert feed.calls == []
+
+    async def test_a_plan_mode_turn_never_polls(self):
+        start_error_watch(thread_id="t", agent_name="rails_plan_mode_agent", api_token="tok")
+        feed = FakeFeed([(9, [crash()])])
+
+        seen, _ = await run(middleware_with(feed), FakeRequest([HumanMessage(content="hi")]))
+
+        assert feed.calls == []
+        assert len(seen.messages) == 1
+
+    async def test_a_turn_with_no_rails_user_token_still_polls(self):
+        # See TestArming in test_rails_error_watch.py: the box reads its own
+        # error log, so being signed out of Rails cannot switch this off.
+        start_error_watch(thread_id="t", agent_name="rails_agent", api_token=None)
+        feed = FakeFeed([(9, [crash()])])
+
+        seen, _ = await run(middleware_with(feed), FakeRequest([HumanMessage(content="hi")]))
+
+        assert feed.calls == [(None, ARMING_WINDOW_SECONDS)]
+        assert len(seen.messages) == 2
+
+
+@pytest.mark.asyncio
+class TestPriming:
+    async def test_the_first_model_call_arms_the_cursor(self):
+        watch = start_error_watch(thread_id="t", agent_name="rails_agent", api_token="tok")
+        feed = FakeFeed([(41, [])])
+
+        seen, _ = await run(middleware_with(feed), FakeRequest([HumanMessage(content="hi")]))
+
+        assert feed.calls == [(None, ARMING_WINDOW_SECONDS)]
+        assert watch.cursor == 41
+        assert len(seen.messages) == 1
+
+    async def test_an_app_already_broken_when_the_user_asked_is_reported(self):
+        # The case the first build missed: user is parked on the error page and
+        # types "fix it". No NEW crash is coming, so the arming call has to be
+        # the one that speaks up.
+        start_error_watch(thread_id="t", agent_name="rails_agent", api_token="tok")
+        feed = FakeFeed([(41, [crash(seq=41)])])
+
+        seen, _ = await run(middleware_with(feed), FakeRequest([HumanMessage(content="fix it")]))
+
+        assert len(seen.messages) == 2
+        assert seen.messages[-1].content.startswith("[automated]")
+        assert "RIGHT NOW" in seen.messages[-1].content
+
+    async def test_the_same_crash_is_not_reported_again_after_arming(self):
+        start_error_watch(thread_id="t", agent_name="rails_agent", api_token="tok")
+        feed = FakeFeed([(41, [crash(seq=41)]), (41, [crash(seq=41)])])
+        mw = middleware_with(feed)
+
+        await run(mw, FakeRequest([HumanMessage(content="fix it")]))
+        seen, _ = await run(mw, FakeRequest([HumanMessage(content="fix it")]))
+
+        assert len(seen.messages) == 1
+
+    async def test_the_second_call_asks_for_what_happened_since(self):
+        start_error_watch(thread_id="t", agent_name="rails_agent", api_token="tok")
+        feed = FakeFeed([(41, []), (41, [])])
+        mw = middleware_with(feed)
+
+        await run(mw, FakeRequest([HumanMessage(content="hi")]))
+        await run(mw, FakeRequest([HumanMessage(content="hi")]))
+
+        assert feed.calls == [(None, ARMING_WINDOW_SECONDS), (41, None)]
+
+
+@pytest.mark.asyncio
+class TestInjection:
+    async def test_a_crash_during_the_turn_is_put_in_front_of_the_model(self):
+        start_error_watch(thread_id="t", agent_name="rails_agent", api_token="tok")
+        feed = FakeFeed([(41, []), (42, [crash(seq=42)])])
+        mw = middleware_with(feed)
+        await run(mw, FakeRequest([HumanMessage(content="hi")]))
+
+        seen, result = await run(
+            mw, FakeRequest([HumanMessage(content="hi"), ToolMessage(content="ok", tool_call_id="1")])
+        )
+
+        assert len(seen.messages) == 3
+        injected = seen.messages[-1]
+        assert isinstance(injected, HumanMessage)
+        assert injected.content.startswith("[automated]")
+        assert "NoMethodError" in injected.content
+        # Transparent: the handler's return value is never touched.
+        assert result == "model-response"
+
+    async def test_the_cursor_advances_so_the_same_crash_is_not_refetched(self):
+        watch = start_error_watch(thread_id="t", agent_name="rails_agent", api_token="tok")
+        feed = FakeFeed([(41, []), (42, [crash(seq=42)]), (42, [])])
+        mw = middleware_with(feed)
+
+        await run(mw, FakeRequest([HumanMessage(content="hi")]))
+        await run(mw, FakeRequest([HumanMessage(content="hi")]))
+        await run(mw, FakeRequest([HumanMessage(content="hi")]))
+
+        assert feed.calls == [(None, ARMING_WINDOW_SECONDS), (41, None), (42, None)]
+        assert watch.cursor == 42
+
+    async def test_nothing_is_appended_after_an_unanswered_tool_call(self):
+        # An assistant message with tool_calls must be followed by ToolMessages;
+        # slipping a HumanMessage in there 400s the next model call.
+        start_error_watch(thread_id="t", agent_name="rails_agent", api_token="tok")
+        feed = FakeFeed([(41, []), (42, [crash(seq=42)])])
+        mw = middleware_with(feed)
+        await run(mw, FakeRequest([HumanMessage(content="hi")]))
+
+        pending = AIMessage(
+            content="",
+            tool_calls=[{"name": "edit_file", "args": {}, "id": "call_1"}],
+        )
+        seen, _ = await run(mw, FakeRequest([HumanMessage(content="hi"), pending]))
+
+        assert len(seen.messages) == 2
+
+
+@pytest.mark.asyncio
+class TestNeverFatal:
+    async def test_a_raising_feed_does_not_break_the_turn(self):
+        start_error_watch(thread_id="t", agent_name="rails_agent", api_token="tok")
+        feed = FakeFeed([RuntimeError("feed exploded")])
+        request = FakeRequest([HumanMessage(content="hi")])
+
+        seen, result = await run(middleware_with(feed), request)
+
+        assert seen is request
+        assert result == "model-response"
+
+    async def test_an_unreachable_feed_leaves_the_cursor_unarmed(self):
+        watch = start_error_watch(thread_id="t", agent_name="rails_agent", api_token="tok")
+        feed = FakeFeed([None, (41, [])])
+        mw = middleware_with(feed)
+
+        await run(mw, FakeRequest([HumanMessage(content="hi")]))
+        assert watch.cursor is None
+
+        # Rails comes back; the next call arms as if it were the first.
+        await run(mw, FakeRequest([HumanMessage(content="hi")]))
+        assert watch.cursor == 41
+        assert feed.calls == [(None, ARMING_WINDOW_SECONDS), (None, ARMING_WINDOW_SECONDS)]
+
+
+def test_every_leonardo_agent_gets_the_middleware(monkeypatch):
+    # Wiring guard, same chokepoint argument as TurnMetricsMiddleware: if it is
+    # not added here, individual modes lose auto-recovery silently.
+    from app.agents.leonardo import agent_factory
+
+    captured = {}
+
+    def fake_create_agent(**kwargs):
+        captured["middleware"] = kwargs.get("middleware")
+        return "agent"
+
+    monkeypatch.setattr(agent_factory, "create_agent", fake_create_agent)
+    agent_factory.build_leonardo_agent(model="x", tools=[])
+
+    assert sum(
+        isinstance(m, RailsErrorWatchMiddleware) for m in captured["middleware"]
+    ) == 1
+
+
+def test_the_middleware_is_not_added_twice(monkeypatch):
+    from app.agents.leonardo import agent_factory
+
+    captured = {}
+
+    def fake_create_agent(**kwargs):
+        captured["middleware"] = kwargs.get("middleware")
+        return "agent"
+
+    monkeypatch.setattr(agent_factory, "create_agent", fake_create_agent)
+    agent_factory.build_leonardo_agent(
+        model="x", tools=[], middleware=[RailsErrorWatchMiddleware()]
+    )
+
+    assert sum(
+        isinstance(m, RailsErrorWatchMiddleware) for m in captured["middleware"]
+    ) == 1
+
+
+def test_the_request_handler_arms_and_resumes_the_watch():
+    """Wiring guard for the three call sites in the WebSocket request handler.
+
+    Source-level, same approach as the build_leonardo_agent guard in
+    test_orphaned_toolcall_repair_all_agents.py: standing the whole handler up
+    would test FastAPI, not this. What must hold is that a user message starts a
+    fresh watch and that BOTH resume paths re-install it — the browser_command
+    resume in particular, since Leo navigating the preview to verify its own fix
+    is the most likely moment for a 500 to appear.
+    """
+    from pathlib import Path
+
+    import app.websocket.request_handler as rh
+
+    source = Path(rh.__file__).read_text()
+
+    assert source.count("start_error_watch(") == 1, "exactly one arm site"
+    assert source.count("resume_error_watch(thread_id=") == 2, (
+        "both handle_approval_response and handle_question_response must resume "
+        "the turn's watch"
+    )

--- a/app/tests/test_rails_errors_endpoint.py
+++ b/app/tests/test_rails_errors_endpoint.py
@@ -1,0 +1,158 @@
+"""The /api/rails-errors proxy the chat page's error tray polls.
+
+Why a proxy at all, rather than the browser reading the Rails feed directly:
+``GET /llama_bot/errors`` sets no CORS headers and the chat page is a different
+origin, so a direct fetch is blocked. Proxying also means this shipped in the
+LlamaBot image alone — it works against every gem old enough to serve the feed,
+with no skeleton release in the way.
+
+What matters here: the Rails bearer token travels in a header and never in the
+query string (it is a live 30-minute credential and query strings land in access
+logs), a cursor probe stays a probe, and every failure degrades to "no
+information" instead of an error the tray would have to render.
+"""
+
+import asyncio
+from typing import Optional
+
+import pytest
+
+from app.routers import api
+
+
+class FakeRequest:
+    def __init__(self, params=None, headers=None):
+        self.query_params = params or {}
+        self.headers = headers or {}
+
+
+class FakeFeed:
+    """Stands in for RailsErrorFeedClient."""
+
+    last: Optional["FakeFeed"] = None
+
+    def __init__(self, *, token=None, result=None, boom=False):
+        self.token = token
+        self._result = result
+        self._boom = boom
+        self.since = "unset"
+        FakeFeed.last = self
+
+    async def fetch(self, *, since):
+        self.since = since
+        if self._boom:
+            raise RuntimeError("rails is restarting")
+        return self._result
+
+
+@pytest.fixture(autouse=True)
+def reset_feed():
+    FakeFeed.last = None
+    yield
+    FakeFeed.last = None
+
+
+def call(request, **feed_kwargs):
+    """Drive the helper the route delegates to.
+
+    The route itself is two lines — an auth dependency and this call — because a
+    ``feed_factory`` keyword on the handler would be read by FastAPI as a query
+    parameter. ``test_endpoint_requires_a_signed_in_user`` covers the wiring.
+    """
+    def factory(token):
+        return FakeFeed(token=token, **feed_kwargs)
+
+    return asyncio.run(api._rails_errors(request, feed_factory=factory))
+
+
+TOKEN = {"X-Rails-Api-Token": "tok-abc"}
+
+
+def test_returns_shaped_entries_for_the_tray():
+    body = call(
+        FakeRequest({"since": "4"}, TOKEN),
+        result=(6, [{
+            "seq": 5,
+            "error_class": "NoMethodError",
+            "message": "undefined method `title' for nil",
+            "method": "GET",
+            "path": "/posts/1",
+            "count": 1,
+            "backtrace": ["app/views/posts/show.html.erb:3"],
+        }]),
+    )
+
+    assert body["seq"] == 6
+    assert body["available"] is True
+    assert body["errors"] == [{
+        "id": "rails-5",
+        "kind": "rails",
+        "message": "NoMethodError: undefined method `title' for nil",
+        "path": "GET /posts/1",
+        "count": 1,
+        "stack": "app/views/posts/show.html.erb:3",
+    }]
+
+
+def test_token_comes_from_the_header():
+    call(FakeRequest({"since": "4"}, TOKEN), result=(1, []))
+    assert FakeFeed.last.token == "tok-abc"
+
+
+def test_token_in_the_query_string_is_ignored():
+    # A live bearer credential must not be loggable. If it only arrives this way
+    # we behave as if we had no token at all.
+    body = call(FakeRequest({"since": "4", "api_token": "tok-abc"}, {}))
+    assert body == {"seq": None, "errors": [], "available": False}
+    assert FakeFeed.last is None
+
+
+def test_no_token_never_dials_rails():
+    body = call(FakeRequest({"since": "4"}, {}))
+    assert body["available"] is False
+    assert FakeFeed.last is None
+
+
+def test_missing_since_is_a_cursor_probe():
+    # How the tray arms itself on page load: learn where the log stands, take
+    # nothing. Crashes from before the user opened the page are not news.
+    body = call(FakeRequest({}, TOKEN), result=(9, []))
+    assert FakeFeed.last.since is None
+    assert body == {"seq": 9, "errors": [], "available": True}
+
+
+def test_garbled_cursor_is_a_probe_not_a_replay():
+    # Reading a junk cursor as 0 would replay the whole ring into the tray.
+    call(FakeRequest({"since": "not-a-number"}, TOKEN), result=(9, []))
+    assert FakeFeed.last.since is None
+
+
+def test_negative_cursor_is_a_probe():
+    call(FakeRequest({"since": "-3"}, TOKEN), result=(9, []))
+    assert FakeFeed.last.since is None
+
+
+def test_cursor_is_passed_through_as_an_int():
+    call(FakeRequest({"since": "12"}, TOKEN), result=(12, []))
+    assert FakeFeed.last.since == 12
+
+
+def test_unavailable_feed_reports_no_information():
+    # Gem too old to serve the endpoint, token expired, Rails restarting. The
+    # tray holds its cursor and tries again; it must not render an error about
+    # not being able to fetch errors.
+    body = call(FakeRequest({"since": "4"}, TOKEN), result=None)
+    assert body == {"seq": None, "errors": [], "available": False}
+
+
+def test_a_raising_feed_is_not_a_500():
+    body = call(FakeRequest({"since": "4"}, TOKEN), boom=True)
+    assert body == {"seq": None, "errors": [], "available": False}
+
+
+def test_endpoint_requires_a_signed_in_user():
+    # Backtraces name file paths and line numbers; this is not public.
+    from app.dependencies import auth
+
+    route = next(r for r in api.router.routes if getattr(r, "path", None) == "/api/rails-errors")
+    assert any(d.call is auth for d in route.dependant.dependencies)

--- a/app/tests/test_rails_token_verification.py
+++ b/app/tests/test_rails_token_verification.py
@@ -1,0 +1,177 @@
+"""Round-trip verification of real ``llama_bot_rails`` WebSocket tokens.
+
+The bug: ``verify_rails_token`` verified nothing. It accepted any string
+containing ``--`` as proof of a trusted internal caller, so ``{"api_token":
+"x--y"}`` authenticated as the Rails gem from anywhere on the internet, and
+the agent-mode gate skipped ``rails_auth`` callers entirely.
+
+Every token below was minted by a **real Rails 7.2.3 app** with the gem loaded,
+using the same digest and serializer ``Rails.application.message_verifier(
+:llamabot_ws)`` uses, against the throwaway secret in ``TEST_SKB``. They are
+golden vectors, not fixtures our own code produced — that is the whole point:
+they prove the Python verifier agrees with Ruby, rather than with itself.
+
+Run with: pytest app/tests/test_rails_token_verification.py -v
+"""
+import pytest
+
+from app.services.rails_message_verifier import (
+    InvalidRailsToken,
+    derive_key,
+    verify,
+)
+
+from app.tests.rails_token_vectors import (  # noqa: F401
+    EXPIRED,
+    JSON_SERIALIZER,
+    NO_METADATA,
+    OTHER_SKB,
+    SHA256_DIGEST,
+    SHA256_KEY_DIGEST,
+    TAMPERED,
+    TEST_SKB,
+    VALID,
+    VALID_NO_USER,
+    WRONG_KEY,
+)
+
+
+class TestAcceptsRealTokens:
+    """Criterion 1: a token Rails actually minted verifies, with the right user."""
+
+    def test_verifies_and_extracts_user_id(self):
+        payload = verify(VALID, TEST_SKB)
+        assert payload["user_id"] == 4242
+        assert payload["session_id"] == "sess-1"
+
+    def test_signed_out_rails_app_still_verifies(self):
+        # current_user_resolver returns nil when nobody is signed into the Rails
+        # app, and the gem mints `user_id: nil` rather than refusing. The
+        # signature still proves the box's own Rails app sent it, so this must
+        # keep working or every signed-out box loses its embedded chat.
+        payload = verify(VALID_NO_USER, TEST_SKB)
+        assert payload["user_id"] is None
+        assert payload["session_id"] == "sess-2"
+
+    def test_payload_without_metadata_envelope(self):
+        # Rails only wraps in `_rails` when expiry or purpose is set.
+        payload = verify(NO_METADATA, TEST_SKB)
+        assert payload["user_id"] == 55
+
+    def test_json_serialized_payload(self):
+        # A box with `message_serializer = :json` mints JSON, not Marshal.
+        payload = verify(JSON_SERIALIZER, TEST_SKB)
+        assert payload["user_id"] == 606
+
+    def test_stronger_signing_digest_still_verifies(self):
+        payload = verify(SHA256_DIGEST, TEST_SKB)
+        assert payload["user_id"] == 777
+
+    def test_stronger_key_derivation_digest_still_verifies(self):
+        # `key_generator_hash_digest_class` is a separate setting from the
+        # signing digest, and a box may have either. Assuming one cost us a
+        # rejected live token — see rails_token_vectors.
+        payload = verify(SHA256_KEY_DIGEST, TEST_SKB)
+        assert payload["user_id"] == 888
+
+
+class TestRejectsForgeries:
+    """Criterion 2: the forgeries that used to sail through."""
+
+    @pytest.mark.parametrize("token", [
+        "x--y",              # the exact string from the disclosure
+        "--",
+        "a--b--c",
+        "",
+        "no-separator",
+        "eyJhbGciOiJIUzI1NiJ9.body.sig",
+    ])
+    def test_junk_is_rejected(self, token):
+        with pytest.raises(InvalidRailsToken):
+            verify(token, TEST_SKB)
+
+    def test_token_signed_with_a_different_key_is_rejected(self):
+        with pytest.raises(InvalidRailsToken):
+            verify(WRONG_KEY, TEST_SKB)
+
+    def test_expired_token_is_rejected(self):
+        with pytest.raises(InvalidRailsToken):
+            verify(EXPIRED, TEST_SKB)
+
+    def test_tampered_payload_is_rejected(self):
+        with pytest.raises(InvalidRailsToken):
+            verify(TAMPERED, TEST_SKB)
+
+    def test_valid_signature_wrong_salt_is_rejected(self):
+        with pytest.raises(InvalidRailsToken):
+            verify(VALID, TEST_SKB, salt="some_other_verifier")
+
+    def test_purpose_mismatch_is_rejected(self):
+        # These tokens carry no purpose; demanding one must fail closed.
+        with pytest.raises(InvalidRailsToken):
+            verify(VALID, TEST_SKB, purpose="login")
+
+
+class TestKeyDerivation:
+    """The derivation digest (SHA256) is not the signing digest (SHA1)."""
+
+    def test_key_is_64_bytes(self):
+        assert len(derive_key(TEST_SKB)) == 64
+
+    def test_salt_changes_the_key(self):
+        assert derive_key(TEST_SKB, "llamabot_ws") != derive_key(TEST_SKB, "other")
+
+    def test_secret_changes_the_key(self):
+        assert derive_key(TEST_SKB) != derive_key(OTHER_SKB)
+
+
+class TestTokenServiceIntegration:
+    """The seam the WebSocket actually calls."""
+
+    @pytest.fixture(autouse=True)
+    def _secret(self, monkeypatch):
+        monkeypatch.setenv("SECRET_KEY_BASE", TEST_SKB)
+
+    def test_forged_token_is_refused(self):
+        from app.services.token_service import verify_rails_token
+        assert verify_rails_token("x--y") is None
+
+    def test_real_token_is_accepted_as_rails_auth(self):
+        from app.services.token_service import verify_rails_token
+        payload = verify_rails_token(VALID)
+        assert payload is not None
+        assert payload["type"] == "rails_auth"
+        assert payload["rails_user_id"] == 4242
+
+    def test_rails_user_id_is_not_exposed_as_user_id(self):
+        # `user_id` is a LlamaBot auth-DB id and gets stamped as the turn owner
+        # (request_context.set_current_user_id) to pick whose ChatGPT
+        # subscription to spend. A Rails app's user id lives in a different
+        # namespace entirely — leaking it into that key would bill the wrong
+        # account, so it travels under `rails_user_id`.
+        from app.services.token_service import verify_rails_token
+        assert verify_rails_token(VALID).get("user_id") is None
+
+    def test_expired_token_is_refused(self):
+        from app.services.token_service import verify_rails_token
+        assert verify_rails_token(EXPIRED) is None
+
+    def test_foreign_key_token_is_refused(self):
+        from app.services.token_service import verify_rails_token
+        assert verify_rails_token(WRONG_KEY) is None
+
+    def test_without_a_shared_secret_nothing_is_trusted(self, monkeypatch):
+        # No SECRET_KEY_BASE means no way to tell real from forged. Fail closed.
+        monkeypatch.delenv("SECRET_KEY_BASE", raising=False)
+        from app.services.token_service import verify_rails_token
+        assert verify_rails_token(VALID) is None
+
+    def test_json_serialized_rails_token_is_recognised(self):
+        # It starts with "eyJ", which the old shape check used as its "this is a
+        # JWT, not a Rails token" signal — so these were misrouted and refused.
+        from app.services.token_service import is_rails_token
+        assert is_rails_token(JSON_SERIALIZER) is True
+
+    def test_a_real_jwt_is_not_mistaken_for_a_rails_token(self):
+        from app.services.token_service import is_rails_token
+        assert is_rails_token("eyJhbGciOiJIUzI1NiJ9.eyJhIjoxfQ.sig") is False

--- a/app/tests/test_report_user_identity.py
+++ b/app/tests/test_report_user_identity.py
@@ -1,0 +1,270 @@
+"""Mothership reports must say WHO sent the message, not just which box.
+
+Before 0.7.4 every report carried ``instance_name`` and nothing else about the
+person at the keyboard, so a multi-user box produced telemetry nobody could
+attribute. These tests pin the wire contract: a ``user`` object keyed on
+``llamapress_user_guid`` (the mothership's own identifier for the account —
+mapping happens there, not here), and total silence when identity is unknown.
+"""
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from app.services import user_context
+from app.services.mothership_client import MothershipClient, TELEMETRY_DISABLED_ENV
+
+FAKE_CONFIG = {
+    "instance_name": "test-instance",
+    "mothership_url": "https://mothership.example.com",
+    "mothership_api_token": "tok-test",
+}
+
+SAMPLE_USER = {
+    "id": 3,
+    "username": "kody@llamapress.ai",
+    "email": "kody@llamapress.ai",
+    "llamapress_user_guid": "guid-abc-123",
+    "role": "engineer",
+    "is_admin": True,
+}
+
+
+@pytest.fixture(autouse=True)
+def _reporting_not_suppressed(monkeypatch):
+    """These tests assert the reported payloads, so the suite-wide telemetry kill
+    switch (app/tests/conftest.py) has to be off. httpx is patched throughout."""
+    monkeypatch.delenv(TELEMETRY_DISABLED_ENV, raising=False)
+
+
+@pytest.fixture(autouse=True)
+def _clean_turn_stamp():
+    """A leaked stamp would attribute one test's report to another's user — the
+    exact failure mode the ContextVar exists to prevent."""
+    token = user_context.set_current(None)
+    yield
+    user_context.reset(token)
+
+
+def _make_client() -> MothershipClient:
+    client = MothershipClient.__new__(MothershipClient)
+    client.config = FAKE_CONFIG
+    return client
+
+
+def _capturing_http(captured: dict):
+    async def fake_post(url, *, json, headers):
+        captured["url"] = url
+        captured["payload"] = json
+        resp = MagicMock(spec=httpx.Response)
+        resp.status_code = 200
+        resp.json.return_value = {"ok": True}
+        resp.raise_for_status = MagicMock()
+        return resp
+
+    mock_http = MagicMock()
+    mock_http.__aenter__ = AsyncMock(return_value=mock_http)
+    mock_http.__aexit__ = AsyncMock(return_value=False)
+    mock_http.post = AsyncMock(side_effect=fake_post)
+    return mock_http
+
+
+async def _post_and_capture(coro_factory) -> dict:
+    captured = {}
+    with patch(
+        "app.services.mothership_client.httpx.AsyncClient",
+        return_value=_capturing_http(captured),
+    ):
+        await coro_factory()
+    return captured["payload"]
+
+
+# ---------------------------------------------------------------------------
+# describe() — the wire shape
+# ---------------------------------------------------------------------------
+
+
+def test_describe_carries_the_guid_the_mothership_minted():
+    """The guid is the join key: the mothership issued it during unified login,
+    so it maps guid -> llamapress.ai account with no translation on this side."""
+    user = SimpleNamespace(
+        id=3,
+        username="kody@llamapress.ai",
+        email="kody@llamapress.ai",
+        llamapress_user_guid="guid-abc-123",
+        role="engineer",
+        is_admin=True,
+    )
+    assert user_context.describe(user) == SAMPLE_USER
+
+
+def test_describe_legacy_user_reports_null_guid_not_a_guess():
+    """A username/password user predates unified login. There is no
+    llamapress.ai account to point at, and inventing one from the username
+    would be a fabricated identity, so the guid stays None."""
+    user = SimpleNamespace(
+        id=1, username="admin", email=None, llamapress_user_guid=None,
+        role="engineer", is_admin=True,
+    )
+    described = user_context.describe(user)
+    assert described["llamapress_user_guid"] is None
+    assert described["username"] == "admin"
+
+
+def test_describe_none_is_none():
+    assert user_context.describe(None) is None
+
+
+def test_from_token_payload_marks_a_rails_gem_caller():
+    """A gem token names a RAILS user in a different namespace — reportable as a
+    partial identity, but never as a llamapress.ai account."""
+    described = user_context.from_token_payload({
+        "sub": "rails_user:5",
+        "source": "llama_bot_rails",
+        "rails_user_id": 5,
+        "role": "rails",
+        "is_admin": False,
+    })
+    assert described["username"] == "rails_user:5"
+    assert described["rails_user_id"] == 5
+    assert described["llamapress_user_guid"] is None
+    assert described["id"] is None
+
+
+# ---------------------------------------------------------------------------
+# report_message
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_report_message_includes_explicit_user():
+    client = _make_client()
+    payload = await _post_and_capture(lambda: client.report_message(
+        thread_id="t-1", role="user", content="hi",
+        sent_at="2026-08-25T00:00:00+00:00", user=SAMPLE_USER,
+    ))
+    assert payload["user"] == SAMPLE_USER
+
+
+@pytest.mark.asyncio
+async def test_report_message_falls_back_to_the_turn_stamp():
+    """The WebSocket path cannot pass a user: report_message fires inside a
+    RequestHandler built before authentication. It reads the stamp instead."""
+    client = _make_client()
+    user_context.set_current(SAMPLE_USER)
+    payload = await _post_and_capture(lambda: client.report_message(
+        thread_id="t-1", role="assistant", content="hello",
+        sent_at="2026-08-25T00:00:00+00:00",
+    ))
+    assert payload["user"] == SAMPLE_USER
+
+
+@pytest.mark.asyncio
+async def test_report_message_omits_user_when_unknown():
+    """No stamp, no argument -> the payload looks exactly as it did before this
+    feature. An unattributed row beats a wrong one."""
+    client = _make_client()
+    payload = await _post_and_capture(lambda: client.report_message(
+        thread_id="t-1", role="user", content="hi",
+        sent_at="2026-08-25T00:00:00+00:00",
+    ))
+    assert "user" not in payload
+
+
+@pytest.mark.asyncio
+async def test_explicit_user_wins_over_the_stamp():
+    client = _make_client()
+    user_context.set_current(SAMPLE_USER)
+    other = dict(SAMPLE_USER, id=9, llamapress_user_guid="guid-other")
+    payload = await _post_and_capture(lambda: client.report_message(
+        thread_id="t-1", role="user", content="hi",
+        sent_at="2026-08-25T00:00:00+00:00", user=other,
+    ))
+    assert payload["user"]["llamapress_user_guid"] == "guid-other"
+
+
+# ---------------------------------------------------------------------------
+# the other three report paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_report_error_includes_user():
+    client = _make_client()
+    user_context.set_current(SAMPLE_USER)
+    payload = await _post_and_capture(lambda: client.report_error(
+        thread_id="t-1", error_class="ValueError",
+        error_message="boom", traceback_str="tb",
+    ))
+    assert payload["user"] == SAMPLE_USER
+
+
+@pytest.mark.asyncio
+async def test_report_turn_metrics_includes_user():
+    client = _make_client()
+    user_context.set_current(SAMPLE_USER)
+    payload = await _post_and_capture(lambda: client.report_turn_metrics(
+        thread_id="t-1", metrics={"total_ms": 1200},
+    ))
+    assert payload["user"] == SAMPLE_USER
+
+
+@pytest.mark.asyncio
+async def test_submit_feedback_includes_user():
+    client = _make_client()
+    payload = await _post_and_capture(lambda: client.submit_feedback(
+        thread_id="t-1", rating="good", user=SAMPLE_USER,
+    ))
+    assert payload["user"] == SAMPLE_USER
+
+
+# ---------------------------------------------------------------------------
+# attribution safety
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_concurrent_turns_do_not_cross_attribute():
+    """Two users' turns run in the same process. A global would hand one
+    person's message to the other's account; a ContextVar is per-task."""
+    client = _make_client()
+    alice = dict(SAMPLE_USER, id=1, username="alice", llamapress_user_guid="guid-alice")
+    bob = dict(SAMPLE_USER, id=2, username="bob", llamapress_user_guid="guid-bob")
+    seen = {}
+
+    async def turn(who, delay):
+        user_context.set_current(who)
+        await asyncio.sleep(delay)
+        payload = await _post_and_capture(lambda: client.report_message(
+            thread_id=f"t-{who['username']}", role="user", content="hi",
+            sent_at="2026-08-25T00:00:00+00:00",
+        ))
+        seen[who["username"]] = payload["user"]["llamapress_user_guid"]
+
+    await asyncio.gather(turn(alice, 0.02), turn(bob, 0.0))
+
+    assert seen == {"alice": "guid-alice", "bob": "guid-bob"}
+
+
+@pytest.mark.asyncio
+async def test_telemetry_kill_switch_still_wins(monkeypatch):
+    """Adding identity must not sneak a report past the harness kill switch."""
+    monkeypatch.setenv(TELEMETRY_DISABLED_ENV, "1")
+    client = _make_client()
+    user_context.set_current(SAMPLE_USER)
+    mock_http = _capturing_http({})
+    with patch("app.services.mothership_client.httpx.AsyncClient", return_value=mock_http):
+        result = await client.report_message(
+            thread_id="t-1", role="user", content="hi",
+            sent_at="2026-08-25T00:00:00+00:00",
+        )
+    assert result is None
+    mock_http.post.assert_not_called()
+
+
+def test_resolve_user_never_raises_when_context_import_fails():
+    """Telemetry identity is best-effort; a broken lookup must not break a turn."""
+    with patch("app.services.user_context.current", side_effect=RuntimeError("boom")):
+        assert MothershipClient._resolve_user(None) is None

--- a/app/tests/test_sso_origin.py
+++ b/app/tests/test_sso_origin.py
@@ -1,0 +1,257 @@
+"""Tests for the SSO return-to-brand contract (app/services/sso_origin.py).
+
+The bug: a user who signed in at builtwithleo.com and later needed to
+re-authorize was bounced to llamapress.ai — the domain baked into
+instance.json — and hit a sign-in wall on a brand they'd never used.
+
+Covered here:
+  * sanitize_sso_origin allowlists hosts (open-redirect guard);
+  * resolve_sso_origin precedence: query param > cookie > configured mothership;
+  * GET /auth/consume remembers the origin and bounces back to it;
+  * the /login SSO CTA points at the remembered brand, with its copy.
+
+Run with: pytest app/tests/test_sso_origin.py -v
+"""
+from urllib.parse import urlparse
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.pool import StaticPool
+from sqlmodel import SQLModel, create_engine
+
+from app.services.sso_origin import (
+    SSO_ORIGIN_COOKIE,
+    brand_display_name,
+    remember_sso_origin,
+    resolve_sso_origin,
+    sanitize_sso_origin,
+)
+
+MOTHERSHIP = "https://llamapress.ai"
+
+
+class _FakeRequest:
+    def __init__(self, query=None, cookies=None):
+        self.query_params = query or {}
+        self.cookies = cookies or {}
+
+
+class _FakeResponse:
+    def __init__(self):
+        self.cookies_set = {}
+
+    def set_cookie(self, key, value, **kwargs):
+        self.cookies_set[key] = (value, kwargs)
+
+
+@pytest.fixture
+def db_engine(monkeypatch):
+    """Fresh shared in-memory sqlite bound into the router (mirrors
+    test_unified_login.py — the /auth/consume route reads its module-level
+    engine)."""
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    SQLModel.metadata.create_all(engine)
+    monkeypatch.setattr("app.routers.unified_login.engine", engine)
+    monkeypatch.setattr("app.db.engine", engine)
+    return engine
+
+
+@pytest.fixture
+def client():
+    # No `with` → skip the app's startup/shutdown (DB init, graph compile).
+    from main import app
+    return TestClient(app, base_url="https://testserver")
+
+
+# =============================================================================
+# sanitize_sso_origin
+# =============================================================================
+
+class TestSanitize:
+    @pytest.mark.parametrize("value,expected", [
+        ("https://builtwithleo.com", "https://builtwithleo.com"),
+        ("builtwithleo.com", "https://builtwithleo.com"),
+        ("https://www.builtwithleo.com/anything?x=1", "https://www.builtwithleo.com"),
+        ("https://llamapress.ai/", "https://llamapress.ai"),
+        ("HTTPS://BuiltWithLeo.com", "https://builtwithleo.com"),
+    ])
+    def test_accepts_allowlisted_brands(self, value, expected):
+        assert sanitize_sso_origin(value, MOTHERSHIP) == expected
+
+    @pytest.mark.parametrize("value", [
+        "",
+        None,
+        "https://evil.example.com",
+        # Lookalikes that a naive substring check would wave through.
+        "https://builtwithleo.com.evil.com",
+        "https://notbuiltwithleo.com",
+        "javascript:alert(1)",
+        "//evil.example.com",
+    ])
+    def test_rejects_everything_else(self, value):
+        assert sanitize_sso_origin(value, MOTHERSHIP) is None
+
+    def test_configured_mothership_is_always_allowed(self):
+        assert sanitize_sso_origin(
+            "https://mothership.test", "https://mothership.test"
+        ) == "https://mothership.test"
+        # ...and is NOT allowed for a box configured elsewhere.
+        assert sanitize_sso_origin("https://mothership.test", MOTHERSHIP) is None
+
+    def test_env_var_extends_the_allowlist(self, monkeypatch):
+        assert sanitize_sso_origin("https://staging.leo.dev", MOTHERSHIP) is None
+        monkeypatch.setenv("SSO_ORIGIN_HOSTS", "leo.dev, other.test")
+        assert sanitize_sso_origin("https://staging.leo.dev", MOTHERSHIP) == \
+            "https://staging.leo.dev"
+
+    def test_http_on_a_public_brand_is_upgraded(self):
+        assert sanitize_sso_origin("http://builtwithleo.com", MOTHERSHIP) == \
+            "https://builtwithleo.com"
+
+    def test_explicit_port_survives(self, monkeypatch):
+        monkeypatch.setenv("SSO_ORIGIN_HOSTS", "localhost")
+        assert sanitize_sso_origin("http://localhost:3000", MOTHERSHIP) == \
+            "http://localhost:3000"
+
+
+# =============================================================================
+# resolve / remember
+# =============================================================================
+
+class TestResolve:
+    def test_query_param_wins(self):
+        req = _FakeRequest(
+            query={"sso_origin": "https://builtwithleo.com"},
+            cookies={SSO_ORIGIN_COOKIE: "https://llamapress.ai"},
+        )
+        assert resolve_sso_origin(req, MOTHERSHIP) == "https://builtwithleo.com"
+
+    def test_falls_back_to_cookie(self):
+        req = _FakeRequest(cookies={SSO_ORIGIN_COOKIE: "https://builtwithleo.com"})
+        assert resolve_sso_origin(req, MOTHERSHIP) == "https://builtwithleo.com"
+
+    def test_falls_back_to_configured_mothership(self):
+        assert resolve_sso_origin(_FakeRequest(), MOTHERSHIP) == MOTHERSHIP
+
+    def test_poisoned_cookie_falls_back_to_mothership(self):
+        req = _FakeRequest(cookies={SSO_ORIGIN_COOKIE: "https://evil.example.com"})
+        assert resolve_sso_origin(req, MOTHERSHIP) == MOTHERSHIP
+
+    def test_none_when_no_mothership_configured(self):
+        assert resolve_sso_origin(_FakeRequest(), "") is None
+
+    def test_remember_sets_cookie_for_valid_origin(self):
+        req = _FakeRequest(query={"sso_origin": "https://builtwithleo.com"})
+        resp = _FakeResponse()
+        remember_sso_origin(req, resp, MOTHERSHIP)
+        value, kwargs = resp.cookies_set[SSO_ORIGIN_COOKIE]
+        assert value == "https://builtwithleo.com"
+        assert kwargs["httponly"] is True
+        assert kwargs["samesite"] == "lax"
+
+    def test_remember_ignores_a_bogus_origin(self):
+        req = _FakeRequest(query={"sso_origin": "https://evil.example.com"})
+        resp = _FakeResponse()
+        remember_sso_origin(req, resp, MOTHERSHIP)
+        assert resp.cookies_set == {}
+
+
+class TestBrandDisplayName:
+    @pytest.mark.parametrize("origin,expected", [
+        ("https://builtwithleo.com", "Leo"),
+        ("https://www.builtwithleo.com", "Leo"),
+        ("https://llamapress.ai", "LlamaPress.ai"),
+        ("https://mothership.test", "mothership.test"),
+    ])
+    def test_labels(self, origin, expected):
+        assert brand_display_name(origin) == expected
+
+
+# =============================================================================
+# Wiring: /auth/consume and the /login CTA
+# =============================================================================
+
+class TestConsumeHonorsOrigin:
+    def test_bounce_goes_to_the_origin_brand(self, db_engine, client, monkeypatch):
+        """A recoverable grant failure re-authorizes at builtwithleo.com."""
+        from app.tests.test_unified_login import FakeMothership, _install_mothership
+
+        fake = FakeMothership(error_code="grant_expired")
+        with _install_mothership(fake):
+            resp = client.get(
+                "/auth/consume?token=T&sso_origin=https://builtwithleo.com",
+                follow_redirects=False,
+            )
+        assert resp.status_code == 302
+        loc = urlparse(resp.headers["location"])
+        assert loc.netloc == "builtwithleo.com"
+        assert loc.path == "/sso/leo/my-box"
+
+    def test_bounce_defaults_to_configured_mothership(self, db_engine, client):
+        from app.tests.test_unified_login import FakeMothership, _install_mothership
+
+        fake = FakeMothership(error_code="grant_expired")
+        with _install_mothership(fake):
+            resp = client.get("/auth/consume?token=T", follow_redirects=False)
+        loc = urlparse(resp.headers["location"])
+        assert loc.netloc == "mothership.test"
+
+    def test_bad_origin_cannot_aim_the_bounce(self, db_engine, client):
+        from app.tests.test_unified_login import FakeMothership, _install_mothership
+
+        fake = FakeMothership(error_code="grant_expired")
+        with _install_mothership(fake):
+            resp = client.get(
+                "/auth/consume?token=T&sso_origin=https://evil.example.com",
+                follow_redirects=False,
+            )
+        loc = urlparse(resp.headers["location"])
+        assert loc.netloc == "mothership.test"
+
+    def test_successful_consume_remembers_the_origin(self, db_engine, client):
+        from app.tests.test_unified_login import (
+            SUCCESS_BODY, FakeMothership, _install_mothership,
+        )
+
+        fake = FakeMothership(payload=SUCCESS_BODY)
+        with _install_mothership(fake):
+            resp = client.get(
+                "/auth/consume?token=T&sso_origin=https://builtwithleo.com",
+                follow_redirects=False,
+            )
+        assert resp.status_code == 302
+        assert SSO_ORIGIN_COOKIE in resp.headers.get("set-cookie", "")
+        # ...and the hand-off URL doesn't leak the param into the chat.
+        assert "sso_origin" not in resp.headers["location"]
+
+
+class TestLoginCtaHonorsOrigin:
+    def _cta(self, request, mothership_url="https://llamapress.ai", name="my-box"):
+        from unittest.mock import MagicMock, patch
+
+        from app.routers import ui
+
+        fake = MagicMock()
+        fake.mothership_url = mothership_url
+        fake.instance_name = name
+        with patch.object(ui, "MothershipClient", return_value=fake):
+            return ui._render_sso_login_cta(request)
+
+    def test_uses_remembered_brand(self):
+        req = _FakeRequest(cookies={SSO_ORIGIN_COOKIE: "https://builtwithleo.com"})
+        html = self._cta(req)
+        assert "https://builtwithleo.com/sso/leo/my-box" in html
+        assert "Sign in with your Leo account" in html
+        assert "llamapress.ai" not in html
+
+    def test_defaults_to_the_configured_mothership(self):
+        html = self._cta(_FakeRequest())
+        assert "https://llamapress.ai/sso/leo/my-box" in html
+        assert "Sign in with your LlamaPress.ai account" in html
+
+    def test_empty_on_self_hosted(self):
+        assert self._cta(_FakeRequest(), mothership_url="", name="") == ""

--- a/app/tests/test_system_prompt_blocks_non_anthropic.py
+++ b/app/tests/test_system_prompt_blocks_non_anthropic.py
@@ -175,7 +175,10 @@ def test_every_non_middleware_agent_flattens_its_cached_prompt():
     offenders = []
     for path in sorted(AGENTS_DIR.rglob("*.py")):
         src = path.read_text()
-        if '"cache_control"' not in src:
+        # The marker is the block being BUILT (`"cache_control": {...}`), not the
+        # string appearing at all — message_invariants.py merely lists it among
+        # the block types providers accept and builds no prompt of its own.
+        if '"cache_control": {' not in src:
             continue
         if "DynamicModelMiddleware" in src:
             continue  # covered by the middleware

--- a/app/tests/test_uiux_question.py
+++ b/app/tests/test_uiux_question.py
@@ -164,13 +164,19 @@ class TestAskUserQuestionUiRelated:
                 ui_related=True,
             )
 
-            mock_interrupt.assert_called_once_with({
-                "type": "user_question",
+            payload = mock_interrupt.call_args[0][0]
+            # The legacy top-level fields are still mirrored (a stale cached frontend
+            # reads those), and the question also rides in the `questions` batch.
+            assert payload["type"] == "user_question"
+            assert payload["question"] == "How should the hero look?"
+            assert payload["options"] == ["Big and bold", "Minimal"]
+            assert payload["context"] == "Phase 1: Clarify"
+            assert payload["ui_related"] is True
+            assert payload["questions"] == [{
                 "question": "How should the hero look?",
                 "options": ["Big and bold", "Minimal"],
-                "context": "Phase 1: Clarify",
                 "ui_related": True,
-            })
+            }]
 
     def test_ui_related_defaults_to_false(self):
         """ui_related defaults to False when the agent omits it."""

--- a/app/tests/test_unified_login.py
+++ b/app/tests/test_unified_login.py
@@ -379,8 +379,9 @@ class TestFailurePaths:
             )
         assert resp.status_code == 200
         assert "text/html" in resp.headers.get("content-type", "")
-        # Loop broken: manual recovery link (no retry param) present.
-        assert "Continue with LlamaPress" in resp.text
+        # Loop broken: manual recovery link (no retry param) present, named
+        # after the brand domain in play (see app/services/sso_origin.py).
+        assert "Continue with mothership.test" in resp.text
         assert any(r["error_class"] == "UnifiedLogin::ConsumeFailed" for r in fake.reported)
 
     def test_unreachable_renders_login_page_no_bounce(self, db_engine, client):

--- a/app/tests/test_uploaded_sheet_preview.py
+++ b/app/tests/test_uploaded_sheet_preview.py
@@ -1,0 +1,120 @@
+"""Spreadsheet previews are parsed on the box, not by Microsoft.
+
+The asset library used to offer "Preview with Microsoft Office Online", which
+embedded view.officeapps.live.com in an iframe. That viewer fetches the file
+from Microsoft's servers, so it can never see an auth-gated
+/api/uploaded-files/preview URL — it was broken by construction. Spreadsheets
+now render as a plain cell grid from /api/uploaded-files/sheet (openpyxl).
+"""
+import csv
+
+import pytest
+from openpyxl import Workbook
+
+import app.routers.api as api
+
+
+def _xlsx(tmp_path, name="book.xlsx", sheets=None):
+    sheets = sheets or {"Sheet1": [["a", 1], ["b", 2]]}
+    wb = Workbook()
+    wb.remove(wb.active)
+    for title, rows in sheets.items():
+        ws = wb.create_sheet(title=title)
+        for row in rows:
+            ws.append(row)
+    path = tmp_path / name
+    wb.save(path)
+    return path
+
+
+@pytest.fixture
+def imports_dir(tmp_path, monkeypatch):
+    monkeypatch.setitem(api.PREVIEW_PATH_PREFIXES, "app/imports", str(tmp_path))
+    return tmp_path
+
+
+class TestSheetEndpoint:
+    @pytest.mark.asyncio
+    async def test_xlsx_returns_cell_rows(self, async_client, imports_dir):
+        _xlsx(imports_dir, sheets={"Data": [["Name", "Qty"], ["Widget", 3]]})
+        r = await async_client.get("/api/uploaded-files/sheet?path=app/imports/book.xlsx")
+        assert r.status_code == 200
+        body = r.json()
+        assert body["sheets"] == ["Data"]
+        assert body["rows"] == [["Name", "Qty"], ["Widget", "3"]]
+        assert body["truncated"] is False
+
+    @pytest.mark.asyncio
+    async def test_sheet_index_selects_the_tab(self, async_client, imports_dir):
+        _xlsx(imports_dir, sheets={"First": [["x"]], "Second": [["y"]]})
+        r = await async_client.get("/api/uploaded-files/sheet?path=app/imports/book.xlsx&sheet=1")
+        assert r.status_code == 200
+        body = r.json()
+        assert body["active"] == 1
+        assert body["rows"] == [["y"]]
+
+    @pytest.mark.asyncio
+    async def test_out_of_range_sheet_falls_back_to_first(self, async_client, imports_dir):
+        _xlsx(imports_dir, sheets={"First": [["x"]]})
+        r = await async_client.get("/api/uploaded-files/sheet?path=app/imports/book.xlsx&sheet=9")
+        assert r.status_code == 200
+        assert r.json()["active"] == 0
+
+    @pytest.mark.asyncio
+    async def test_row_cap_reports_the_full_count(self, async_client, imports_dir):
+        rows = [[i] for i in range(api.SHEET_PREVIEW_MAX_ROWS + 25)]
+        _xlsx(imports_dir, sheets={"Big": rows})
+        r = await async_client.get("/api/uploaded-files/sheet?path=app/imports/book.xlsx")
+        body = r.json()
+        assert len(body["rows"]) == api.SHEET_PREVIEW_MAX_ROWS
+        assert body["total_rows"] == api.SHEET_PREVIEW_MAX_ROWS + 25
+        assert body["truncated"] is True
+
+    @pytest.mark.asyncio
+    async def test_csv_is_parsed_too(self, async_client, imports_dir):
+        p = imports_dir / "rows.csv"
+        with open(p, "w", newline="") as fh:
+            csv.writer(fh).writerows([["Name", "Qty"], ["Widget", "3"]])
+        r = await async_client.get("/api/uploaded-files/sheet?path=app/imports/rows.csv")
+        assert r.status_code == 200
+        assert r.json()["rows"] == [["Name", "Qty"], ["Widget", "3"]]
+
+    @pytest.mark.asyncio
+    async def test_tsv_uses_tab_delimiter(self, async_client, imports_dir):
+        (imports_dir / "rows.tsv").write_text("Name\tQty\nWidget\t3\n")
+        r = await async_client.get("/api/uploaded-files/sheet?path=app/imports/rows.tsv")
+        assert r.status_code == 200
+        assert r.json()["rows"] == [["Name", "Qty"], ["Widget", "3"]]
+
+    @pytest.mark.asyncio
+    async def test_legacy_xls_returns_415_for_client_fallback(self, async_client, imports_dir):
+        # openpyxl can't read the legacy binary format; 415 tells the frontend to
+        # fall back to its client-side reader rather than showing an error.
+        (imports_dir / "old.xls").write_bytes(b"\xd0\xcf\x11\xe0")
+        r = await async_client.get("/api/uploaded-files/sheet?path=app/imports/old.xls")
+        assert r.status_code == 415
+
+    @pytest.mark.asyncio
+    async def test_corrupt_workbook_is_422_not_500(self, async_client, imports_dir):
+        (imports_dir / "broken.xlsx").write_bytes(b"not a zip file at all")
+        r = await async_client.get("/api/uploaded-files/sheet?path=app/imports/broken.xlsx")
+        assert r.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_path_traversal_blocked(self, async_client, imports_dir):
+        r = await async_client.get("/api/uploaded-files/sheet?path=app/imports/../../etc/passwd")
+        assert r.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_missing_file_is_404(self, async_client, imports_dir):
+        r = await async_client.get("/api/uploaded-files/sheet?path=app/imports/nope.xlsx")
+        assert r.status_code == 404
+
+
+class TestNoThirdPartyViewer:
+    def test_office_online_iframe_is_gone_from_the_frontend(self):
+        from pathlib import Path
+        repo_root = Path(__file__).resolve().parents[2]
+        js = (repo_root / "app/frontend/chat/ui/FileAttachmentManager.js").read_text()
+        assert "officeapps.live.com" not in js
+        assert "asset-office-btn" not in js

--- a/app/tests/test_websocket_auth.py
+++ b/app/tests/test_websocket_auth.py
@@ -149,17 +149,26 @@ class TestTokenServiceUnit:
         assert is_rails_token("single-dash-only") is False
         assert is_rails_token("") is False
 
-    def test_verify_rails_token_trusted(self):
-        """Test that Rails tokens are trusted."""
+    def test_verify_rails_token_requires_a_real_signature(self, monkeypatch):
+        """Rails tokens are verified, not taken on trust.
+
+        This test used to assert the opposite — that any ``<x>--<y>`` string
+        produced a `rails_auth` payload — which is precisely what let an
+        anonymous WebSocket frame authenticate as the gem and run the engineer
+        agent. See app/tests/test_rails_token_verification.py.
+        """
         from app.services.token_service import verify_rails_token
+        from app.tests.rails_token_vectors import TEST_SKB, VALID
 
-        # Valid Rails-style token
-        payload = verify_rails_token("base64data--base64signature")
+        monkeypatch.setenv("SECRET_KEY_BASE", TEST_SKB)
 
+        assert verify_rails_token("base64data--base64signature") is None
+
+        payload = verify_rails_token(VALID)
         assert payload is not None
-        assert payload["sub"] == "rails_gem"
         assert payload["type"] == "rails_auth"
         assert payload["source"] == "llama_bot_rails"
+        assert payload["rails_user_id"] == 4242
 
     def test_verify_rails_token_rejects_non_rails(self):
         """Test that non-Rails tokens are rejected by verify_rails_token."""
@@ -353,29 +362,36 @@ class TestWebSocketAuthEnabled:
             response = websocket.receive_json()
             assert response["type"] == "auth_error"
 
-    def test_rails_token_succeeds(self):
-        """When auth required, Rails tokens should be accepted."""
+    def test_rails_token_succeeds(self, monkeypatch):
+        """When auth required, a genuine Rails token is accepted."""
         from fastapi.testclient import TestClient
         from main import app
 
+        from app.tests.rails_token_vectors import TEST_SKB, VALID
+
+        monkeypatch.setenv("SECRET_KEY_BASE", TEST_SKB)
         client = TestClient(app)
 
         with client.websocket_connect("/ws") as websocket:
-            # Send Rails-style token
+            # A token this Rails app really minted — a forged one is refused,
+            # which is covered in test_rails_token_verification.py.
             websocket.send_json({
                 "type": "auth",
-                "token": "rails-data--rails-signature"
+                "token": VALID
             })
 
             response = websocket.receive_json()
             assert response["type"] == "auth_success"
-            assert response["user"] == "rails_gem"
+            assert response["user"] == "rails_user:4242"
 
-    def test_api_token_in_message_authenticates(self):
+    def test_api_token_in_message_authenticates(self, monkeypatch):
         """Rails gem pattern: api_token in message payload should authenticate."""
         from fastapi.testclient import TestClient
         from main import app
 
+        from app.tests.rails_token_vectors import TEST_SKB, VALID
+
+        monkeypatch.setenv("SECRET_KEY_BASE", TEST_SKB)
         client = TestClient(app)
 
         with client.websocket_connect("/ws") as websocket:
@@ -383,7 +399,7 @@ class TestWebSocketAuthEnabled:
             websocket.send_json({
                 "message": "Hello",
                 "thread_id": "test",
-                "api_token": "rails-data--rails-signature"
+                "api_token": VALID
             })
 
             # First response should be auth_success
@@ -445,3 +461,43 @@ class TestWSTokenEndpoint:
         assert payload["type"] == "ws_auth"
         assert "sub" in payload
         assert "user_id" in payload
+
+
+class TestAuthIsRequiredByDefault:
+    """WS_AUTH_REQUIRED shipped defaulting to false, and no provisioner set it.
+
+    `self.authenticated = not WS_AUTH_REQUIRED` meant a socket that simply never
+    sent an `auth` frame started out authenticated, on every box in the fleet.
+    """
+
+    def _reload(self, monkeypatch, value):
+        import importlib
+
+        import app.websocket.web_socket_handler as mod
+
+        if value is None:
+            monkeypatch.delenv("WS_AUTH_REQUIRED", raising=False)
+        else:
+            monkeypatch.setenv("WS_AUTH_REQUIRED", value)
+        return importlib.reload(mod)
+
+    def test_defaults_to_required_when_unset(self, monkeypatch):
+        assert self._reload(monkeypatch, None).WS_AUTH_REQUIRED is True
+
+    def test_an_operator_can_still_switch_it_off(self, monkeypatch):
+        assert self._reload(monkeypatch, "false").WS_AUTH_REQUIRED is False
+
+    def test_a_fresh_socket_does_not_start_out_authenticated(self, monkeypatch):
+        from unittest.mock import MagicMock, patch
+
+        mod = self._reload(monkeypatch, None)
+        with patch("app.websocket.request_handler.RequestHandler"):
+            handler = mod.WebSocketHandler(MagicMock(), MagicMock())
+        assert handler.authenticated is False
+
+    def teardown_method(self):
+        # Leave the module as the rest of the suite expects to find it.
+        import importlib
+
+        import app.websocket.web_socket_handler as mod
+        importlib.reload(mod)

--- a/app/tests/test_websocket_mode_enforcement.py
+++ b/app/tests/test_websocket_mode_enforcement.py
@@ -166,25 +166,78 @@ async def test_admin_revoking_a_mode_from_a_role_takes_effect(handler, engine):
 
 # --- non-browser callers keep their existing behaviour --------------------
 
-@pytest.mark.asyncio
-async def test_rails_gem_token_is_not_gated(handler):
-    """verify_rails_token returns no role claim; the gem is a trusted internal caller.
+def _as_rails_gem(handler, rails_user_id=7):
+    """Authenticate as the llama_bot_rails gem, the way verify_rails_token does."""
+    from app.services.token_service import RAILS_ROLE
 
-    NOTE: that trust is currently unverified (token_service.verify_rails_token does
-    no signature check) — tracked separately. This test pins the gate's behaviour,
-    not an endorsement of that path.
-    """
     handler.authenticated = True
-    handler.auth_user = {"sub": "rails_gem", "type": "rails_auth", "source": "llama_bot_rails"}
+    handler.auth_user = {
+        "sub": f"rails_user:{rails_user_id}",
+        "type": "rails_auth",
+        "source": "llama_bot_rails",
+        "rails_user_id": rails_user_id,
+        "role": RAILS_ROLE,
+        "is_admin": False,
+    }
+
+
+@pytest.mark.asyncio
+async def test_rails_gem_can_run_the_engineer_agent_by_default(handler):
+    """The embedded Rails chat is the box owner's own chat — it must keep working.
+
+    This is the regression guard on the rollout risk: tightening `rails_auth`
+    must not cost a box its in-app chat.
+    """
+    _as_rails_gem(handler)
     assert await _authorize(handler, {"agent_name": "rails_agent"}) is True
 
 
 @pytest.mark.asyncio
-async def test_unauthenticated_is_left_to_ws_auth_required(handler):
-    """WS_AUTH_REQUIRED governs this path; the gate has no role to check."""
+async def test_rails_gem_is_denied_a_mode_its_role_does_not_grant(handler, engine):
+    """The gem used to skip the gate entirely; now it is a role like any other."""
+    _as_rails_gem(handler)
+    _configure(engine, {"rails": ["chat"]})
+    assert await _authorize(handler, {"agent_name": "rails_agent"}) is False
+    assert await _authorize(handler, {"agent_name": "rails_plain_chat_mode"}) is True
+
+
+@pytest.mark.asyncio
+async def test_unauthenticated_frame_naming_an_agent_is_denied(handler):
+    """The disclosed bug: no cookie, no token, and the engineer agent ran.
+
+    The gate used to `return True` for anything that was not a browser JWT,
+    which meant an anonymous socket naming `rails_agent` sailed straight
+    through. It fails closed now.
+    """
     handler.authenticated = False
     handler.auth_user = None
-    assert await _authorize(handler, {"agent_name": "rails_agent"}) is True
+    with patch("app.websocket.web_socket_handler.WS_AUTH_REQUIRED", True):
+        assert await _authorize(handler, {"agent_name": "rails_agent"}) is False
+
+
+@pytest.mark.asyncio
+async def test_unauthenticated_denial_says_authentication_not_permissions(handler):
+    handler.authenticated = False
+    handler.auth_user = None
+    with patch("app.websocket.web_socket_handler.WS_AUTH_REQUIRED", True):
+        await _authorize(handler, {"agent_name": "rails_agent"})
+    payload = handler.manager.send_personal_message.await_args[0][0]
+    assert payload["type"] == "auth_error"
+
+
+@pytest.mark.asyncio
+async def test_operator_who_turned_auth_off_still_gets_a_working_box(handler):
+    """WS_AUTH_REQUIRED=false is an explicit opt-out of auth altogether.
+
+    Denying every agent frame in that mode would make the flag mean "chat is
+    broken" rather than "no auth on this box", so the gate defers to it. The
+    default is now `true`, so this is a deliberate choice, not the out-of-box
+    state that made the disclosure possible.
+    """
+    handler.authenticated = False
+    handler.auth_user = None
+    with patch("app.websocket.web_socket_handler.WS_AUTH_REQUIRED", False):
+        assert await _authorize(handler, {"agent_name": "rails_agent"}) is True
 
 
 # --- the wiring ------------------------------------------------------------

--- a/app/tests/test_websocket_preauth_frames.py
+++ b/app/tests/test_websocket_preauth_frames.py
@@ -1,0 +1,136 @@
+"""Control frames must not be reachable before authentication.
+
+`cancel`, `attach`, `approval_response` and `question_response` were dispatched
+*above* the auth check in `handle_websocket`, so they bypassed WS_AUTH_REQUIRED
+even when it was switched on. Two of them have real reach:
+
+  * `attach` replays a background run's buffered output by `thread_id` — an
+    anonymous socket could read another connection's conversation.
+  * `approval_response` resumes a run parked on a human approval, i.e. it can
+    approve a tool call somebody else was asked to confirm.
+
+Only `ping` and `auth` are legitimately pre-auth frames.
+
+Run with: pytest app/tests/test_websocket_preauth_frames.py -v
+"""
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import WebSocketDisconnect
+
+
+@pytest.fixture
+def handler():
+    from app.websocket.web_socket_handler import WebSocketHandler
+
+    manager = MagicMock()
+    manager.app = MagicMock()
+    manager.send_personal_message = AsyncMock()
+    manager.connect = AsyncMock()
+    manager.disconnect = MagicMock()
+    manager.deduplicator.register = MagicMock(return_value=True)
+
+    websocket = MagicMock()
+    websocket.client = "test-client"
+
+    with patch("app.websocket.request_handler.RequestHandler"):
+        h = WebSocketHandler(websocket, manager)
+
+    h._is_websocket_open = lambda ws: True
+    h.request_handler.start_chat_run = AsyncMock()
+    h.request_handler.start_resume_run = AsyncMock()
+    h.request_handler.cleanup_connection = MagicMock()
+
+    run_manager = MagicMock()
+    run_manager.cancel = AsyncMock(return_value=True)
+    run_manager.attach = MagicMock(return_value=None)
+    h.request_handler._run_manager = MagicMock(return_value=run_manager)
+    h._run_manager = run_manager
+    return h
+
+
+async def _drive(handler, frames, auth_required=True):
+    handler.websocket.receive_json = AsyncMock(
+        side_effect=[*frames, WebSocketDisconnect(code=1000, reason="done")]
+    )
+    with patch("app.websocket.web_socket_handler.WS_AUTH_REQUIRED", auth_required), \
+         patch("app.permissions.custom_modes", return_value={}):
+        await handler.handle_websocket()
+
+
+def _authenticated(handler):
+    handler.authenticated = True
+    handler.auth_user = {
+        "sub": "alice", "user_id": 1, "role": "engineer",
+        "is_admin": False, "type": "ws_auth",
+    }
+
+
+class TestUnauthenticatedControlFramesAreRefused:
+
+    @pytest.mark.asyncio
+    async def test_attach_does_not_replay_a_run(self, handler):
+        await _drive(handler, [{"type": "attach", "thread_id": "someone-elses", "last_seq": 0}])
+        handler._run_manager.attach.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_cancel_does_not_stop_a_run(self, handler):
+        await _drive(handler, [{"type": "cancel", "thread_id": "someone-elses"}])
+        handler._run_manager.cancel.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_approval_response_does_not_resume_a_run(self, handler):
+        await _drive(handler, [{"type": "approval_response", "thread_id": "t1", "approved": True}])
+        handler.request_handler.start_resume_run.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_question_response_does_not_resume_a_run(self, handler):
+        await _drive(handler, [{"type": "question_response", "thread_id": "t1", "answer": "yes"}])
+        handler.request_handler.start_resume_run.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_the_client_is_told_it_needs_to_authenticate(self, handler):
+        await _drive(handler, [{"type": "attach", "thread_id": "t1"}])
+        sent = [c[0][0] for c in handler.manager.send_personal_message.await_args_list]
+        assert any(m.get("type") == "auth_error" for m in sent)
+
+
+class TestLegitimateTrafficIsUnaffected:
+
+    @pytest.mark.asyncio
+    async def test_ping_still_answers_before_authentication(self, handler):
+        await _drive(handler, [{"type": "ping"}])
+        sent = [c[0][0] for c in handler.manager.send_personal_message.await_args_list]
+        assert any(m.get("type") == "pong" for m in sent)
+
+    @pytest.mark.asyncio
+    async def test_authenticated_attach_still_works(self, handler):
+        _authenticated(handler)
+        await _drive(handler, [{"type": "attach", "thread_id": "t1", "last_seq": 2}])
+        handler._run_manager.attach.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_authenticated_cancel_still_works(self, handler):
+        _authenticated(handler)
+        await _drive(handler, [{"type": "cancel", "thread_id": "t1"}])
+        handler._run_manager.cancel.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_a_control_frame_race_does_not_close_the_socket(self, handler):
+        """An `attach` can race the async auth handshake on reconnect.
+
+        Dropping the frame is right; killing the connection would turn a race
+        into a reconnect loop, so the socket must survive to serve the
+        `auth` frame that is right behind it.
+        """
+        await _drive(handler, [
+            {"type": "attach", "thread_id": "t1"},
+            {"type": "ping"},
+        ])
+        sent = [c[0][0] for c in handler.manager.send_personal_message.await_args_list]
+        assert any(m.get("type") == "pong" for m in sent), "socket closed on a raced attach"
+
+    @pytest.mark.asyncio
+    async def test_boxes_with_auth_switched_off_keep_working(self, handler):
+        await _drive(handler, [{"type": "attach", "thread_id": "t1"}], auth_required=False)
+        handler._run_manager.attach.assert_called_once()

--- a/app/websocket/request_handler.py
+++ b/app/websocket/request_handler.py
@@ -7,6 +7,7 @@ from starlette.websockets import WebSocketState
 from app.websocket.web_socket_request_context import WebSocketRequestContext
 from app.lib.token_usage import extract_token_usage
 from app.lib.turn_metrics import start_turn
+from app.lib.rails_error_watch import resume_error_watch, start_error_watch
 from typing import Dict, Optional
 
 from langchain_core.messages import HumanMessage
@@ -83,6 +84,30 @@ async def _report_tool_messages(*, messages, mothership, thread_id: str, agent_d
                 "agent_depth": agent_depth,
             }],
         )
+
+
+def _prepend_request_shape(exc: Exception, traceback_str: str) -> str:
+    """Put the rejected request's SHAPE at the top of the reported traceback.
+
+    A provider 400 arrives with ``'param': None`` and nothing else — 32
+    occurrences on 7 boxes in 7 days for our own default model, and the
+    mothership had no way to tell what was wrong with the request we sent.
+    The shape is attached to the exception by
+    ``message_invariants.log_bad_request_shape`` at the model-call boundary.
+
+    It goes FIRST because ``report_error`` truncates the traceback at 5000
+    characters, and it carries no message content — roles, content kinds, block
+    types, tool-call pairing and sizes only.
+    """
+    shape = getattr(exc, "llamabot_request_shape", None)
+    if not shape:
+        return traceback_str
+    try:
+        import json as _json
+        rendered = _json.dumps(shape, default=str)[:3000]
+    except Exception:  # noqa: BLE001
+        return traceback_str
+    return f"[llamabot request shape]\n{rendered}\n\n{traceback_str}"
 
 
 class RequestHandler:
@@ -283,7 +308,7 @@ class RequestHandler:
                 # line — changing that input would re-fingerprint every existing
                 # incident and split its history in two.
                 error_message=describe_exception(exc),
-                traceback_str=_tb.format_exc(),
+                traceback_str=_prepend_request_shape(exc, _tb.format_exc()),
                 agent_mode=agent_mode,
                 model=(message or {}).get("llm_model"),
                 llamabot_version=version,
@@ -928,6 +953,17 @@ class RequestHandler:
                 thread_id=str(incoming_message.get("thread_id", "")),
                 agent_mode=incoming_message.get("agent_name"),
             )
+
+            # Arm mid-turn Rails auto-recovery for this turn. Installed in the
+            # same async context and for the same reason as start_turn above:
+            # RailsErrorWatchMiddleware runs inside LangGraph's node tasks,
+            # which inherit a copy of this context. A new user message always
+            # gets a fresh repair budget. See docs/dev/rails_auto_recovery.md.
+            start_error_watch(
+                thread_id=str(incoming_message.get("thread_id", "")),
+                agent_name=incoming_message.get("agent_name"),
+                api_token=incoming_message.get("api_token"),
+            )
             turn_started_at = _time.monotonic()
             try:
                 app, state, agent_config = self.get_langgraph_app_and_state(incoming_message)
@@ -1331,6 +1367,13 @@ class RequestHandler:
                     "recursion_limit": recursion_limit
                 }
 
+                # Same turn, continued after an interrupt: put the turn's Rails
+                # error watch back on this context so a crash caused by the work
+                # either side of the pause is still noticed. Chiefly this is the
+                # browser_command path — Leo navigating the preview to verify is
+                # exactly when a 500 shows up. No-op if the turn never armed one.
+                resume_error_watch(thread_id=str(response_message.get("thread_id", "")))
+
                 # Auto-repair corrupted thread state (defensive - less likely in HITL flow).
                 # No-ops while the graph is paused on the interrupt we are about to
                 # resume — repairing there would discard the user's decision.
@@ -1456,8 +1499,13 @@ class RequestHandler:
 
                     # Plan mode question interrupt
                     if isinstance(interrupt_value, dict) and interrupt_value.get("type") == "user_question":
+                        # `questions` is the batch (1-4). The top-level question/options/
+                        # ui_related mirror its first entry so a stale cached frontend
+                        # still renders that question instead of an empty card.
+                        questions = interrupt_value.get("questions", [])
                         await websocket.send_json({
                             "type": "question_request",
+                            "questions": questions,
                             "question": interrupt_value.get("question", ""),
                             "options": interrupt_value.get("options", []),
                             "context": interrupt_value.get("context", ""),
@@ -1465,7 +1513,9 @@ class RequestHandler:
                             "thread_id": message_data.get('thread_id'),
                             "agent_name": message_data.get('agent_name'),
                         })
-                        logger.info("Graph interrupted for plan mode question")
+                        logger.info(
+                            f"Graph interrupted for plan mode question ({len(questions) or 1} asked)"
+                        )
 
                     # Plan mode visual (UI/UX) question interrupt — options carry HTML previews
                     elif isinstance(interrupt_value, dict) and interrupt_value.get("type") == "uiux_question":
@@ -1559,6 +1609,13 @@ class RequestHandler:
                     },
                     "recursion_limit": recursion_limit
                 }
+
+                # Same turn, continued after an interrupt: put the turn's Rails
+                # error watch back on this context so a crash caused by the work
+                # either side of the pause is still noticed. Chiefly this is the
+                # browser_command path — Leo navigating the preview to verify is
+                # exactly when a 500 shows up. No-op if the turn never armed one.
+                resume_error_watch(thread_id=str(response_message.get("thread_id", "")))
 
                 # Auto-repair corrupted thread state. No-ops while the graph is
                 # paused on the question interrupt we are about to resume —

--- a/app/websocket/web_socket_handler.py
+++ b/app/websocket/web_socket_handler.py
@@ -16,7 +16,20 @@ from app.websocket.error_text import describe_exception
 logger = logging.getLogger(__name__)
 
 # Authentication configuration
-WS_AUTH_REQUIRED = os.getenv("WS_AUTH_REQUIRED", "false").lower() == "true"
+# Defaults ON. It shipped defaulting to false, which meant a socket that simply
+# never sent an `auth` frame was marked authenticated and could run any agent —
+# and no provisioner set the variable, so every box ran with it off. Leonardo's
+# .env.example has said `WS_AUTH_REQUIRED=true` all along; this makes the code
+# agree with the documented intent. Self-hosters who genuinely want an open box
+# can still set it to false explicitly.
+WS_AUTH_REQUIRED = os.getenv("WS_AUTH_REQUIRED", "true").lower() == "true"
+
+# Frames that act on an already-running turn rather than starting one. They are
+# refused without authentication like anything else, but refusing one drops the
+# frame instead of closing the socket — see handle_websocket.
+_CONTROL_FRAME_TYPES = frozenset({
+    "cancel", "attach", "approval_response", "question_response",
+})
 
 # Frame fields that are credentials, not data. They must never reach the logs:
 # `api_token` is a bearer credential for a specific Rails user (30-min TTL), and
@@ -152,6 +165,17 @@ class WebSocketHandler:
             # the intended behavior. See app/lib/request_context.py.
             from app.lib.request_context import set_current_user_id
             set_current_user_id(payload.get("user_id"))
+            # Stamp WHO this connection's turns belong to, so every mothership
+            # report fired from inside the run (report_message, report_error,
+            # report_turn_metrics) is attributable to a person rather than just
+            # to this box. One DB read per connection, not per message; the
+            # RequestHandler is built before auth, so there is nowhere to thread
+            # the user through by hand. See app/services/user_context.py.
+            from app.services import user_context
+            user_context.set_current(
+                user_context.for_user_id(payload.get("user_id"))
+                or user_context.from_token_payload(payload)
+            )
             await self.manager.send_personal_message({
                 "type": "auth_success",
                 "user": payload.get("sub")
@@ -176,16 +200,38 @@ class WebSocketHandler:
         which is why this sits before the type dispatch: any future frame type
         that names a mode is covered without touching this function.
 
-        Only browser JWTs carry a role claim, so only they are enforced:
-          * ``rails_auth`` — the llama_bot_rails gem, a trusted internal caller
-            with no role to check (see token_service.verify_rails_token).
-          * unauthenticated — WS_AUTH_REQUIRED already governs that path below.
+        Every authenticated caller carries a role, so all of them are enforced
+        the same way — browser JWTs by the user's own role, the llama_bot_rails
+        gem by the ``rails`` role. This used to `return True` for anything that
+        was not a browser JWT, on the premise that ``rails_auth`` meant a
+        trusted internal caller. Nothing verified that premise (any string with
+        a ``--`` in it produced a ``rails_auth`` payload), so the branch was an
+        open door: an anonymous socket naming ``rails_agent`` ran the engineer
+        agent, shell tools and all. It fails closed now, and
+        ``verify_rails_token`` actually checks the signature.
+
+        The one caller still allowed through unauthenticated is a box whose
+        operator has explicitly set ``WS_AUTH_REQUIRED=false``. Denying there
+        would make that flag mean "chat is broken" rather than "this box has no
+        auth"; the default is now on, so it is a deliberate choice.
         """
         agent_name = json_data.get("agent_name")
         if not agent_name:
             return True
-        if not self.auth_user or self.auth_user.get("type") != "ws_auth":
-            return True
+
+        if not self.auth_user:
+            if not WS_AUTH_REQUIRED:
+                return True
+            logger.warning(
+                f"Denied agent '{agent_name}' to an unauthenticated client "
+                f"from {self.websocket.client}"
+            )
+            if self._is_websocket_open(self.websocket):
+                await self.manager.send_personal_message({
+                    "type": "auth_error",
+                    "content": "Authentication required. Please refresh the page.",
+                }, self.websocket)
+            return False
 
         from sqlmodel import Session
 
@@ -329,6 +375,41 @@ class WebSocketHandler:
                             break
                         continue
 
+                    # Authenticate BEFORE any dispatch. This used to sit below
+                    # the control-frame handlers, so `cancel`, `attach`,
+                    # `approval_response` and `question_response` bypassed
+                    # WS_AUTH_REQUIRED entirely: `attach` replays a background
+                    # run's buffered output by thread_id, and
+                    # `approval_response` resumes a run parked on a human
+                    # approval — both reachable with no credentials at all.
+                    # `ping` and `auth` above are the only pre-auth frames.
+                    await self._check_auth_from_message(json_data)
+
+                    if not self.authenticated:
+                        if WS_AUTH_REQUIRED:
+                            frame_type = json_data.get("type") if isinstance(json_data, dict) else None
+                            logger.warning(
+                                f"{self._log_ctx()} Unauthenticated '{frame_type or 'message'}' "
+                                f"frame rejected from {self.websocket.client}"
+                            )
+                            if self._is_websocket_open(self.websocket):
+                                await self.manager.send_personal_message({
+                                    "type": "auth_error",
+                                    "content": "Authentication required. Please refresh the page."
+                                }, self.websocket)
+                            if frame_type in _CONTROL_FRAME_TYPES:
+                                # Drop the frame, keep the socket. A control
+                                # frame can arrive just ahead of the `auth`
+                                # frame on reconnect (the browser fetches its
+                                # token asynchronously); closing here would
+                                # turn that race into a reconnect loop.
+                                continue
+                            break
+                        elif not auth_warning_sent:
+                            # Auth not required but not authenticated - warn once (for migration)
+                            logger.info(f"Unauthenticated WebSocket from {self.websocket.client} (auth not required)")
+                            auth_warning_sent = True
+
                     # Authorize the agent mode BEFORE any dispatch. Sits here so
                     # every frame that names an agent_name is gated by one check
                     # — chat, approval_response, question_response, and anything
@@ -378,25 +459,6 @@ class WebSocketHandler:
                             self._attached_threads.add(str(tid))
                         await self.request_handler.start_resume_run(json_data, self.websocket, "question")
                         continue
-
-                    # For all other messages, check authentication
-                    # First try to extract token from message (Rails gem pattern)
-                    await self._check_auth_from_message(json_data)
-
-                    if not self.authenticated:
-                        if WS_AUTH_REQUIRED:
-                            # Auth required but not authenticated - reject and close
-                            logger.warning(f"{self._log_ctx()} Unauthenticated message rejected from {self.websocket.client}")
-                            await self.manager.send_personal_message({
-                                "type": "auth_error",
-                                "content": "Authentication required. Please refresh the page."
-                            }, self.websocket)
-                            break
-                        else:
-                            # Auth not required but not authenticated - warn once (for migration)
-                            if not auth_warning_sent:
-                                logger.info(f"Unauthenticated WebSocket from {self.websocket.client} (auth not required)")
-                                auth_warning_sent = True
 
                     # Idempotency guard (Layer 1 seatbelt): a dropped socket can
                     # make the browser re-send a message it already delivered

--- a/docs/dev/rails_auto_recovery.md
+++ b/docs/dev/rails_auto_recovery.md
@@ -1,0 +1,170 @@
+# Mid-turn Rails auto-recovery (0.7.4)
+
+When agent-written code crashes the Rails app, the user should never be the one
+who discovers it. Leo notices during the same turn and fixes it before handing
+back.
+
+## Shape
+
+```
+Rails exception  ──▶ MothershipReporter.report_exception   (already the single funnel:
+                          │                                 rack middleware, Rails.error
+                          │                                 subscriber, Leonardo error page)
+                          ├──▶ mothership telemetry  (unchanged)
+                          └──▶ LlamaBotRails::ErrorLog   ring buffer, in memory
+                                        │
+                                        ▼
+                          GET /llama_bot/errors?since=<seq>   (agent-token gated)
+                                        │
+                    ┌───────────────────┘  polled once per model call
+                    ▼
+LlamaBot  RailsErrorWatchMiddleware.awrap_model_call
+                    │
+                    └──▶ appends one `[automated]` HumanMessage, then calls the handler
+```
+
+Pull, not push. Rails does not know LlamaBot's URL; LlamaBot already knows
+Rails' (`RAILS_BASE_URL`). Polling also catches crashes in background jobs and
+in requests the user's browser never made — a push from the preview iframe only
+sees pages that iframe happened to load.
+
+The model-call boundary is the injection point because it is the only place
+LangGraph lets you add a message to a live run without cancelling and restarting
+it, and it is the point the model actually reads.
+
+## Why these guardrails
+
+The failure mode this feature invites is a fix→break→fix loop that burns a
+thread. Every rail below exists to bound that:
+
+| Rail | Effect |
+| --- | --- |
+| Arming call looks back `ARMING_WINDOW_SECONDS` (120s), then the cursor takes over | Catches the common case — the app was ALREADY broken when the user asked — without replaying the whole ring. v1 primed to *now* and so was structurally silent for exactly that case. |
+| `MAX_INJECTIONS_PER_TURN = 3` | Fourth new error injects a "stop and explain to the user" note instead, then the watch goes quiet. |
+| Fingerprint dedup per turn | A render loop firing the same `NoMethodError` 200× is mentioned once. |
+| `MAX_REPORT_CHARS = 4000` | A 40-frame backtrace cannot blow the context window. |
+| Plan-mode agents disarmed | Read-only modes are not allowed to act on it. |
+| Every failure path returns `None` | Old gem, timeout, expired token, malformed JSON — the turn proceeds untouched. |
+
+## Auth
+
+`Authorization: LlamaBotFeed <hmac>`, where both sides compute
+`HMAC-SHA256(SECRET_KEY_BASE, "llamabot-error-feed")`. Both containers are handed
+the same `SECRET_KEY_BASE` from the same `.env`, so nothing has to be provisioned.
+Plain HMAC rather than ActiveSupport's `MessageVerifier` because the other end is
+Python and Marshal-based signing cannot be reproduced there.
+
+**This is the second design.** The first authenticated as the signed-in Rails
+user, reusing the `api_token` the chat frontend puts on every WebSocket frame.
+That token only exists while the human holds a Devise session in the browser tab,
+so the whole feature silently no-opped for anyone signed out — the log line was
+`no Rails api_token on the frame`. Whether the box can read its OWN error log
+must not hinge on a browser session. The per-user token survives only as a
+fallback for an ejected app whose Rails container does not share the secret.
+
+The endpoint returns 403 to anything else, so backtraces stay private.
+
+## Kill switch
+
+`LLAMA_BOT_ERROR_FEED=false` in the Rails container turns the ring buffer off
+(the endpoint then returns an empty feed). Independent of
+`LLAMA_BOT_ERROR_TELEMETRY`, which governs mothership reporting only.
+
+---
+
+# TDD plan
+
+Each component is unit-testable in isolation. Write the test, watch it fail,
+implement, watch it pass.
+
+## Gem — `llama_bot_rails` (rspec)
+
+### 1. `LlamaBotRails::ErrorLog` — `spec/lib/llama_bot_rails/error_log_spec.rb`
+
+| # | Test | Asserts |
+| --- | --- | --- |
+| 1 | records class, message, method, path, backtrace | entry fields populated from the exception + rack env |
+| 2 | assigns strictly increasing `seq` | second entry's seq > first |
+| 3 | `since(seq)` returns only newer entries | cursor semantics |
+| 4 | `since(latest_seq)` returns `[]` | no re-delivery |
+| 5 | caps at `MAX_ENTRIES` | oldest fall off, buffer never grows |
+| 6 | repeat of the newest fingerprint collapses | one entry, `count: 2`, fresh `seq` |
+| 7 | a *different* fingerprint does not collapse | two entries |
+| 8 | nil backtrace / no env does not raise | entry still recorded |
+| 9 | disabled by `LLAMA_BOT_ERROR_FEED=false` | `record` no-ops, `since` returns `[]` |
+| 10 | `record` swallows internal failure | returns nil, never raises |
+
+### 2. Reporter tee — `spec/lib/llama_bot_rails/mothership_reporter_error_log_spec.rb`
+
+| # | Test | Asserts |
+| --- | --- | --- |
+| 1 | records locally even when mothership is **not configured** | local recovery does not depend on telemetry creds |
+| 2 | records locally even when **throttled** | throttle is a bandwidth rail, not a recovery rail |
+| 3 | `ignorable?` exceptions (404 / RoutingError) are **not** recorded | no false alarms from bot scans |
+| 4 | same exception object reported twice records **once** | dedup marker independent of the telemetry marker |
+| 5 | mothership dispatch is unchanged when configured | tee is additive, existing telemetry spec still green |
+
+### 3. Endpoint — `spec/controllers/llama_bot_rails/errors_controller_spec.rb`
+
+| # | Test | Asserts |
+| --- | --- | --- |
+| 1 | no `Authorization` header → 403 | backtraces are not public |
+| 2 | valid agent token → 200 JSON `{seq:, errors: []}` | happy path |
+| 3 | no `since` param → `errors` empty, `seq` current | cursor probe |
+| 4 | `?since=N` → only entries with `seq > N` | delta fetch |
+| 5 | non-numeric `since` → treated as probe, no 500 | hostile input |
+
+## LlamaBot (pytest, run in the container)
+
+### 4. Pure turn logic — `app/tests/test_rails_error_watch.py`
+
+Tests `RailsErrorWatch.plan_injection()` — no LangGraph, no HTTP, no event loop.
+
+| # | Test | Asserts |
+| --- | --- | --- |
+| 1 | no new errors → `None` | quiet turn stays quiet |
+| 2 | one new error → text contains `[automated]`, class, message, path | the model gets what it needs |
+| 3 | same fingerprint twice → second call `None` | per-turn dedup |
+| 4 | three distinct errors → three injections | budget spends correctly |
+| 5 | fourth error → give-up text, `injections` frozen | loop bound |
+| 6 | fifth error after give-up → `None` | give-up delivered once |
+| 7 | huge backtrace → text ≤ `MAX_REPORT_CHARS` | context safety |
+| 8 | two errors in one poll → single message listing both | no burst of messages |
+| 9 | `agent_can_auto_recover("rails_plan_mode_agent")` is False | mode gate |
+| 10 | `agent_can_auto_recover("rails_agent")` is True | mode gate, positive case |
+| 11 | watch with no `api_token` is not armed | graceful degradation |
+
+### 5. Feed client — `app/tests/test_rails_error_feed_client.py`
+
+Driven by an injected `httpx.MockTransport`; no network.
+
+| # | Test | Asserts |
+| --- | --- | --- |
+| 1 | 200 with valid body → `(seq, errors)` | happy path |
+| 2 | sends `Authorization: LlamaBot <token>` | auth wiring |
+| 3 | `since=None` → no `since` query param | cursor probe |
+| 4 | `since=7` → `?since=7` | delta fetch |
+| 5 | 403 → `None` | expired token degrades silently |
+| 6 | 404 → `None` | old gem without the endpoint |
+| 7 | timeout / connect error → `None` | Rails down mid-turn |
+| 8 | malformed JSON → `None` | never raises into the turn |
+| 9 | body missing `seq` → `None` | contract violation is not a crash |
+
+### 6. Middleware — `app/tests/test_rails_error_watch_middleware.py`
+
+Fake request + fake handler; asserts structure only.
+
+| # | Test | Asserts |
+| --- | --- | --- |
+| 1 | no active watch → handler called with request untouched | inert in headless runs and tests |
+| 2 | first call primes the cursor and injects nothing | pre-turn errors ignored |
+| 3 | new error on a later call → one message appended before the handler runs | the actual feature |
+| 4 | handler's response returned unchanged | transparent |
+| 5 | client raising → handler still called, no exception escapes | never fatal |
+| 6 | disarmed watch (plan mode) → no poll attempted | mode gate honoured at the boundary |
+| 7 | `build_leonardo_agent` includes the middleware exactly once | wiring, idempotent |
+
+## Manual QA
+
+Lives in `docs/test_plans/0.7.4.md` — the loop that cannot be unit tested is
+"Leo actually fixed it", which needs a real model.

--- a/docs/dev/sso_return_to_brand.md
+++ b/docs/dev/sso_return_to_brand.md
@@ -1,0 +1,92 @@
+# SSO return-to-brand (`sso_origin`) — 0.7.4
+
+## The bug
+
+The mothership Rails app now answers on two domains: `llamapress.ai` (original)
+and `builtwithleo.com` (new). A box only knows one of them — whatever
+`.leonardo/instance.json` carries as `mothership_url`, which for every box in
+the fleet today is `https://llamapress.ai`.
+
+So a user who signed up and signed in at **builtwithleo.com**, then landed in
+their box, got sent to **llamapress.ai** the next time the box needed them to
+re-authorize (expired grant, used grant, the login-page SSO button). Different
+domain → different Rails session → a sign-in wall on a brand they have never
+used.
+
+## Why not detect it
+
+Two guesses were considered and rejected:
+
+- **Host header.** Instance boxes are all on `*.llamapress.ai`; there is no
+  wildcard DNS on `builtwithleo.com`. The host carries no brand signal.
+- **`Referer`.** Routinely stripped on a cross-origin redirect, so it would
+  silently fall back to llamapress.ai most of the time.
+
+The origin has to be *told* to the box.
+
+## The contract
+
+**Mothership → box.** Whenever the mothership redirects a browser into a box, it
+appends its own base URL as `sso_origin`:
+
+```
+https://<box>/auth/consume?token=<grant>&sso_origin=https://builtwithleo.com
+https://<box>/login?token=<magic-link>&sso_origin=https://builtwithleo.com
+```
+
+Both entry points accept it. It is optional — omitting it keeps today's
+behavior exactly (fall back to `mothership_url`).
+
+**Box side** (`app/services/sso_origin.py`):
+
+1. Validate against an allowlist of apex domains — `llamapress.ai`,
+   `builtwithleo.com`, plus whatever host `mothership_url` points at, plus
+   anything in the `SSO_ORIGIN_HOSTS` env var (comma-separated, for staging).
+   A host matches when it *is* an apex or is a subdomain of one. Anything else
+   is ignored and we fall back to `mothership_url`.
+2. Remember it in the `leo_sso_origin` cookie (HttpOnly, SameSite=Lax, 1 year).
+   It is a branding preference, not a credential, and should outlive the
+   session cookie.
+3. Build every **user-facing** mothership link from it:
+   - the `/login` page CTA — `<origin>/sso/leo/{instance_name}`, copy reads
+     "Sign in with your **Leo** account" on builtwithleo.com;
+   - the `/auth/consume` recovery bounce on `grant_expired`/`grant_used`/
+     `grant_not_found`;
+   - the "Continue with **Leo**" link on the sign-in error page.
+
+Precedence is: this request's `?sso_origin=` → the cookie → `mothership_url`.
+
+**Server-to-server calls are untouched.** Every `MothershipClient` API call
+(lease renewal, `verify_login_grant`, telemetry, overlay ads) still goes to
+`mothership_url` — that is the credentialed channel and the API token is scoped
+to it. `sso_origin` only ever changes what a *browser* is pointed at.
+
+## Open-redirect safety
+
+`sso_origin` arrives as an unvalidated query param, so it is treated as hostile.
+Only an allowlisted host is honored, and the match is host-based, not substring
+— `https://builtwithleo.com.evil.com` and `https://notbuiltwithleo.com` are both
+rejected. `http://` on a public brand domain is upgraded to `https://`. Path,
+query and fragment are stripped; only `scheme://host[:port]` survives. A
+poisoned cookie is re-validated on every read and falls back the same way.
+
+## Brand copy
+
+`BRAND_DISPLAY_NAMES` in `app/services/sso_origin.py` maps apex → label:
+`llamapress.ai` → "LlamaPress.ai", `builtwithleo.com` → "Leo". An unlisted host
+(self-hosted mothership) renders as the bare host. Change the label there, not
+in the routers.
+
+## Still on llamapress.ai
+
+Only SSO is brand-aware. These static links in the chat UI are still hardcoded
+and would need their own pass if the rebrand goes further:
+`app/frontend/chat.html` (header logo, support mailto, pricing link),
+`app/frontend/chat/ui/IframeManager.js` (wiki link),
+`app/routers/api.py` (`COOKBOOK_URL`).
+
+## Tests
+
+`app/tests/test_sso_origin.py` — allowlist/lookalike rejection, precedence,
+the `/auth/consume` bounce target, cookie persistence, and the `/login` CTA
+host + copy.

--- a/docs/dev_logs/0.7.4
+++ b/docs/dev_logs/0.7.4
@@ -1,0 +1,24 @@
+0.7.4:
+[x] - Building screen can now show rotating promos served from mothership.
+[x] - Mothership controls when those promos show, per user.
+[x] - Turned off the yellow inactivity warning banner (kept behind a flag).
+[x] - Leo now spots a Rails crash mid-turn and fixes it before handing back.
+[x] - SSO sends you back to the domain you came from, not always llamapress.ai.
+[x] - "My Uploads" opens the full asset library straight away (no intermediate list), and the library can go full screen.
+[x] - Spreadsheets preview as a real cell grid, parsed on the box — the broken Microsoft Office Online iframe is gone.
+[x] - GitHub sign-in (/gh) now finishes on its own — it keeps checking while you authorize, and the moment you switch back to the tab, so the refresh button is optional.
+[x] - Leo can ask a few questions in one card now, instead of one per turn.
+[x] - Long beginner-mode chats compact now instead of hitting the token wall.
+[x] - New check_page tool so Leo loads every page it writes.
+[x] - Prompts stop advertising tools that are switched off on the box.
+[x] - Writing a migration now runs it, so the app stops going down.
+[x] - edit_file no longer claims success on an edit that never landed.
+[x] - A timed-out helper now reports what it already did.
+[x] - bash_command stops blocking ordinary Ruby like Rails.env.
+[x] - Rails crashes now show in the chat's error notice too.
+[x] - Building screen only shrinks for a promo that actually loads; with no promo it looks exactly as it did before.
+[x] - Error notice now says whether it's a Rails or JavaScript error.
+[x] - Chat WebSocket now rejects forged Rails tokens.
+[x] - Agent modes deny by default instead of allowing.
+[x] - WebSocket auth is required by default now.
+[x] - Mothership telemetry now says which signed-in user sent each message, not just which box.

--- a/docs/handoff_mothership_user_attribution.md
+++ b/docs/handoff_mothership_user_attribution.md
@@ -1,0 +1,68 @@
+# Mothership handoff — who sent the message (user attribution on telemetry)
+
+**From:** LlamaBot 0.7.4 (shipping now)
+**To:** LlamaPress.ai mothership
+**Instance-side code:** `app/services/user_context.py`
+
+## The gap
+
+Every report an instance sends — `report_message`, `report_error`,
+`report_turn_metrics`, `submit_feedback` — carried `instance_name` and nothing
+about *who* was at the keyboard. A box with three people on it produced one
+undifferentiated stream: "instance foo sent 400 messages" with no way to say
+which account sent which, which user is hitting the errors, or whose turns are
+slow.
+
+## What instances now send
+
+All four report endpoints may now carry an optional `user` object:
+
+```json
+"user": {
+  "id": 3,
+  "username": "kody@llamapress.ai",
+  "email": "kody@llamapress.ai",
+  "llamapress_user_guid": "b7f0…",
+  "role": "engineer",
+  "is_admin": true
+}
+```
+
+The same shape already goes to `POST /api/leonardo/overlay_ads` (it previously
+sent a four-field subset; it now sends this).
+
+**`llamapress_user_guid` is the join key, and it is yours.** The mothership
+minted it during unified login and the instance stored it on the local shadow
+user (`app/routers/unified_login.py`). The box is not translating one identity
+into another — it is echoing back a foreign key you already own. So the mapping
+to a llamapress.ai account belongs on your side: `guid -> user`, one lookup.
+
+**Do not join on `email`.** It is a synced copy of the mothership profile,
+carried for human readability in triage only. Matching accounts by email is
+precisely the spoofable path `unified_login` refuses to take; the same reasoning
+applies to the reporting side.
+
+## Cases where identity is partial or absent
+
+The field is **omitted entirely** when the instance does not know who is acting.
+Treat a missing `user` as "unattributed", never as "the box's only user".
+
+| Case | What arrives |
+|---|---|
+| Unified-login (SSO) user | Full object, `llamapress_user_guid` set — maps to an account |
+| Legacy username/password user | Object with `llamapress_user_guid: null` — identifiable per-box only, because no llamapress.ai account exists to map to |
+| `llama_bot_rails` gem token (Rails-embedded chat) | Partial object: `{username: "rails_user:5", rails_user_id: 5, source: "llama_bot_rails", id: null, llamapress_user_guid: null}` — a **Rails** user id, a different namespace from yours; never resolve it against llamapress.ai accounts |
+| Unauthenticated / DB unreachable / pre-0.7.4 instance | No `user` key at all |
+
+## Asks
+
+1. Persist `user` on `InstanceMessage`, `InstanceError`, the turn-metrics row and
+   the feedback annotation. A jsonb column plus a resolved `user_id` FK
+   (populated from `llamapress_user_guid` when it matches) is enough.
+2. Segment the existing dashboards by resolved user, keeping "unattributed" as a
+   visible bucket rather than folding it into the box owner.
+3. `overlay_ads` can now target on `llamapress_user_guid` instead of the box-local
+   `id`, which is stable across instances for the same person.
+
+Backward compatible in both directions: instances that don't send `user` behave
+exactly as before, and a mothership that ignores the field loses nothing.

--- a/docs/test_plans/0.7.4.md
+++ b/docs/test_plans/0.7.4.md
@@ -1,0 +1,633 @@
+# Test plan — 0.7.4
+
+Manual QA checklist for user-visible changes in 0.7.4. See `README.md` for conventions.
+The full change list for this release lives in `docs/dev_logs/0.7.4`.
+
+**Status:** in progress
+**Tester:**
+**Date:**
+
+---
+
+## Jumbotron: rotating promos in the building overlay
+
+The "Your App is Building!" overlay now has a promo slot under the animation. The
+creative is **mothership-owned HTML** — a snippet is written/edited on the mothership
+and picked up by every instance on its next build, with no instance deploy. More than
+one snippet rotates on a cadence the mothership sets (default 3 minutes).
+
+The snippet is rendered inside a **sandboxed, opaque-origin iframe** (`allow-scripts`
+without `allow-same-origin`), so a promo can animate itself but can never reach the chat
+DOM, cookies or the session. Everything fails open: no mothership, an old mothership
+that 404s the endpoint, a timeout — the overlay simply shows no slot, exactly as before.
+
+**Setup**
+
+- Change is in **LlamaBot** — needs a released image or a `--force-recreate` (uvicorn
+  runs without `--reload`), plus a hard refresh for the overlay JS.
+- Code: `app/services/overlay_ads.py`, `app/services/mothership_client.py`
+  (`fetch_overlay_ads`), `app/routers/api.py` (`GET /api/overlay-ads`),
+  `app/frontend/chat/ui/OverlayAds.js`, `app/frontend/chat/ui/IframeManager.js`.
+  Automated coverage: `app/tests/test_overlay_ads.py`,
+  `app/tests/js/overlay_ads.test.mjs`.
+- **The mothership half is not built yet.** Until it ships
+  `POST /api/leonardo/overlay_ads`, QA this through the local override file below.
+
+### The override file (also how you preview creative before publishing)
+
+Drop `.leonardo/overlay_ads.json` next to `instance.json` — it **wins over the
+mothership** and is re-read on every request, so you edit the file, refresh, and see the
+new promo. On this dev box that path is `~/dev/Leonardo/.leonardo/overlay_ads.json`
+(bind-mounted to `/app/app/.leonardo/`).
+
+```json
+{
+  "rotate_seconds": 180,
+  "ads": [
+    { "id": "pro", "height": 140, "html": "<div style=\"padding:20px\">Go Pro</div>" },
+    { "id": "wiki", "height": 140, "html": "<div style=\"padding:20px\">Read the wiki</div>" }
+  ]
+}
+```
+
+`html` is required; `id` and `height` are optional. The backend clamps everything: at
+most 10 ads, 64KB per snippet, height 60–400px, rotation 15–3600s.
+
+### Console shortcuts (skip the send-a-message-and-wait loop)
+
+`window.leoAds` is installed automatically by `IframeManager` — **nothing to paste.** Open
+devtools on the chat page and use it directly:
+
+| Call | Does |
+|---|---|
+| `leoAds.show()` | Overlay up now, promos load — no agent turn |
+| `leoAds.next()` | Jump to the next promo instead of waiting out the cadence |
+| `leoAds.status()` | `{overlay, mode, ads, showing, rotateSeconds}` |
+| `leoAds.plan()` | Force the todo-list layout (promo shrinks under the box) |
+| `leoAds.question()` | Force the question layout (promo must disappear) |
+| `leoAds.building()` | Back to the jumbotron layout |
+| `leoAds.hide()` / `leoAds.toggle()` | Dismiss / flip |
+| `leoAds.ads()` | Table of what `/api/overlay-ads` is serving right now |
+
+`show()`/`hide()`/`toggle()` use public methods and are stable. `next()`, `plan()`,
+`question()`, `building()` poke overlay internals — debug-only, and a chat mutation can
+flip a forced mode back (the plan mirror owns the mode in real use).
+
+Local creative iteration: edit `.leonardo/overlay_ads.json`, then `leoAds.show()`. The
+override file is re-read on **every** request, so there's no 60s cache to wait out — that
+only applies to mothership-served ads.
+
+**The happy path**
+
+- [ ] With no `.leonardo/overlay_ads.json` and a mothership that doesn't serve promos,
+      send Leo a build request. The overlay looks **exactly as it did in 0.7.3** — no
+      empty box, no gap.
+- [ ] `curl localhost:8000/api/overlay-ads` → `{"ads":[],"rotate_seconds":180}`, HTTP 200.
+- [ ] Write the override file above with **three** promos and `"rotate_seconds": 15`
+      (short, so you don't wait 3 minutes). Hard-refresh the chat.
+- [ ] Start a build. The status block (animation + title + tip) is a small pill in the
+      **top-left**; the promo fills the rest of the pane — up to 900px wide and the full
+      height. The promo, not the title, is what your eye lands on.
+- [ ] Wait ~15s. It cross-fades to the second promo, then the third, then **wraps back
+      to the first**.
+- [ ] A promo authored as a short banner (fixed `height`) still fills the tall slot —
+      its background stretches rather than leaving dead space below it.
+- [ ] Click a link inside a promo → it opens in a **new tab**, and the chat page behind
+      it is untouched.
+
+**Display policy — the mothership decides when a promo shows**
+
+All four gates verified in-browser; re-check after any overlay change. Drive them with a
+local `.leonardo/overlay_ads.json` carrying a `policy` object, and `leoAds.status()` to
+read the verdict.
+
+- [ ] Default policy: promo is **absent** ~1s into a build and **present** by ~7s
+      (`show_after_seconds: 5`). `leoAds.status().verdict` is `ok` throughout — the
+      verdict is "allowed", the delay is separate.
+- [ ] `"show_after_seconds": 0` → promo appears immediately.
+- [ ] `"enabled": false` → never appears; verdict is `disabled-by-policy`.
+- [ ] `"modes": ["building"]` → promo shows while starting up, then **disappears** once a
+      todo list exists (`leoAds.plan()` to force it).
+- [ ] `"min_interval_seconds": 1800` → shows on the first build, then verdict is
+      `cooldown:<n>s-left` on the next two. `leoAds.resetCooldown()` makes it show again.
+- [ ] A policy field you don't send keeps its default — send only `show_after_seconds`
+      and confirm `leoAds.status().policy` still has `modes` and `enabled` populated.
+- [ ] `"modes": ["building","plan","question"]` → `question` is **stripped**; a promo must
+      never appear while Leo is waiting on an answer.
+
+**Personalisation**
+
+- [ ] `leoAds.policy()` shows the `variant` the mothership assigned this browser.
+- [ ] Sign in as two different users on the same box; each gets their own fetch (the
+      cache is keyed per user, so targeted creative can't leak between them).
+
+**The states it must not break**
+
+- [ ] Once Leo writes a plan, the overlay switches to the todo list — the promo shrinks
+      to its payload `height` (140 default) and sits below the todo box, 480px wide. The
+      todo list gets the space back; `height` only applies in this mode.
+- [ ] When Leo asks a question (AskUserQuestion), the promo slot **disappears** — nothing
+      competes with the question card — and comes back after you answer.
+- [ ] Hit **Escape** (or the **Hide** pill) mid-build. The overlay goes away and the
+      promo goes with it.
+- [ ] Start another build immediately. The promo comes back and rotates normally (the
+      previous rotation timer must not have leaked — two overlapping timers would show
+      up as promos flipping twice as fast).
+
+**Fail-open**
+
+- [ ] Put deliberate garbage in `.leonardo/overlay_ads.json` (e.g. `{ not json`). Refresh
+      and build: no promo slot, no console error, the overlay still works.
+- [ ] Give a promo an empty `"html": ""`. It is dropped; the other promos still show.
+- [ ] Delete the override file. Refresh: back to the mothership answer (no slot today).
+
+**Security — the one that matters**
+
+- [ ] With a promo showing, inspect the slot in devtools. The iframe's `sandbox`
+      attribute is `allow-scripts allow-popups allow-popups-to-escape-sandbox`.
+      **`allow-same-origin` must NOT be present** — with `allow-scripts` it cancels the
+      sandbox and hands the promo the user's session.
+- [ ] Put `<script>parent.document.title='pwned'</script>` in a promo's html. The chat
+      page title is unchanged (the frame is cross-origin to the parent).
+
+---
+
+## Inactivity warning banner is off
+
+The yellow "Session expiring soon due to inactivity." bar no longer appears. The lease
+and activity-sync behind it are unchanged — only the banner is suppressed.
+
+- [ ] Open the chat and leave it completely idle past the lease warning window
+      (`lease_duration_seconds - 60`, see `/api/lease-status`). No yellow banner appears.
+- [ ] In devtools, `document.querySelector('[data-llamabot="timeout-warning"]')` still
+      exists in the DOM and is still `hidden` — the markup is kept, just never shown.
+- [ ] Network tab: `/api/update-activity` still fires as you use the chat, and
+      `/api/lease-status` is still fetched on load. Session leasing is unaffected.
+- [ ] Flip `INACTIVITY_WARNING_BANNER_ENABLED` to `true` in
+      `app/frontend/chat/config.js`, hard-refresh, idle again: the banner comes back and
+      "Continue Working" dismisses it. Flip it back to `false`.
+
+---
+
+## Mothership contract (for whoever builds the other half)
+
+`POST /api/leonardo/overlay_ads`, `Authorization: Bearer <mothership_api_token>`:
+
+```
+request:  {"instance_name": "...", "llamabot_version": "0.7.4"}
+response: {"rotate_seconds": 180,
+           "ads": [{"id": "pro", "height": 140, "html": "<div>...</div>"}]}
+```
+
+Anything else (404, 500, timeout, garbage) is treated as "no promos". Instances cache
+the answer for 60s, so a creative edit is live fleet-wide within about a minute.
+
+---
+
+## Leo fixes a Rails crash mid-turn
+
+The point of this one: a turn should never END on the "Something broke in this Rails
+app" page. Leo notices the crash during the same turn and repairs it before handing
+back. Design notes in `docs/dev/rails_auto_recovery.md`.
+
+Requires a Rails container running llama_bot_rails 0.7.4+ (the feed endpoint) and a
+chat mode that can edit files (NOT plan mode).
+
+### The happy path
+
+- [ ] Open the chat with the Rails preview visible. Ask Leo to make a change that it
+      will verify by loading a page — e.g. "add a `subtitle` field to the posts index
+      and show it on the page".
+- [ ] While it works, watch for a `[automated]` system bubble if the app breaks. When
+      one appears, Leo should immediately go and fix that exception rather than
+      finishing and reporting success.
+- [ ] The turn ends with a working page in the preview, not a red error page.
+
+### Force the failure (the honest test)
+
+- [ ] Ask Leo to make an edit, then — while the turn is still running — break the app
+      yourself in another editor (e.g. add `raise "boom"` to a controller action Leo
+      will load).
+- [ ] Leo picks the exception up on its next step and fixes it inside the same turn.
+- [ ] The `[automated]` message names the exception class, the request path, and the
+      first few backtrace lines.
+
+### The rails hold
+
+- [ ] Break the app in a way Leo cannot fix (e.g. `raise "boom"` in a before_action it
+      keeps re-adding). After **3** repair attempts Leo stops and explains in plain
+      language what is broken instead of looping.
+- [ ] Repeat the same broken page many times in one turn. Leo mentions it once, not
+      once per request.
+- [ ] Switch to a plan-mode chat and break the app. Plan mode does NOT try to fix it —
+      it stays read-only.
+
+### It degrades quietly
+
+- [ ] Stop the Rails container mid-turn (`docker compose stop llamapress`). The turn
+      finishes normally — no errors in the chat, no hang.
+- [ ] `LLAMA_BOT_ERROR_FEED=false` on the Rails container: the whole feature goes
+      silent, and everything else still works.
+- [ ] Unauthenticated `curl http://llamapress:3000/llama_bot/errors` returns **403**.
+      Backtraces must never be public.
+
+---
+
+## SSO returns you to the domain you came from
+
+The mothership now answers on **builtwithleo.com** as well as **llamapress.ai**. Every
+user-facing sign-in link on the box should point at the domain the user actually
+arrived from, not at whatever `.leonardo/instance.json` has as `mothership_url`.
+
+Requires the mothership to append `sso_origin=<its own base URL>` when it redirects a
+browser into a box (`/auth/consume?token=…` and the legacy `/login?token=…`). See
+`docs/dev/sso_return_to_brand.md` for the contract.
+
+### The login-page button follows the brand
+
+- [ ] Open `https://<box>/login` with no extra params. The button reads
+      **"Sign in with your LlamaPress.ai account"** and links to `llamapress.ai`.
+- [ ] Open `https://<box>/login?sso_origin=https://builtwithleo.com`. The button now
+      reads **"Sign in with your Leo account"** and links to
+      `https://builtwithleo.com/sso/leo/<instance>`.
+- [ ] Reload `https://<box>/login` with NO params. It still says "Leo" and still points
+      at builtwithleo.com — the origin is remembered in a cookie.
+- [ ] Clicking the button lands you on builtwithleo.com's sign-in, and after signing in
+      you come back into the box signed in. You are never asked to sign in at
+      llamapress.ai.
+
+### End to end from the new brand
+
+- [ ] Sign in at **builtwithleo.com**, open your instance from there.
+- [ ] In the box, sign out (or wait for the grant to expire) and trigger sign-in again.
+      Every prompt stays on builtwithleo.com.
+- [ ] Repeat the same flow starting from **llamapress.ai** — it stays on llamapress.ai.
+      Neither brand leaks into the other.
+
+### It can't be aimed somewhere else
+
+- [ ] `https://<box>/login?sso_origin=https://evil.example.com` — the button still
+      points at llamapress.ai. Same for `https://builtwithleo.com.evil.com` and
+      `https://notbuiltwithleo.com`.
+- [ ] A self-hosted box (no `.leonardo/instance.json`) shows the plain
+      username/password form with no SSO button at all.
+
+### Nothing else moved
+
+- [ ] Chat, previews, and telemetry still work — server-to-server mothership calls
+      still go to `mothership_url`, only browser links changed.
+
+---
+
+## Activity: filter by person, and clocks that say their zone
+
+Two changes to the Activity screens (`/llama_bot/activity`), both in
+**llama_bot_rails** — needs a Rails container on gem 0.7.4+.
+
+1. The feed can be narrowed to **one person**, and the Usage page's People list is the
+   way in: click a name, land on their feed.
+2. Every clock is rendered in **one named zone**, and the page says which. The default
+   is **Pacific**; a host app that sets `config.time_zone` wins; a host app that sets
+   `config.llama_bot_rails.display_time_zone` beats both.
+
+Automated coverage: gem `spec/controllers/llama_bot_rails/activity_events_controller_spec.rb`,
+`spec/helpers/llama_bot_rails/activity_helper_time_zone_spec.rb`,
+`spec/lib/llama_bot_rails/display_time_zone_spec.rb`.
+
+**Setup** — you need a few events with real actors on them. Sign in and click around
+(each save records one), or seed two by hand:
+
+```ruby
+E = LlamaBotRails::ActivityEvent
+E.create!(event_type: "contact.updated", occurred_at: Time.utc(2026, 8, 23, 2, 30),
+          source: "admin_ui", human: true,
+          actor_type: "User", actor_id: "7", actor_label: "Grace Hopper")
+E.create!(event_type: "invoice.approved", occurred_at: Time.current,
+          source: "admin_ui", human: true,
+          actor_type: "User", actor_id: "9", actor_label: "Alan Turing")
+```
+
+### Filtering to one person
+
+- [ ] Open **Activity**. The filter bar has a **Person** dropdown, first in the row,
+      defaulting to **Everyone** and listing everyone who appears in the feed.
+- [ ] Pick a person → **Filter**. Only their rows remain, and a banner above the filters
+      reads *"Showing only <name>."*
+- [ ] Click **Show everyone** in that banner. Back to the full feed, and any other
+      filter you had set (search text, date range) is still applied.
+- [ ] Person combines with the other filters — pick a person AND a date range and both
+      bite.
+- [ ] Open **Usage**. Each row in **People** is now clickable and hovers. Click one →
+      the feed opens filtered to that person, human actions only.
+- [ ] Open any event's **Details**. The **Actor** is a link; click it → their feed.
+- [ ] Someone who acted before their name was recorded shows as **User #<id>** rather
+      than disappearing from the dropdown.
+
+### The zone, stated plainly
+
+- [ ] Activity, Usage and a record's History each carry a line under the heading:
+      *"All times shown in Pacific Time (PDT)."* (PST in winter.)
+- [ ] An event's **Details** page shows its full timestamp followed by the same zone
+      name.
+- [ ] Pick an event you know the UTC time of. The clock on the feed is that time minus
+      7 hours (8 in winter) — not the UTC number.
+- [ ] An event from late evening Pacific that is already "tomorrow" in UTC is grouped
+      under the **Pacific** day heading, and says **Today** on the right day.
+- [ ] Set a **From**/**To** of that same Pacific day. The late-evening event is
+      included — the date box means a Pacific day, not a UTC one.
+- [ ] Drop `llama_activity_history(record)` into a host app page (or open one that
+      already has it): the timeline ends with *"Times shown in Pacific Time (PDT)."*
+
+### Overriding the zone
+
+- [ ] In the overlay's `config/application.rb`, set
+      `config.time_zone = "Eastern Time (US & Canada)"`, restart. Every clock and every
+      zone line on these pages now reads Eastern.
+- [ ] Add `config.llama_bot_rails.display_time_zone = "UTC"` to an initializer, restart.
+      The pages read **UTC** — it outranks `config.time_zone`.
+- [ ] Remove both. Back to Pacific. (A host app whose `config.time_zone` is left at
+      Rails' default of UTC gets Pacific — that default is indistinguishable from
+      "never set one", so it is treated as unset. Set `display_time_zone = "UTC"` to
+      really mean UTC.)
+
+## My Uploads and the spreadsheet preview
+
+Setup: upload at least one `.xlsx` (multi-sheet if you have one), one `.csv`, and one
+`.docx` via the paperclip → **Upload file**.
+
+### One click to the library
+
+- [ ] Paperclip → **My Uploads**. The full-screen **Asset Library** modal opens
+      immediately — the old narrow list panel with the expand arrow never appears.
+- [ ] The attach menu closes behind it. Esc, the ✕, and clicking the backdrop all close
+      the modal.
+
+### Spreadsheets show cells, not an error
+
+- [ ] Click the `.xlsx`. The right pane shows a spreadsheet grid: A/B/C column headers,
+      numbered rows, your real cell values. Numbers are right-aligned.
+- [ ] Multi-sheet workbook: tabs across the top; clicking one loads that sheet's cells.
+- [ ] A sheet over 500 rows shows the first 500 and a line saying so with the true total.
+- [ ] Click the `.csv` — same grid.
+- [ ] Nothing anywhere offers **"Preview with Microsoft Office Online"**, and no preview
+      loads `view.officeapps.live.com` (check the Network tab — there should be no
+      request off this box for a preview).
+- [ ] Turn off your network / block `cdnjs.cloudflare.com`, reload, open the `.xlsx`
+      again: it still renders. The grid comes from this box now, not a CDN.
+- [ ] Click the `.docx`: "No inline preview for .docx files" plus **Download** — no
+      broken external viewer.
+- [ ] **Attach to message** from the modal still puts the file in the composer.
+
+### Making the sheet bigger
+
+- [ ] With a spreadsheet open, hit the **expand** arrows in the modal header. The modal
+      fills the screen, the file list gets out of the way, and the grid gets the full
+      width — noticeably more columns and rows visible.
+- [ ] The same button (now inward arrows, tooltip *"Back to the file list"*) returns to
+      the two-pane layout.
+- [ ] **Esc** while expanded collapses back to the two-pane view; **Esc** again closes
+      the modal.
+- [ ] Close the modal while expanded, then reopen **My Uploads**: you get the normal
+      two-pane layout with the file list, not a listless full-screen view.
+
+---
+
+## Plan mode: several questions on one card
+
+Leo used to ask one clarifying question per turn — answer, wait for the round-trip,
+answer the next. It can now put **2–4 questions on a single card** and take all the
+answers at once. The "See visual options" escape hatch survives and is now
+**per-question**: you can ask for live previews on question 2 while answering 1 and 3
+in text.
+
+Use **Plan mode** (or Engineer Plan / Ticket Plan mode) for all of this. A request with
+a few genuinely open decisions works best, e.g. *"add a discount code box to checkout"*.
+
+### The batched card
+
+- [ ] Leo's first move is a single card with **more than one question** on it, each
+      numbered (1, 2, 3…) down the left.
+- [ ] The footer reads **"0 of 3 answered"** and **Continue is greyed out**.
+- [ ] Click an option on question 1 — the count goes to "1 of 3" and Continue is still
+      greyed out. Answer them all and Continue lights up.
+- [ ] Each question has its own option chips, its own **Skip**, and its own type-your-own
+      box. Options are still multi-select — click two, both stay lit.
+- [ ] Per-question **Skip** does *not* submit the card; it marks that one question
+      skipped (it looks dimmed/selected) and counts it toward the total.
+- [ ] Clicking an option on a skipped question un-skips it.
+- [ ] **Skip all** in the footer submits the whole card immediately, as before.
+- [ ] Hit **Continue**. Your chat bubble shows one line per question,
+      `question → your answer`, and skipped ones read `(skipped)`.
+- [ ] **Leo answers all of them in ONE reply** — it must not re-ask anything you just
+      answered. This is the whole point of the change.
+
+### Visual options still work, per question
+
+- [ ] Ask for something with a look-and-feel decision in it, so one question in the batch
+      carries the dashed **"See visual options"** chip (eye icon).
+- [ ] Only the visual question has the chip — the plain text questions don't.
+- [ ] Answer the other questions normally, tap **See visual options** on the visual one,
+      hit Continue.
+- [ ] Your bubble shows **"See visual options"** for that question — *not* a wall of
+      instructions to Leo.
+- [ ] Leo comes back with the **live preview carousel** (‹ › arrows, "Choose this",
+      "Expand") for **that question only**.
+- [ ] Critically: Leo does **not** re-ask the questions you already answered. It keeps
+      them and only re-asks the visual one.
+- [ ] Type something in the visual question's text box *as well as* tapping the chip —
+      Leo's previews should reflect what you typed (e.g. "keep it subtle").
+- [ ] Pick a design in the carousel. Leo carries on with that design plus your earlier
+      answers.
+
+### One question still behaves exactly as before
+
+- [ ] Ask something narrow enough that Leo asks a **single** question. The card looks
+      like it always did: options in a row with **Skip**, a text box with the **↑ send
+      arrow**, no numbering, no "0 of 1 answered" footer.
+- [ ] The send arrow submits. **Skip** submits immediately.
+- [ ] On a single visual question, "See visual options" still triggers the preview
+      carousel.
+
+### The building overlay mirror
+
+- [ ] Trigger a batched question while the **"Your App is Building!"** overlay is up.
+- [ ] The overlay title reads **"3 questions from Leo"** (matching the count), and the
+      whole card is mirrored inside it.
+- [ ] If the card is taller than the overlay slot, it **scrolls inside the box** — the
+      overlay itself must not overflow.
+- [ ] Answer in the overlay copy → the chat copy locks too (greyed, unclickable), and
+      the overlay reverts to building/plan. Answering in the chat copy does the same to
+      the overlay copy. It must submit **once**, not twice.
+
+### Typing instead of clicking
+
+- [ ] With a batched card on screen, ignore it and type into the **main chat box**
+      instead. Your text is taken as the answer and Leo carries on — no hang, no
+      re-asked card.
+
+### Edge cases
+
+- [ ] Ask something broad enough that Leo wants many questions. It shows **at most 4**
+      on one card, then asks the rest on the next turn — none are silently dropped.
+- [ ] A question containing a double quote (`Use the "big" hero?`) renders normally —
+      no broken layout, no stray attribute text on the page.
+
+---
+
+## Rails crashes show in the chat's error notice
+
+The companion to "Leo fixes a Rails crash mid-turn". That one covers crashes Leo
+caused and repairs silently; this one covers crashes **the user causes themselves**,
+clicking around their own app while Leo is idle. Until now those only showed as a
+Rails error page inside the preview, with no way to tell whether Leo could see it.
+
+Now they land in the same quiet notice above the composer that already carries the
+preview's JavaScript errors, and ride along with the next message.
+
+Requires a Rails container running llama_bot_rails 0.7.4+ (the same feed endpoint as
+the section above) and a signed-in Rails session, since the notice reads the feed with
+the browser's Rails token.
+
+### The happy path
+
+- [ ] Open the chat. The notice above the composer is **hidden** — a crash from before
+      you opened the page must not greet you.
+- [ ] In the preview, do something that 500s. `/telemetry_boom` is a deliberate crash
+      route if the app has one; otherwise break a page (e.g. rename a method a view
+      calls) and load it.
+- [ ] Within a few seconds the notice appears: **"1 error detected"**, a *Read more*
+      link, and a **Show Leo** box already ticked.
+- [ ] **Read more** opens a popup that leads with a plain sentence ("The server hit an
+      error handling that request."), then the real exception, then `on GET /your/path`.
+      *Technical details* expands to the Ruby backtrace.
+- [ ] Reload the same broken page a few times. It stays **one** entry — the popup says
+      "happened N times" rather than the notice climbing to "5 errors detected".
+- [ ] Send any message. Leo answers knowing about the crash (ask "what broke?" and it
+      describes *your* exception, not a guess). The notice clears once sent.
+
+### Not crying wolf
+
+- [ ] Load a URL that doesn't exist (`/definitely-not-a-page`). A 404 is not a crash —
+      **no notice appears**.
+- [ ] Untick **Show Leo**, then send a message. The errors stay in the tray and are NOT
+      in the message; the popup says so too.
+- [ ] Dismiss the notice with **×**. It hides and stops sending. A *new, different*
+      error reopens it; another repeat of the same one does not.
+
+### While Leo is working
+
+- [ ] Ask Leo to make a change that breaks a page mid-turn. During the turn, the notice
+      must **stay hidden** — that crash is Leo's to fix (previous section), and showing
+      it here would hand you a problem already being handled.
+- [ ] After the turn finishes, break a page yourself. The notice appears again — the
+      poller was quiet, not switched off.
+
+### Degrading
+
+- [ ] Sign out of the Rails app (leave LlamaBot signed in) and reload the chat. No
+      notice, no console errors, chat works normally.
+- [ ] Stop the Rails container, leave the chat open a minute, start it again, then break
+      a page. The notice still appears — a restart rewinds the crash feed, and the tray
+      must re-arm rather than go deaf for the rest of the session.
+- [ ] Against a box on a **pre-0.7.4 gem** (no feed endpoint): no notice, no console
+      noise, and the polling backs off instead of hitting the endpoint every few seconds
+      (check the Network tab — it should slow to about once a minute).
+
+---
+
+## Passkeys (WebAuthn) in the base image — opt-in
+
+The `devise-webauthn` gem now ships in the LlamaPress-Simple image. **Nothing changes for
+an app that does not opt in**, so most of this checklist is proving the fleet is
+undisturbed. Opting in is two steps in the app: include `PasskeyAuthenticatableUser` in
+`User`, and set `PASSKEYS_ENABLED=true`.
+
+Note: WebAuthn needs a **real https hostname** — passkeys will not work through the
+builder preview pane until the mothership adds `allow="publickey-credentials-get *;
+publickey-credentials-create *"` to the preview iframe. Test on the box's own URL
+(`https://rails-<dns>.leo.llamapress.ai`), in a tab of its own.
+
+### Every existing app (the fleet-safety pass — do this one first)
+
+- [ ] On a box that has NOT opted in, sign in with email + password. It works exactly as
+      before. This is the important one: every box gets this gem on the next image push.
+- [ ] Sign in with a **wrong** password — still rejected, still the same error.
+- [ ] On a box with 2FA turned on, sign in with password + OTP. Still works.
+- [ ] `GET /.well-known/webauthn` returns JSON like
+      `{"origins":["https://rails-<dns>.leo.llamapress.ai", ...]}` — and it answers while
+      signed **out**.
+- [ ] The origins list contains **every** hostname the app answers on, not just one.
+- [ ] Visit `/users/passkeys/new` on a box that has not opted in — it 404s. The passkey
+      routes should not exist until a project asks for them.
+
+### After a project opts in
+
+- [ ] Signed in, register a passkey (Touch ID / Windows Hello / phone). The OS prompt
+      names **this app's** hostname, never `llamapress.ai` or `leo.llamapress.ai`.
+- [ ] Sign out, then sign in with the passkey alone. You land signed in.
+- [ ] **Password sign-in still works** for the same account. Passkeys are added
+      alongside passwords, never instead of them.
+- [ ] At enrollment the app shows one-time recovery codes. Save them.
+- [ ] Use one recovery code — it works. Use the *same* one again — it is refused.
+- [ ] Register a passkey on the box's `leo.llamapress.ai` hostname, then open the app on
+      the mirror/custom domain. The passkey is still offered (this is what
+      `/.well-known/webauthn` buys us). If it is not, check that hostname is in the
+      origins list.
+
+### Misconfiguration should be loud, not silent
+
+- [ ] Set `PASSKEY_RP_ID=llamapress.ai` and recreate the container with
+      `PASSKEYS_ENABLED=true`. The app **refuses to boot** with a message about a shared
+      platform domain. (A shared relying party would offer one customer's passkey inside
+      another customer's app — this is the failure the guard exists for.)
+- [ ] Same value with `PASSKEYS_ENABLED` unset: the app boots, logs a warning, and no
+      relying party is configured.
+- [ ] `PASSKEYS_ENABLED=true` on a box with no instance name: boots, and the log says no
+      relying party could be derived.
+
+## WebSocket authentication (security fix)
+
+Unauthenticated frames could run any agent, including engineer mode with its shell
+and file tools. Three things changed: gem tokens are cryptographically verified,
+the agent-mode gate fails closed, and `WS_AUTH_REQUIRED` defaults to on.
+
+**Anyone testing a box needs a signed-in browser now — that is the point.** If chat
+stops working after this, check `SECRET_KEY_BASE` is set in the llamabot container
+and matches the Rails one; that is the single dependency the fix adds.
+
+### The hole is closed
+
+Run against your own dev box only.
+
+- [ ] Open a WebSocket to `/ws` with no cookie or token, send
+      `{"message":"hi","agent_name":"rails_agent","thread_id":"t"}`. You get
+      `auth_error` and **no agent output**.
+- [ ] Same frame with `"api_token":"x--y"`. Also refused — a made-up token is not a
+      token. (This one defeated `WS_AUTH_REQUIRED=true` before.)
+- [ ] Send `{"type":"attach","thread_id":"<a thread with a live run>"}` with no
+      credentials. Refused, and none of that run's output is replayed.
+- [ ] Send `{"type":"approval_response","thread_id":"t","approved":true}` with no
+      credentials. Refused — it must not approve a pending tool call.
+- [ ] `{"type":"ping"}` still returns `pong` without authenticating.
+
+### Nothing that should work broke
+
+- [ ] **Browser chat.** Sign in, send a message, watch it stream back. Switch modes.
+- [ ] **Rails-embedded chat** — the path most likely to break. Sign into the Rails
+      app, open the chat, send a message, confirm the agent replies. The backend log
+      shows `auth_success` as `rails_user:<id>`.
+- [ ] **Rails app signed out.** The gem mints `user_id: nil`; the signature is still
+      valid, so chat must keep working. A box losing its in-app chat here is a
+      release blocker.
+- [ ] **Reconnect mid-run.** Start a long turn, kill the network briefly, let it
+      reconnect. Output resumes and the spinner clears — `attach` now waits for the
+      auth handshake instead of a 300ms timer, so this is the regression to watch.
+- [ ] **Cancel.** Start a turn, press stop. It stops.
+- [ ] Token expiry is 30 minutes and the gem re-mints per message, so leave a tab
+      open an hour and send a message — it still works.
+
+### Mode permissions
+
+- [ ] As a `user`-role account, a hand-edited frame naming `rails_agent` is denied.
+- [ ] In admin settings, set the **rails** role to `chat` only. The Rails-embedded
+      chat can no longer run engineer mode. Set it back.


### PR DESCRIPTION
[x] - Building screen can now show rotating promos served from mothership. [x] - Mothership controls when those promos show, per user. [x] - Turned off the yellow inactivity warning banner (kept behind a flag). [x] - Leo now spots a Rails crash mid-turn and fixes it before handing back. [x] - SSO sends you back to the domain you came from, not always llamapress.ai. [x] - "My Uploads" opens the full asset library straight away (no intermediate list), and the library can go full screen. [x] - Spreadsheets preview as a real cell grid, parsed on the box — the broken Microsoft Office Online iframe is gone. [x] - GitHub sign-in (/gh) now finishes on its own — it keeps checking while you authorize, and the moment you switch back to the tab, so the refresh button is optional. [x] - Leo can ask a few questions in one card now, instead of one per turn. [x] - Long beginner-mode chats compact now instead of hitting the token wall. [x] - New check_page tool so Leo loads every page it writes. [x] - Prompts stop advertising tools that are switched off on the box. [x] - Writing a migration now runs it, so the app stops going down. [x] - edit_file no longer claims success on an edit that never landed. [x] - A timed-out helper now reports what it already did. [x] - bash_command stops blocking ordinary Ruby like Rails.env. [x] - Rails crashes now show in the chat's error notice too. [x] - Building screen only shrinks for a promo that actually loads; with no promo it looks exactly as it did before. [x] - Error notice now says whether it's a Rails or JavaScript error. [x] - Chat WebSocket now rejects forged Rails tokens. [x] - Agent modes deny by default instead of allowing. [x] - WebSocket auth is required by default now.
[x] - Mothership telemetry now says which signed-in user sent each message, not just which box.