### PR TITLE
0.7.5:

### DIFF
--- a/app/agents/leonardo/llm_factory.py
+++ b/app/agents/leonardo/llm_factory.py
@@ -27,6 +27,11 @@ from langchain_google_genai import ChatGoogleGenerativeAI
 from langchain_openai import ChatOpenAI
 from langchain_qwq import ChatQwen
 
+from app.agents.leonardo.openrouter_models import (
+    api_base as openrouter_api_base,
+    get_openrouter_model,
+)
+
 
 logger = logging.getLogger(__name__)
 
@@ -40,6 +45,81 @@ DEFAULT_LLM_MODEL = "muse-spark-1.2-contributor"
 # always build this one, so it is what keeps chat working on a box the Muse
 # rollout has not reached (or that deliberately opts out).
 FALLBACK_TEXT_MODEL = "deepseek-v4-flash"
+
+# --- Stall detection -------------------------------------------------------
+#
+# How long an async stream may go without producing a content chunk before the
+# client gives up on it. This is `langchain_openai`'s `stream_chunk_timeout`,
+# which measures the gap between *parsed* chunks — SSE keepalives do not reset
+# it, so it is the only thing that catches "HTTP 200, then nothing".
+#
+# 25s is chosen, not inherited. The library's own default is 120s, and on
+# 2026-08-26 a Muse Spark endpoint accepted requests and streamed nothing:
+# 120s per attempt x 5 rung-1 attempts was ~10 minutes of a spinning shimmer
+# before anything else in the ladder got a turn. No healthy call on any fleet
+# model waits 25s for a first chunk (measured 0.5-2.0s on the same endpoint an
+# hour later), so this only ever fires on a genuinely dead stream.
+#
+# Deliberately NOT disabled and not unbounded — a disabled chunk timeout is how
+# you get a turn that hangs forever. The env var is the same one the library
+# reads, so an operator override lands once and means one thing.
+STREAM_CHUNK_TIMEOUT_ENV = "LANGCHAIN_OPENAI_STREAM_CHUNK_TIMEOUT_S"
+_DEFAULT_STREAM_CHUNK_TIMEOUT_S = 25.0
+
+
+def stream_chunk_timeout_s() -> float:
+    """Seconds of content silence tolerated on a stream before it is abandoned."""
+    raw = os.getenv(STREAM_CHUNK_TIMEOUT_ENV, "").strip()
+    if raw:
+        try:
+            value = float(raw)
+            if value > 0:
+                return value
+            logger.warning(
+                "%s=%r is not positive; a disabled chunk timeout hangs a turn "
+                "forever. Using %ss.", STREAM_CHUNK_TIMEOUT_ENV, raw,
+                _DEFAULT_STREAM_CHUNK_TIMEOUT_S,
+            )
+        except ValueError:
+            logger.warning(
+                "%s=%r is not a number; using %ss.",
+                STREAM_CHUNK_TIMEOUT_ENV, raw, _DEFAULT_STREAM_CHUNK_TIMEOUT_S,
+            )
+    return _DEFAULT_STREAM_CHUNK_TIMEOUT_S
+
+
+def _apply_stream_chunk_timeout(client):
+    """Stamp the chosen chunk timeout onto a freshly built client.
+
+    Applied here rather than in each constructor call because llm_factory has
+    eleven `ChatOpenAI(` call sites, each with its own kwargs dict; a per-site
+    fix reliably misses one and leaves a 120s hole in the fleet. Set after
+    construction so the branches stay untouched.
+
+    Silently skipped for clients that have no such field (Anthropic, Gemini —
+    they are not OpenAI-compatible and carry their own timeouts), and never
+    fatal: a client that cannot take the hint is still a working client.
+    """
+    try:
+        if "stream_chunk_timeout" in getattr(type(client), "model_fields", {}):
+            client.stream_chunk_timeout = stream_chunk_timeout_s()
+    except Exception as e:  # noqa: BLE001 - never break model construction
+        logger.debug("could not set stream_chunk_timeout on %r: %s", type(client), e)
+    return client
+
+
+# DeepSeek's own API (api.deepseek.com), as opposed to the same weights served by
+# GMI/Fireworks. Only these need DeepSeekReasoningMiddleware: DeepSeek direct is
+# the strict one about assistant messages carrying reasoning_content, while the
+# OpenAI-compatible resellers accept messages without it. Kept here rather than
+# in the middleware so adding a DeepSeek-direct model is one edit, not two —
+# `deepseek-v4-pro` spent several releases missing from the middleware's
+# hardcoded name check precisely because they were separate lists.
+DEEPSEEK_DIRECT_MODELS = frozenset({
+    "deepseek-v4-flash",
+    "deepseek-v4-pro",
+    "deepseek-v4-flash-vision-exp",
+})
 
 
 class FakeTestChatModel(BaseChatModel):
@@ -151,14 +231,19 @@ def provider_key(*env_vars: str) -> str:
     return _MISSING_KEY_PLACEHOLDER
 
 
-# Which env vars credential the two models the default can resolve to, in the
-# same precedence `get_llm` uses to build them. Only these two are listed: this
-# map answers "can this box actually construct its default model", not "what is
-# in the dropdown" — that question belongs to /api/available-models, which keeps
-# the full registry (test_model_registry_consistency pins the two in agreement).
+# Which env vars credential the models a POLICY DEFAULT can resolve to, in the
+# same precedence `get_llm` uses to build them. Deliberately not the full
+# registry — this map answers "can this box actually construct the model it is
+# about to fall back to", not "what is in the dropdown", which belongs to
+# /api/available-models (test_model_registry_consistency pins them in agreement).
+#
+# Two kinds of default resolve through here: the default TEXT model
+# (`default_text_model`) and the box's vision model (`vision_model`), which is
+# why the vision entry is listed alongside the other two.
 DEFAULT_MODEL_KEY_ENVS = {
     "muse-spark-1.2-contributor": ("META_API_KEY", "MODEL_API_KEY"),
     "deepseek-v4-flash": ("DEEPSEEK_API_KEY",),
+    "deepseek-v4-flash-vision-exp": ("DEEPSEEK_API_KEY",),
 }
 
 
@@ -417,6 +502,20 @@ def get_llm(model_name: str):
         )
         model_name = replacement
 
+    # Construction lives in _build_client so the stall guard is applied in ONE
+    # place. See _apply_stream_chunk_timeout: the alternative was editing eleven
+    # constructor call sites and missing one.
+    return _apply_stream_chunk_timeout(_build_client(model_name))
+
+
+def _build_client(model_name: str):
+    """Construct the provider client for an ALREADY policy-resolved model name.
+
+    Split out of :func:`get_llm` purely so every branch below flows through one
+    post-construction hook. Call ``get_llm``, never this — the operator policy
+    gate lives up there, and this function will happily build a model the box is
+    not allowed to run.
+    """
     if model_name == "deepseek-v4-flash":
         return ChatDeepSeekWithReasoning(
             model="deepseek-v4-flash",
@@ -426,6 +525,64 @@ def get_llm(model_name: str):
     if model_name == "deepseek-v4-pro":
         return ChatDeepSeekWithReasoning(
             model="deepseek-v4-pro",
+            timeout=180,
+            max_retries=0,
+        )
+    # Config-driven OpenRouter entries (see openrouter_models). ONE branch serves
+    # every OpenRouter endpoint — the provider pin, model id and client choice all
+    # come from the registry — so adding an endpoint is a config block, not a code
+    # change. Checked BEFORE the hardcoded branches so an overlay can deliberately
+    # shadow a compiled-in name; checked AFTER the policy gate above so a
+    # registered model is still subject to DISABLED_MODELS like any other.
+    openrouter_entry = get_openrouter_model(model_name)
+    if openrouter_entry is not None:
+        # provider_key(), never a bare os.getenv: the OpenAI SDK falls back to
+        # OPENAI_API_KEY when api_key is None, which would send our OpenAI key to
+        # openrouter.ai (see test_provider_key_never_leaks_openai).
+        kwargs = dict(
+            model=openrouter_entry["model"],
+            api_base=openrouter_api_base(),
+            api_key=provider_key("OPENROUTER_API_KEY"),
+            timeout=180,
+            max_retries=0,
+        )
+        extra_body = openrouter_entry.get("extra_body")
+        if extra_body:
+            # Where the provider/quantization pin actually travels. OpenRouter
+            # reads `provider` as a top-level request field, and extra_body is
+            # what the OpenAI-compatible client passes through untouched.
+            kwargs["extra_body"] = extra_body
+        if openrouter_entry.get("reasoning", True):
+            return ChatDeepSeekWithReasoning(**kwargs)
+        return ChatOpenAI(**kwargs)
+
+    if model_name == "deepseek-v4-flash-vision-exp":
+        # DeepSeek V4 Flash's multimodal sibling on DeepSeek's own API — the only
+        # vision model a box can run on the DEEPSEEK_API_KEY it already has.
+        # Before this entry, image understanding anywhere in the fleet required a
+        # META key for Muse, so a DeepSeek-only box refused image attachments
+        # outright (see model_policy.vision_model).
+        #
+        # Verified live against api.deepseek.com (2026-08-25), because the vision
+        # guide documents none of it: image + tool calling in one request works
+        # (returns a real tool_calls block describing the image), tool calling
+        # without an image works, a system prompt alongside an image works, and
+        # reasoning_content still streams as deltas — so the same
+        # ChatDeepSeekWithReasoning client carries it, only the model id differs.
+        #
+        # Two API-side constraints worth knowing (both 400s, both verified):
+        #   * images are accepted ONLY in user messages — an image block in an
+        #     assistant message is rejected outright. Nothing sends one today;
+        #     don't add an image-carrying tool result without re-checking.
+        #   * the text-only models reject images ("This model does not support
+        #     image"), which is what MODEL_CAPABILITIES + the multimodal stripper
+        #     exist to prevent.
+        #
+        # `-exp` is DeepSeek's own name for it: experimental, with no published
+        # deprecation policy. Treat a sudden 400 on this id as "it was withdrawn"
+        # rather than a bug on our side — vision_model() falls back on its own.
+        return ChatDeepSeekWithReasoning(
+            model="deepseek-v4-flash-vision-exp",
             timeout=180,
             max_retries=0,
         )
@@ -472,8 +629,13 @@ def get_llm(model_name: str):
         # rationale above.
         return ChatDeepSeekWithReasoning(
             model=os.getenv(
+                # Fireworks retired the unversioned `deepseek-v4-flash` alias
+                # (2026-08: 404 "Model not found, inaccessible, and/or not
+                # deployed"); only dated snapshots are listed now. Pin the
+                # snapshot explicitly and re-pin when Fireworks publishes a
+                # newer one — the env var is the escape hatch in between.
                 "FIREWORKS_DEEPSEEK_MODEL",
-                "accounts/fireworks/models/deepseek-v4-flash",
+                "accounts/fireworks/models/deepseek-v4-flash-0731",
             ),
             api_base=os.getenv(
                 "FIREWORKS_BASE_URL", "https://api.fireworks.ai/inference/v1"
@@ -665,6 +827,10 @@ def get_llm(model_name: str):
         client = _chatgpt_subscription_client(model_name)
         if client is not None:
             return client
+        # Deferred, like the policy import in get_llm, for the same circular-
+        # import reason (model_policy reads DEFAULT_LLM_MODEL from this module).
+        from app.agents.leonardo.model_policy import enabled_default_model
+
         fallback = enabled_default_model()
         logger.warning(
             "No usable ChatGPT credential for %r; falling back to %r. "
@@ -726,6 +892,47 @@ def get_llm(model_name: str):
             api_key=provider_key("ALIBABA_API_KEY"),
             enable_thinking=True,
             thinking_budget=8192,
+            max_retries=0,
+        )
+    if model_name == "qwen3.8-27b-hetzner":
+        # Qwen3.8-27B on Hetzner's Inference API — an EU-hosted,
+        # OpenAI-compatible endpoint, so a plain ChatOpenAI with an overridden
+        # base_url is the whole client (same shape as the self-hosted vLLM
+        # entries above). The base_url is load-bearing: without it ChatOpenAI
+        # talks to api.openai.com, which has never heard of this model id.
+        #
+        # Deliberately NOT ChatQwen: langchain_qwq exists for Alibaba
+        # DashScope's thinking/reasoning_content shape (see `qwen3.7-plus`).
+        # This is a generic gateway in front of open weights, not DashScope.
+        #
+        # Dense 27B, 262k context, text + image in. Hetzner's /v1/models is the
+        # definitive list of what they serve; HETZNER_QWEN_MODEL moves this
+        # entry to their other one (`Qwen/Qwen3.6-35B-A3B-FP8`, MoE, 35B total /
+        # 3B active, same context and modalities) with no code change.
+        #
+        # THE SHARP EDGE IS REQUESTS, NOT TOKENS: 10 requests per 60s per key
+        # (alongside a generous 4M in / 100k out tokens per 60s). A single
+        # agentic Leo turn is many sequential requests, so even one busy user on
+        # a key will hit 429s. Those are classified transient and retried by the
+        # resilience middleware, so they show up as slow turns rather than
+        # failed ones — but it is why this must not become a fleet default while
+        # the API is in its free experimental phase.
+        #
+        # `provider_key` (not os.getenv) is load-bearing — see its docstring: an
+        # api_key of None would address our OpenAI secret to inference.hetzner.com.
+        #
+        # No `chat_template_kwargs={"enable_thinking": False}` here, unlike the
+        # RunPod Qwen3-8B branch: we control neither Hetzner's serve flags nor
+        # their chat template, and an unknown kwarg risks a 400 for no benefit.
+        # If thinking leaks inline as <think>...</think> inside `content`, that
+        # is the first knob to try.
+        return ChatOpenAI(
+            model=os.getenv("HETZNER_QWEN_MODEL", "Qwen3.8-27B"),
+            base_url=os.getenv(
+                "HETZNER_BASE_URL", "https://inference.hetzner.com/api/v1"
+            ),
+            api_key=provider_key("HETZNER_API_KEY"),
+            timeout=180,
             max_retries=0,
         )
     if model_name == "muse-spark-1.2-contributor":

--- a/app/agents/leonardo/message_invariants.py
+++ b/app/agents/leonardo/message_invariants.py
@@ -279,13 +279,94 @@ def looks_like_bad_request(exc) -> bool:
     return status in (400, 422)
 
 
-def log_bad_request_shape(exc, messages, *, tools=None, model=None, label: str = "") -> Dict[str, Any]:
+# The three distinct conditions hiding behind BadRequestError on the fleet. Counting them
+# as one made P1-3 look bigger than it is and hid the fact that two of them already have
+# owners: the context ceiling is not a bad request, and malformed history is the repair
+# path's class. Substrings, because providers reword their prose but keep the shape.
+_BAD_REQUEST_SIGNATURES = (
+    ("context_length_exceeded", ("maximum context length", "context_length_exceeded",
+                                 "reduce the length of the messages")),
+    ("malformed_history", ("must contain at least one message",
+                           "insufficient tool messages",
+                           "tool_call_id", "invalid_request_error: messages")),
+    ("invalid_parameters", ("contains invalid parameters", "invalid parameters",
+                            "check the request body")),
+)
+
+
+def classify_bad_request(exc) -> str:
+    """Name which KIND of 400 this is, so three different bugs stop being one number.
+
+    Returns "unknown" rather than guessing: an unrecognised rejection is a thing we want
+    to see arrive, not something to file under the nearest existing label.
+    """
+    text = str(getattr(exc, "message", "") or exc or "").lower()
+    for name, needles in _BAD_REQUEST_SIGNATURES:
+        if any(needle in text for needle in needles):
+            return name
+    return "unknown"
+
+
+# Anything whose NAME says credential. The payload reaches the mothership, so a key in it
+# would be a disclosure rather than a clue.
+_SECRET_KEY_HINTS = ("key", "token", "secret", "password", "authorization", "credential")
+
+# ...except these, which merely CONTAIN one of those words. `max_tokens` is the parameter
+# most likely to be the culprit in an "invalid parameters" rejection, so redacting it would
+# have removed the single most useful field from the payload this exists to produce.
+_NEVER_SECRET = frozenset({
+    "max_tokens", "max_completion_tokens", "max_output_tokens", "max_new_tokens",
+    "max_prompt_tokens", "token_usage", "logit_bias", "top_logprobs",
+})
+
+# Message bodies are described separately by describe_message_shape(); copying them here
+# would duplicate user content into a second payload for no diagnostic gain.
+_BULK_KEYS = ("messages", "tools", "input", "prompt", "contents")
+
+_MAX_PARAM_CHARS = 512
+
+
+def redact_request_params(params: Dict[str, Any] | None) -> Dict[str, Any]:
+    """The outgoing request parameters, safe to log.
+
+    P1-3 is a provider answering "the request contains invalid parameters" and then
+    declining to say WHICH one — `param` is null on every one of the 15 occurrences. We
+    have never recorded what we sent, so there is nothing to compare a working box
+    against. Unknown keys are deliberately kept: the next offending parameter is, by
+    definition, one we are not thinking about today.
+    """
+    out: Dict[str, Any] = {}
+    for key, value in (params or {}).items():
+        lowered = str(key).lower()
+        if lowered in _BULK_KEYS:
+            continue
+        if lowered not in _NEVER_SECRET and any(hint in lowered for hint in _SECRET_HINT_SET):
+            out[key] = "[redacted]"
+            continue
+        if isinstance(value, dict):
+            out[key] = redact_request_params(value)
+            continue
+        text = str(value)
+        out[key] = value if len(text) <= _MAX_PARAM_CHARS else text[:_MAX_PARAM_CHARS]
+    return out
+
+
+_SECRET_HINT_SET = _SECRET_KEY_HINTS
+
+
+def log_bad_request_shape(exc, messages, *, tools=None, model=None, label: str = "",
+                          request_params: Dict[str, Any] | None = None) -> Dict[str, Any]:
     """Log (and return) the shape of a request a provider rejected.
 
     Returned so the caller can attach it to a ``report_error`` payload; the
     mothership has nothing else to go on when the provider says ``'param': None``.
     """
     shape = describe_message_shape(messages, tools=tools, model=model)
+    # WHICH 400 this is, and what we actually sent. Without these the mothership sees a
+    # message it cannot act on and three unrelated bugs averaged into one count.
+    shape["bad_request_kind"] = classify_bad_request(exc)
+    if request_params:
+        shape["request_params"] = redact_request_params(request_params)
     try:
         logger.error(
             "Provider rejected the request (%s) %s — request shape: %s",

--- a/app/agents/leonardo/model_capabilities.py
+++ b/app/agents/leonardo/model_capabilities.py
@@ -39,6 +39,10 @@ MODEL_CAPABILITIES = {
     # DeepSeek - primarily text focused
     'deepseek-v4-flash': {'images': False, 'video': False, 'pdf': False},
     'deepseek-v4-pro': {'images': False, 'video': False, 'pdf': False},
+    # ...except this one: DeepSeek's multimodal sibling, images only. No video,
+    # and PDFs are not ingested natively (DeepSeek's Files API is a separate
+    # upload path we don't use), so both stay off.
+    'deepseek-v4-flash-vision-exp': {'images': True, 'video': False, 'pdf': False},
     # Same model as deepseek-v4-flash, served by GMI Cloud rather than
     # DeepSeek's own API — same (text-only) capabilities.
     'deepseek-v4-flash-gmi': {'images': False, 'video': False, 'pdf': False},
@@ -55,6 +59,11 @@ MODEL_CAPABILITIES = {
 
     # Qwen3-8B on our own RunPod GPU (vLLM) - the dense text model, no vision.
     'qwen3-8b-runpod': {'images': False, 'video': False, 'pdf': False},
+
+    # Qwen3.8-27B (dense) on Hetzner's Inference API - text + image in, per
+    # Hetzner's published model table. No video, and PDFs are not ingested
+    # natively, so both stay off.
+    'qwen3.8-27b-hetzner': {'images': True, 'video': False, 'pdf': False},
 
     # Muse Glimmer 30B on the same self-hosted pod. The base model is multimodal,
     # but this community AWQ INT4 checkpoint's vision path is unverified — declared
@@ -84,7 +93,17 @@ def get_model_capabilities(model_name: str) -> dict:
     ``unknown variant image_url, expected text``. Keep every real model listed
     explicitly above so only genuine skew/typos ever hit this default.
     """
-    return MODEL_CAPABILITIES.get(model_name, {'images': True, 'video': True, 'pdf': True})
+    if model_name in MODEL_CAPABILITIES:
+        return MODEL_CAPABILITIES[model_name]
+    # Config-driven OpenRouter entries declare their own capabilities, so they
+    # never reach the permissive default below. Imported lazily: this module is a
+    # leaf that half the app imports, and openrouter_models reads a file.
+    from app.agents.leonardo.openrouter_models import get_openrouter_model
+
+    entry = get_openrouter_model(model_name)
+    if entry is not None:
+        return dict(entry["capabilities"])
+    return {'images': True, 'video': True, 'pdf': True}
 
 
 def get_file_category(mime_type: str) -> str:

--- a/app/agents/leonardo/model_policy.py
+++ b/app/agents/leonardo/model_policy.py
@@ -11,6 +11,9 @@ the user has no write path to:
     names). Authoritative: mothership owns this file.
   * The ``ENABLED_MODELS`` / ``DISABLED_MODELS`` environment variables
     (comma-separated), baked into the container by the box operator.
+  * The OpenRouter model registry (``.leonardo/openrouter_models.json``, see
+    :mod:`app.agents.leonardo.openrouter_models`). Also operator-owned and
+    host-mounted; registering an entry there enables it (step 2b below).
 
 **Resolution (most-specific wins):**
 
@@ -20,7 +23,7 @@ the user has no write path to:
      Disable sources UNION: any source can turn a model off.
   1a. **Model-switching lock** — when ``MODEL_SWITCHING_ALLOWED`` is off (it is
      ON by default since 0.7.0; the var is a per-box opt-OUT), only the resolved
-     default text model is enabled, plus the vision model when
+     default text model is enabled, plus the box's resolved vision model when
      ``VISION_MODEL_ALLOWED`` is on (so the image auto-switch still works). This
      coarse operator gate sits above the fail-open/allow-list logic below but
      still yields to an explicit disable in step 1.
@@ -29,6 +32,16 @@ the user has no write path to:
      default degrades to on a box with no META key) are globally enabled, so
      every instance always keeps a model it can actually run. Only an explicit
      disable (step 1) turns them off.
+  2a. **Resolved vision model** — whichever vision model this box holds a key for
+     (see :func:`vision_model`) is enabled while ``VISION_MODEL_ALLOWED`` is on,
+     so image uploads work without the operator hand-editing an allow-list on
+     every box. Yields to an explicit disable in step 1.
+  2b. **Registered OpenRouter models** — an entry in the OpenRouter registry is
+     enabled by that registration. The file is operator-owned and host-mounted,
+     exactly like the two sources above, so requiring the operator to ALSO name
+     it in ``ENABLED_MODELS`` would be configuring one intent twice — the
+     friction that registry exists to remove. Yields to an explicit disable in
+     step 1, and to ``"enabled": false`` in the entry itself.
   3. **Allow-list** — if ``enabled_models`` / ``ENABLED_MODELS`` is configured,
      only the named models are enabled (for everything not covered above). Allow
      sources INTERSECT: neither can broaden what the other restricts.
@@ -57,6 +70,11 @@ from app.agents.leonardo.llm_factory import (
     FALLBACK_TEXT_MODEL,
     has_provider_key,
 )
+from app.agents.leonardo.openrouter_models import (
+    API_KEY_ENV as OPENROUTER_API_KEY_ENV,
+    is_openrouter_model,
+    openrouter_models,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -81,16 +99,52 @@ _INSTANCE_CONFIG_PATH = ".leonardo/instance.json"
 _MODEL_SWITCHING_ALLOWED_DEFAULT = True
 _VISION_ALLOWED_DEFAULT = False
 
-# The single vision model the frontend image auto-switch targets. Kept reachable
-# (when vision is allowed) even while manual switching is locked, so image sends
-# still work without opening up the whole dropdown.
+# The vision model the frontend image auto-switch targets, in preference order.
+# Whichever one this box holds a key for is kept reachable (when vision is
+# allowed) even while manual switching is locked, so image sends still work
+# without opening up the whole dropdown.
 #
-# Same model as the fleet default: Muse is multimodal (see model_capabilities),
-# so on a box with a META key there is nothing to switch TO — the auto-switch
-# only fires for a user who has manually moved to a text-only model. A box
-# WITHOUT a META key has no vision at all, and the frontend says so rather than
-# sending an image to a model that cannot read it.
-VISION_MODEL = "muse-spark-1.2-contributor"
+# First choice is the fleet default itself: Muse is multimodal (see
+# model_capabilities), so on a box with a META key there is nothing to switch TO
+# — the auto-switch only fires for a user who has manually moved to a text-only
+# model. Second choice (0.7.5) is DeepSeek's vision sibling, which runs on the
+# DEEPSEEK_API_KEY every box already has. Before it existed, a box without a META
+# key had no vision at all and the frontend said so; now that is only true of a
+# box with no usable key of either kind.
+_VISION_MODELS = (
+    "muse-spark-1.2-contributor",
+    "deepseek-v4-flash-vision-exp",
+)
+
+# The subset of the above that is ONLY a vision target. Muse is absent on
+# purpose: it is a general-purpose model that happens to be multimodal, and is
+# the fleet's default text model. DeepSeek's vision sibling is not — it is a
+# variant you switch TO for an image and back from, so it must never be picked
+# as a box's default text model (see enabled_default_model).
+_VISION_ONLY_MODELS = frozenset({"deepseek-v4-flash-vision-exp"})
+
+# Preserved as the *preferred* vision model. Prefer `vision_model()` — this
+# constant is what a box with every key resolves to, not what any given box runs.
+VISION_MODEL = _VISION_MODELS[0]
+
+
+def vision_model() -> str:
+    """The vision model THIS box can actually build, or "" if it has none.
+
+    Same shape as :func:`default_text_model` and for the same reason: naming a
+    model whose key the box does not hold is not a degraded box, it is a box
+    where every image send 401s. Returning "" is meaningful — it is what makes
+    the frontend show "no image-capable model is configured" instead of sending
+    an image somewhere it cannot be read.
+
+    Policy (disable lists, allow-lists, the switching lock) is NOT consulted
+    here; this answers only "is it buildable", exactly like default_text_model.
+    """
+    for name in _VISION_MODELS:
+        if has_provider_key(name):
+            return name
+    return ""
+
 
 # Always enabled regardless of any allow-list, so every instance keeps a model it
 # can actually run: the fleet default (Muse, also the image auto-switch target)
@@ -118,6 +172,7 @@ _DEFAULT_ENABLED_MODELS = _FAIL_OPEN_MODELS | {
 _KNOWN_MODELS = [
     "deepseek-v4-flash",
     "deepseek-v4-pro",
+    "deepseek-v4-flash-vision-exp",
     "deepseek-v4-flash-gmi",
     "deepseek-v4-flash-fireworks",
     "claude-4.5-sonnet",
@@ -136,12 +191,26 @@ _KNOWN_MODELS = [
     "gemini-3-pro",
     "gemini-3.1-flash-lite",
     "qwen3.7-plus",
+    "qwen3.8-27b-hetzner",
     "qwen3-8b-runpod",
     "muse-glimmer-30b-runpod",
     "nemotron-lightning-30b-runpod",
     "nemotron-lightning-30b-fireworks",
     "muse-spark-1.2-contributor",
 ]
+
+
+def known_models() -> list:
+    """Every model name the policy knows how to fall back to.
+
+    The compiled list plus whatever the OpenRouter registry currently holds, so a
+    config-registered model can be chosen as a fallback instead of being invisible
+    to the walk in :func:`enabled_default_model`. Registry names go LAST: a
+    third-party-routed endpoint should never outrank a first-party model when
+    picking what a box runs by default.
+    """
+    extra = [name for name in openrouter_models() if name not in _KNOWN_MODELS]
+    return [*_KNOWN_MODELS, *extra]
 
 
 def _csv_names(raw: str) -> list:
@@ -262,11 +331,31 @@ def is_model_enabled(model_name: str) -> bool:
         # chat down entirely instead of merely restricting it.
         if model_name == default_text_model():
             return True
-        if model_name == VISION_MODEL and vision_allowed():
+        if model_name == vision_model() and vision_allowed():
             return True
         return False
     # 3. The fail-open defaults are globally enabled (survive any allow-list).
     if model_name in _FAIL_OPEN_MODELS:
+        return True
+    # 3a. So is the box's resolved vision model, whenever vision is switched on.
+    #     Without this, a DeepSeek-only box could never reach the vision model:
+    #     the compiled default allow-list (step 4) names only the two blessed
+    #     text models, so the operator would have to hand-edit ENABLED_MODELS on
+    #     every box just to make image uploads work. Muse-keyed boxes are
+    #     unaffected — their vision model is already a fail-open default above.
+    #     Still yields to an explicit disable (step 1) and to VISION_MODEL_ALLOWED.
+    if model_name and model_name == vision_model() and vision_allowed():
+        return True
+    # 2b. A registered OpenRouter entry is enabled by its registration — the
+    #     registry file is operator-owned, so the act of adding a block IS the
+    #     operator saying "offer this". See the module docstring.
+    #
+    #     ...but only on a box that holds an OPENROUTER_API_KEY. The registry
+    #     ships a compiled-in example entry, and without this clause EVERY fleet
+    #     box would grow a dropdown option it cannot run, breaking the invariant
+    #     that an unconfigured box offers exactly the two blessed models. A key
+    #     is what turns the compiled-in default from an example into an offer.
+    if is_openrouter_model(model_name) and os.getenv(OPENROUTER_API_KEY_ENV, "").strip():
         return True
     # 4. The allow-list — the box's own, or the compiled two-model default.
     return model_name in _allowlist()
@@ -284,13 +373,24 @@ def enabled_default_model() -> str:
     preferred = default_text_model()
     if is_model_enabled(preferred):
         return preferred
-    for name in _KNOWN_MODELS:
+    for name in known_models():
         # Never resolve the box default onto a model paid for by an individual
         # user's ChatGPT plan: a user who has connected nothing could not chat at
         # all. _KNOWN_MODELS lists them last, which used to be enough — it stopped
         # being enough once the compiled default set turned the API-key models
         # off, leaving a subscription model as the first survivor of this walk.
         if name in _CHATGPT_SUBSCRIPTION_MODELS:
+            continue
+        # Nor onto a model that exists only as a vision switch target. Step 2a
+        # can enable one on a box whose allow-list names nothing else, and this
+        # walk would then hand it every text turn as well.
+        if name in _VISION_ONLY_MODELS:
+            continue
+        # Nor onto a config-registered OpenRouter endpoint. Step 2b enables those
+        # wherever a key exists, so without this the lockout fallback would quietly
+        # move a box onto a third-party-routed endpoint someone added to try — a
+        # thing a user PICKS, never what a box falls back to running.
+        if is_openrouter_model(name):
             continue
         if is_model_enabled(name):
             return name
@@ -301,6 +401,76 @@ def enabled_default_model() -> str:
         FALLBACK_TEXT_MODEL,
     )
     return FALLBACK_TEXT_MODEL
+
+
+def fallback_model(
+    primary: str,
+    *,
+    needs_vision: bool = False,
+    exclude=(),
+) -> Optional[str]:
+    """A different model to finish this step on when ``primary`` stops answering.
+
+    Rung 2 of the resilience ladder (docs/dev/error_telemetry.md §3), which until
+    0.7.5 was never built: when the Muse Spark endpoint accepted requests and
+    streamed nothing on 2026-08-26, rung 1 retried that same dead endpoint five
+    times and there was nowhere else to go.
+
+    Resolved from policy, never from a literal model id — the rule
+    ``test_no_agent_hardcodes_a_fallback_model`` exists to enforce, after every
+    ``rails_*`` agent spent 0.7.0 naming a DeepSeek id inline as its fallback and
+    silently ignoring the fleet default. (That sweep is line-based over source
+    text, so even writing the offending idiom in a comment here trips it — as it
+    should: this is the one function most tempted to reintroduce it.)
+
+    Candidates must be BOTH enabled by policy and buildable on this box's keys.
+    A fallback the box cannot build is a second failure, and one policy disables
+    is one ``get_llm`` would immediately substitute straight back — which on a
+    single-model box would be the model that just stalled.
+
+    ``needs_vision`` keeps the image routing rule intact across the fallback: a
+    turn carrying a screenshot must not be finished by a model that cannot see
+    it, because answering the question without the image is worse than failing.
+
+    Returns ``None`` when there is genuinely nowhere to go (a box pinned to one
+    model, or an image turn with a single vision-capable model). The caller must
+    treat that as "no rung 2" and let the original error surface.
+    """
+    tried = {primary, *exclude}
+
+    if needs_vision:
+        if not vision_allowed():
+            return None
+        for name in _VISION_MODELS:
+            if name in tried:
+                continue
+            if has_provider_key(name) and is_model_enabled(name):
+                return name
+        return None
+
+    # The box's own default first: it is what the operator chose to run, and on
+    # the Muse box in the incident it is also the model that stalled — hence the
+    # tried check rather than returning it outright.
+    preferred = enabled_default_model()
+    if preferred not in tried and has_provider_key(preferred):
+        return preferred
+
+    for name in known_models():
+        if name in tried:
+            continue
+        # The same three exclusions enabled_default_model() walks past, for the
+        # same reasons: never spend an individual user's ChatGPT plan, never hand
+        # a text turn to a vision-only switch target, and never quietly move a
+        # box onto a third-party-routed endpoint someone registered to try out.
+        if name in _CHATGPT_SUBSCRIPTION_MODELS:
+            continue
+        if name in _VISION_ONLY_MODELS:
+            continue
+        if is_openrouter_model(name):
+            continue
+        if is_model_enabled(name) and has_provider_key(name):
+            return name
+    return None
 
 
 def effective_model(model_name: str) -> str:

--- a/app/agents/leonardo/openrouter_models.py
+++ b/app/agents/leonardo/openrouter_models.py
@@ -1,0 +1,300 @@
+"""Config-driven OpenRouter model registry.
+
+Every other model in the fleet costs six code edits to add — the dropdown,
+``get_llm``, ``MODEL_CAPABILITIES``, ``_KNOWN_MODELS``, the api-key map and the
+label map (``test_model_registry_consistency`` exists to make missing one a red
+build). That is the right shape for a model with its own client, its own quirks
+and its own reasons to exist.
+
+It is the wrong shape for OpenRouter. OpenRouter is one OpenAI-compatible
+endpoint in front of hundreds of models and, for each model, dozens of *provider
+endpoints* that differ only in price, quantization and throughput —
+``deepseek/deepseek-v4-flash-0731`` alone is served by 28 of them. Trying one is
+a pricing experiment, not a code change, so they live in config instead:
+
+    {
+      "models": {
+        "deepseek-flash-0731-relace": {
+          "label": "DeepSeek V4 Flash 0731 (Relace fp4)",
+          "short_label": "DS 0731 Relace",
+          "model": "deepseek/deepseek-v4-flash-0731",
+          "provider": {"order": ["relace/fp4"], "allow_fallbacks": false},
+          "capabilities": {"images": false, "video": false, "pdf": false}
+        }
+      }
+    }
+
+Adding an endpoint is that block. The registry feeds ``get_llm``, the capability
+table, the policy's known-models list, the api-key map and the dropdown, so a
+registered model is fully wired the moment the file is read.
+
+**Layering** mirrors :mod:`app.lib.langgraph_registry`: a platform base compiled
+in below, then a host-mounted client overlay that survives container recreates.
+Overlay entries win on a name collision, so a box can re-point or re-price a
+built-in entry without a rebuild.
+
+**Ownership and trust.** The overlay is OPERATOR-owned, exactly like
+``instance.json`` and ``ENABLED_MODELS`` — it is mounted from the host, and no
+agent tool writes to it (the AI-builder's write target is ``langgraph.local.json``
+specifically). That is what lets a registered model be *enabled* by default:
+requiring the operator to also name it in ``ENABLED_MODELS`` would mean
+configuring the same intent twice, which is the friction this file removes. An
+explicit ``DISABLED_MODELS`` entry still wins, and ``"enabled": false`` turns one
+off in place.
+
+**Fail-open everywhere**: a missing, unreadable or malformed overlay is logged
+and skipped. A broken config file must never take the dropdown down.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# The OpenAI-compatible endpoint. Overridable for a proxy/mock in tests.
+DEFAULT_API_BASE = "https://openrouter.ai/api/v1"
+API_BASE_ENV = "OPENROUTER_BASE_URL"
+
+# One key for every entry — that is the point of routing through OpenRouter.
+API_KEY_ENV = "OPENROUTER_API_KEY"
+
+# Host-mounted client overlay. Sits beside instance.json in the .leonardo mount so
+# it survives a container recreate and stays off the platform sync allowlist.
+OVERLAY_PATH_ENV = "OPENROUTER_MODELS_CONFIG"
+DEFAULT_OVERLAY_PATH = ".leonardo/openrouter_models.json"
+
+# Capability defaults for an entry that declares none. Text-only on purpose —
+# the opposite of get_model_capabilities' permissive unknown-model default,
+# because here we are reading a config file the operator just wrote: guessing
+# "probably multimodal" would offer an image upload that 400s at the provider.
+_DEFAULT_CAPABILITIES = {"images": False, "video": False, "pdf": False}
+
+# Compiled-in base entries. Deliberately small: endpoints we have actually
+# smoke-tested (tool calling + reasoning + streaming through the pin), not a
+# catalogue of the 28 that exist. Everything else belongs in the overlay.
+#
+# Both cost nothing on a box without an OPENROUTER_API_KEY: policy step 2b gates
+# registration on the key, so a fleet box never grows a dropdown option it
+# cannot run.
+_BASE_MODELS = {
+    "deepseek-flash-0731-relace": {
+        "label": "DeepSeek V4 Flash 0731 (Relace fp4)",
+        "short_label": "DS 0731 Relace",
+        "model": "deepseek/deepseek-v4-flash-0731",
+        # Pin ONE provider endpoint with fallbacks off. Without this, OpenRouter
+        # load-balances across all 28 endpoints for this model, and the whole
+        # reason to pick relace/fp4 ($0.04/$0.08 per M, vs $0.22/$0.66 at
+        # DeepSeek direct) evaporates on the first silent reroute. It also keeps
+        # prompt caching meaningful: cache hit rate is per-replica, so a request
+        # that lands on a different provider each turn caches nothing.
+        #
+        # allow_fallbacks:false means a Relace outage is a FAILED TURN, not a
+        # silent switch to a pricier endpoint. That is the intended trade —
+        # flip it to true in the overlay if a box would rather pay than fail.
+        "provider": {"order": ["relace/fp4"], "allow_fallbacks": False},
+        "capabilities": {"images": False, "video": False, "pdf": False},
+    },
+    "deepseek-flash-0731-digitalocean": {
+        "label": "DeepSeek V4 Flash 0731 (DigitalOcean)",
+        "short_label": "DS 0731 DO",
+        "model": "deepseek/deepseek-v4-flash-0731",
+        # Same weights as the Relace entry above, different host. Costs more
+        # ($0.08/$0.252 per M vs $0.04/$0.08) and buys two things:
+        #
+        #   * Uptime. 99.06% vs 97.94% over the last day when this was added.
+        #     With allow_fallbacks off, a provider's downtime is our failed turn.
+        #   * A named US host. Routing already adds OpenRouter as a processor;
+        #     DigitalOcean is at least a jurisdiction we can point at, which is
+        #     the same reasoning that moved deepseek-v4-flash to Fireworks.
+        #
+        # !! TOOL CALLING IS UNRELIABLE HERE — do not point a Leo box at this
+        # without re-measuring. A single probe passes (it returns a valid
+        # tool_call), which is exactly why this needs the warning: the problem
+        # only shows up at volume. Measured against the real 22.8k-token
+        # RAILS_AGENT_PROMPT with the real tool set, 2026-08-26:
+        #
+        #   * invented tool names that were never bound — `Read`,
+        #     `exec_command`, `list_files`, `exec` — in 4 of 9 sequential turns,
+        #   * one turn emitted its raw tool-call template as PLAIN TEXT
+        #     (`<|DSML|...:invoke name="grep">`) instead of a structured call,
+        #     which points at a broken tool-call parser on the serving side —
+        #     the same class of defect as a vLLM missing --tool-call-parser,
+        #   * ~9s/turn, vs 1.6s on the Relace entry above.
+        #
+        # By contrast the fp4 Relace entry scored 12/12 correct tool choice with
+        # zero invented names, so this is NOT a quantization story — quantization
+        # is unreported here and fp4 there. It is how this host serves the model.
+        #
+        # Kept registered because an operator asked for it and it is a valid
+        # choice for non-tool-calling use; flip "enabled": false in the overlay,
+        # or DISABLED_MODELS, to take it off the dropdown.
+        #
+        # Quantization is reported "unknown", which is NOT a claim of higher
+        # precision — 10 of this model's 29 endpoints report "unknown",
+        # DeepSeek's own first-party endpoint and Fireworks among them. It may
+        # well be fp4 like Relace. The field is unreported metadata, so it is not
+        # a reason to prefer this endpoint; judge both on behavior.
+        "provider": {"order": ["digitalocean"], "allow_fallbacks": False},
+        "capabilities": {"images": False, "video": False, "pdf": False},
+    },
+    "glm-5.3-flash-zai": {
+        "label": "GLM 5.3 Flash (Z.AI fp8)",
+        "short_label": "GLM 5.3F",
+        "model": "z-ai/glm-5.3-flash",
+        # First non-DeepSeek endpoint to earn a compiled-in slot, and the first
+        # to match Relace on the measurement that actually matters. Probed
+        # 2026-08-27 against the real 22.8k-token RAILS_AGENT_PROMPT with the
+        # real tool set, 12 turns:
+        #
+        #   * 12/12 correct tool choice, 0 invented tool names, 0 raw-template
+        #     leaks, 12/12 well-formed args, 12/12 second hops. (One second hop
+        #     returned empty on a first run and not on a re-run — a flake, not a
+        #     pattern, but it is the only blemish in 24 observed.)
+        #   * reasoning_content populated on all 12; streams as deltas.
+        #   * ~7s/turn. That is the trade — Relace is 1.6s. It is a reasoning
+        #     model and the time is thinking, not a sick endpoint, but a latency-
+        #     sensitive box should still prefer Relace.
+        #
+        # Prompt caching is the reason to want this one: 22,208 of 22,250 input
+        # tokens came back as cache reads, at $0.015/M cached vs $0.075/M fresh.
+        # Per-replica as always, which is what the provider pin protects.
+        #
+        # Pinned to Z.AI's own fp8 endpoint at the operator's explicit choice.
+        # Note what that means: this is a first-party CHINESE host, and the move
+        # of deepseek-v4-flash to Fireworks was made on jurisdiction grounds.
+        # US-hosted alternatives for the same weights exist at 2x the token price
+        # (baseten/fp8 and cloudflare, both $0.15/$0.50, 100%/99.9% uptime) —
+        # swap the `order` below in the overlay to move without a rebuild.
+        "provider": {"order": ["z-ai/fp8"], "allow_fallbacks": False},
+        # images: MEASURED, not read off the model card — a 256x256 PNG is
+        # described correctly through the pin, via data-URL or bare base64.
+        # Beware the probe trap: an 8x8 PNG is rejected with `400 code 1210
+        # 图片输入格式/解析错误`, which reads exactly like "no vision path".
+        # video: the model card claims it; untested here, so it stays off.
+        "capabilities": {"images": True, "video": False, "pdf": False},
+    },
+}
+
+
+def _overlay_path() -> Path:
+    """Where the client overlay lives. Returned whether or not it exists."""
+    explicit = os.getenv(OVERLAY_PATH_ENV)
+    if explicit:
+        return Path(explicit).expanduser()
+    return Path(DEFAULT_OVERLAY_PATH)
+
+
+def _read_overlay() -> dict:
+    """Read the overlay's ``models`` map. Fail-open to ``{}`` on any problem."""
+    path = _overlay_path()
+    try:
+        with path.open("r", encoding="utf-8") as f:
+            data = json.load(f)
+    except FileNotFoundError:
+        return {}
+    except (json.JSONDecodeError, OSError) as e:
+        logger.warning("Could not read OpenRouter model overlay %s: %s", path, e)
+        return {}
+
+    models = data.get("models") if isinstance(data, dict) else None
+    if not isinstance(models, dict):
+        if models is not None:
+            logger.warning("%s: 'models' is not an object; ignoring overlay", path)
+        return {}
+    return models
+
+
+def _normalize(name: str, raw: dict) -> Optional[dict]:
+    """Validate one entry and fill in its defaults, or None if unusable.
+
+    The only hard requirement is ``model`` — the OpenRouter model id. An entry
+    without one cannot build a client, and silently registering it would put a
+    dead option in the dropdown, so it is dropped loudly instead.
+    """
+    if not isinstance(raw, dict):
+        logger.warning("OpenRouter entry %r is not an object; skipping", name)
+        return None
+
+    model_id = raw.get("model")
+    if not isinstance(model_id, str) or not model_id.strip():
+        logger.warning(
+            "OpenRouter entry %r has no 'model' (the OpenRouter model id); skipping", name
+        )
+        return None
+
+    caps = raw.get("capabilities")
+    capabilities = dict(_DEFAULT_CAPABILITIES)
+    if isinstance(caps, dict):
+        # Only the three keys the rest of the app knows how to act on, coerced to
+        # bool so a JSON string can't make `if caps['images']` accidentally true.
+        for key in _DEFAULT_CAPABILITIES:
+            if key in caps:
+                capabilities[key] = bool(caps[key])
+
+    entry = {
+        "model": model_id.strip(),
+        "label": str(raw.get("label") or name),
+        "short_label": str(raw.get("short_label") or raw.get("label") or name),
+        "capabilities": capabilities,
+        # Whether this entry is offered at all. Lets an operator park a config
+        # block (keeping the pricing notes) without it reaching the dropdown.
+        "enabled": raw.get("enabled", True) is not False,
+        # OpenRouter's thinking normalization differs from DeepSeek's own API, so
+        # which client to build stays per-entry rather than sniffed from the id.
+        # Default True: every model worth pinning an endpoint for today is a
+        # reasoning model, and the reasoning-aware client is a superset.
+        "reasoning": raw.get("reasoning", True) is not False,
+    }
+
+    # Provider routing (pin an endpoint / quantization) and any other top-level
+    # OpenRouter request field. Merged into one extra_body, entry-provided
+    # extra_body first so `provider` stays authoritative for the common case.
+    extra_body = {}
+    raw_extra = raw.get("extra_body")
+    if isinstance(raw_extra, dict):
+        extra_body.update(raw_extra)
+    provider = raw.get("provider")
+    if isinstance(provider, dict):
+        extra_body["provider"] = provider
+    if extra_body:
+        entry["extra_body"] = extra_body
+
+    return entry
+
+
+def openrouter_models() -> dict:
+    """The merged, validated registry: ``{frontend_name: entry}``.
+
+    Overlay entries win on a name collision, so a box can re-point or re-price a
+    compiled-in entry without a rebuild. Read fresh each call — the overlay is a
+    mounted file an operator edits live, and caching it would mean a container
+    restart just to try a different provider endpoint.
+    """
+    merged: dict = {}
+    for source in (_BASE_MODELS, _read_overlay()):
+        for name, raw in source.items():
+            if not isinstance(name, str) or not name.strip():
+                continue
+            entry = _normalize(name.strip(), raw)
+            if entry is not None:
+                merged[name.strip()] = entry
+    return {name: e for name, e in merged.items() if e["enabled"]}
+
+
+def get_openrouter_model(name: str) -> Optional[dict]:
+    """The registry entry for ``name``, or None if it isn't an OpenRouter model."""
+    return openrouter_models().get(name)
+
+
+def is_openrouter_model(name: str) -> bool:
+    """True if ``name`` is served through OpenRouter (so get_llm must route it)."""
+    return name in openrouter_models()
+
+
+def api_base() -> str:
+    """The OpenAI-compatible base URL, overridable for a proxy or a test double."""
+    return os.getenv(API_BASE_ENV) or DEFAULT_API_BASE

--- a/app/agents/leonardo/rails_agent/middleware.py
+++ b/app/agents/leonardo/rails_agent/middleware.py
@@ -15,16 +15,23 @@ import logging
 import time
 
 from app.agents.leonardo.rails_agent.state import RailsAgentState
-from app.agents.leonardo.llm_factory import get_llm, system_message_for_model
+from app.agents.leonardo.llm_factory import (
+    DEEPSEEK_DIRECT_MODELS,
+    get_llm,
+    system_message_for_model,
+)
 # The box's resolved default (Muse where the box has a META key, DeepSeek
 # where it does not) — never a hardcoded id, or a turn that arrives without
 # an explicit llm_model silently ignores the fleet default.
-from app.agents.leonardo.model_policy import enabled_default_model
+from app.agents.leonardo.model_policy import enabled_default_model, fallback_model
 from app.agents.leonardo.resilience import (
     is_transient_error,
+    retry_notice_text,
     _MODEL_RETRY_MAX_ATTEMPTS,
     _MODEL_RETRY_BASE_DELAY,
     _MODEL_RETRY_MAX_DELAY,
+    _MODEL_RETRY_MAX_TOTAL_SECONDS,
+    _RETRY_NOTICE_AFTER_SECONDS,
     _model_retry_delay,
 )
 from app.agents.leonardo.model_capabilities import (
@@ -332,12 +339,18 @@ class DeepSeekReasoningMiddleware(AgentMiddleware):
     ensures that AIMessages without reasoning_content get an empty string value,
     which satisfies the API requirement.
 
+    Scoped to DEEPSEEK_DIRECT_MODELS (api.deepseek.com), not every model with
+    "deepseek" in the name: the same weights served by GMI and Fireworks accept
+    assistant messages without reasoning_content, so this must not fire there.
+    The membership test replaced a hardcoded ``== "deepseek-v4-flash"``, which
+    silently skipped every other DeepSeek-direct model on the dropdown.
+
     See: https://api-docs.deepseek.com/guides/thinking_mode#tool-calls
     """
 
     def _inject_reasoning_content(self, messages, model_name: str):
         """Inject reasoning_content into AIMessages for DeepSeek reasoner."""
-        if model_name != "deepseek-v4-flash":
+        if model_name not in DEEPSEEK_DIRECT_MODELS:
             return messages
 
         modified_messages = []
@@ -365,7 +378,7 @@ class DeepSeekReasoningMiddleware(AgentMiddleware):
     def wrap_model_call(self, request, handler):
         """Sync version: Inject reasoning_content for DeepSeek."""
         model_name = request.state.get('llm_model', '')
-        if model_name == "deepseek-v4-flash":
+        if model_name in DEEPSEEK_DIRECT_MODELS:
             messages = self._inject_reasoning_content(list(request.messages), model_name)
             return handler(request.override(messages=messages))
         return handler(request)
@@ -373,7 +386,7 @@ class DeepSeekReasoningMiddleware(AgentMiddleware):
     async def awrap_model_call(self, request, handler):
         """Async version: Inject reasoning_content for DeepSeek."""
         model_name = request.state.get('llm_model', '')
-        if model_name == "deepseek-v4-flash":
+        if model_name in DEEPSEEK_DIRECT_MODELS:
             messages = self._inject_reasoning_content(list(request.messages), model_name)
             return await handler(request.override(messages=messages))
         return await handler(request)
@@ -399,6 +412,123 @@ class DeepSeekReasoningMiddleware(AgentMiddleware):
 # tests reaching mw._MODEL_RETRY_MAX_ATTEMPTS) resolve unchanged.
 
 
+# How many times one step may move to a different model. One: escalation stays
+# inside a single turn (docs/dev/error_telemetry.md §3, "the over-engineering
+# trap"), and every extra rung is another full retry budget the user waits
+# through. If the second model is down too, the box has a bigger problem than
+# this ladder can paper over.
+_MODEL_FALLBACK_MAX_RUNGS = 1
+
+_IMAGE_BLOCK_TYPES = frozenset(
+    {"image", "image_url", "input_image", "media", "video", "video_url"}
+)
+
+
+def _notify_retry(attempt: int, *, sync: bool):
+    """Push "Model is not responding. Retrying (N of M)…" into the shimmer.
+
+    Only called once the retry has cost the user real time — the threshold check
+    lives at the call site so the fast-503 case does not even build a frame.
+    Rides the same ``AIMessageChunk``-with-thinking shape ``/compact`` already
+    uses, so it lands in the shimmer and not in the transcript as a message from
+    Leo.
+
+    Returns a coroutine to await on the async path, None on the sync path.
+    """
+    from app.lib import turn_notices
+
+    frame = turn_notices.thinking_frame(retry_notice_text(attempt))
+    if sync:
+        try:
+            turn_notices.notify(frame)
+        except Exception as e:  # noqa: BLE001 - a notice never fails a turn
+            logger.debug("could not announce a retry: %s", e)
+        return None
+    return turn_notices.anotify(frame)
+
+
+def _request_carries_an_image(request) -> bool:
+    """Whether this step is asking a model to look at something.
+
+    Decides which fallback pool rung 2 may draw from, and the two ways of being
+    wrong are NOT symmetric. Saying "image" about a text turn only narrows the
+    fallback pool. Saying "text" about an image turn lets rung 2 pick a model
+    that cannot see, which then either 400s on the image blocks or — worse —
+    answers the question about the screenshot without the screenshot. So this
+    reads every shape it can and treats any doubt as an image.
+
+    Scope is the whole message list, not just the newest message, on purpose:
+    the history travels with every step, so an image three turns back still has
+    to be legible to whatever model finishes this one.
+    """
+    def _blocks(message):
+        # Raw content AND LangChain's normalized view: the normalizer rewrites
+        # `image_url` to `image`, and a provider-specific shape may only be
+        # legible in one of the two. Checking both costs nothing and the cost of
+        # a miss is a blind model answering a question about a screenshot.
+        yield getattr(message, "content", None)
+        try:
+            yield message.content_blocks
+        except Exception:  # noqa: BLE001 - older messages have no such view
+            pass
+
+    try:
+        for message in getattr(request, "messages", None) or []:
+            for content in _blocks(message):
+                if not isinstance(content, list):
+                    continue
+                for block in content:
+                    if isinstance(block, dict) and block.get("type") in _IMAGE_BLOCK_TYPES:
+                        return True
+    except Exception as e:  # noqa: BLE001 - never break a turn deciding this
+        logger.debug("could not inspect the request for images: %s", e)
+    return False
+
+
+def _announce_fallback(primary: str, fallback: str, *, sync: bool):
+    """Say in the UI that the step finished somewhere else.
+
+    Reuses ``model_substituted``, which is already built end to end (raised in
+    request_handler, branched in MessageHandler.js, rendered as the banner above
+    the composer). It only ever fired for *policy* substitution before the run
+    started; ``reason`` is what lets the same banner word a mid-turn failure
+    fallback differently.
+
+    Returns the coroutine to await on the async path, or None on the sync path
+    (where it has already been queued).
+    """
+    frame = {
+        "type": "model_substituted",
+        "requested": primary,
+        "effective": fallback,
+        "reason": "fallback",
+    }
+    from app.lib import turn_notices
+
+    if sync:
+        try:
+            turn_notices.notify(frame)
+        except Exception as e:  # noqa: BLE001 - a notice never fails a turn
+            logger.debug("could not announce the model fallback: %s", e)
+        return None
+    return turn_notices.anotify(frame)
+
+
+def _model_request_params(request):
+    """Best-effort snapshot of the invocation parameters on the bound model.
+
+    Reads whatever the provider client exposes rather than a fixed list — the next
+    offending parameter is by definition one we are not thinking about today. Redaction
+    happens in message_invariants.redact_request_params, not here.
+    """
+    model = getattr(request, "model", None)
+    for attr in ("_default_params", "_identifying_params", "model_kwargs"):
+        params = getattr(model, attr, None)
+        if isinstance(params, dict) and params:
+            return dict(params)
+    return {}
+
+
 def _record_bad_request_shape(exc, request, llm_model):
     """Attach a redacted description of a rejected request to the exception."""
     from app.agents.leonardo.message_invariants import (
@@ -415,6 +545,10 @@ def _record_bad_request_shape(exc, request, llm_model):
             tools=getattr(request, "tools", None),
             model=llm_model,
             label=f"model={llm_model}",
+            # The parameters we actually sent. The provider answers "invalid parameters"
+            # and then reports param=null on every occurrence, so this is the only way to
+            # diff a failing box against a working one.
+            request_params=_model_request_params(request),
         )
     except Exception:  # noqa: BLE001 - diagnosis must never mask the real error
         logger.debug("could not describe the rejected request", exc_info=True)
@@ -446,58 +580,146 @@ class DynamicModelMiddleware(AgentMiddleware):
             overrides["system_message"] = system_message_for_model(system_message, llm_model)
         return request.override(**overrides)
 
+    def _next_rung(self, request, llm_model, tried):
+        """Rung 2: the model to finish this step on, or None to give up.
+
+        Resolved through model_policy — never a literal id here (see
+        ``fallback_model``'s docstring and ``test_no_agent_hardcodes_a_fallback_
+        model``). ``tried`` is what stops the two-dead-endpoint loop: on a Muse
+        box the policy default IS the model that just stalled, so without it the
+        resolver would hand Muse back as DeepSeek's fallback and the pair would
+        bounce forever.
+        """
+        try:
+            return fallback_model(
+                llm_model,
+                needs_vision=_request_carries_an_image(request),
+                exclude=tried,
+            )
+        except Exception as e:  # noqa: BLE001 - no rung 2 beats no turn
+            logger.warning("Could not resolve a fallback model: %s", e)
+            return None
+
     def wrap_model_call(self, request, handler):
-        """Sync: select the model, then retry the call on transient failures."""
+        """Sync: select the model, retry it, then fall back to another model.
+
+        Two bounds, not one. The attempt counter alone is meaningless against a
+        provider that stalls — see ``_MODEL_RETRY_MAX_TOTAL_SECONDS`` — so the
+        wall clock ends rung 1 too, and rung 2 gets a turn instead of the user
+        watching the same dead endpoint be retried five times.
+        """
         llm_model = request.state.get('llm_model') or enabled_default_model()
         logger.info(f"Using LLM model: {llm_model}")
         req = self._override(request, llm_model)
+        tried = {llm_model}
+        fallbacks_used = 0
         attempt = 0
+        started_at = time.monotonic()
         while True:
             try:
                 return handler(req)
             except Exception as e:
                 attempt += 1
-                if attempt >= _MODEL_RETRY_MAX_ATTEMPTS or not is_transient_error(e):
-                    # A provider that rejects the REQUEST tells us nothing
-                    # actionable ("'param': None" — 32 occurrences on 7 boxes in
-                    # 7 days for our own default model). Describe the shape of
-                    # what we sent, redacted, so the fleet report has something
-                    # to diagnose from.
+                elapsed = time.monotonic() - started_at
+                # A deterministic error (bad kwarg, 400) fails identically on
+                # every provider, so it must not spend rung 2's budget either.
+                if not is_transient_error(e):
                     _record_bad_request_shape(e, req, llm_model)
                     raise
+                if attempt >= _MODEL_RETRY_MAX_ATTEMPTS or elapsed >= _MODEL_RETRY_MAX_TOTAL_SECONDS:
+                    fallback = (
+                        None if fallbacks_used >= _MODEL_FALLBACK_MAX_RUNGS
+                        else self._next_rung(request, llm_model, tried)
+                    )
+                    if fallback is None:
+                        logger.warning(
+                            f"Giving up on {llm_model} after {elapsed:.0f}s and "
+                            f"{attempt} attempts; no fallback model available"
+                        )
+                        _record_bad_request_shape(e, req, llm_model)
+                        raise
+                    logger.warning(
+                        f"{llm_model} stalled for {elapsed:.0f}s over {attempt} "
+                        f"attempts; finishing this step on {fallback}"
+                    )
+                    _announce_fallback(llm_model, fallback, sync=True)
+                    llm_model = fallback
+                    tried.add(fallback)
+                    fallbacks_used += 1
+                    req = self._override(request, llm_model)
+                    attempt = 0
+                    started_at = time.monotonic()
+                    # No backoff: the whole point of moving is that waiting on
+                    # this provider has stopped being worth anything.
+                    continue
                 logger.warning(
                     f"Transient model error on {llm_model} (attempt {attempt}/"
                     f"{_MODEL_RETRY_MAX_ATTEMPTS - 1}): {e!r}; retrying"
                 )
+                if elapsed >= _RETRY_NOTICE_AFTER_SECONDS:
+                    _notify_retry(attempt, sync=True)
                 time.sleep(_model_retry_delay(attempt))
 
     async def awrap_model_call(self, request, handler):
-        """Async: select the model, then retry the call on transient failures.
+        """Async: select the model, retry it, then fall back to another model.
 
         The async path previously had NO retry at all — this closes that gap for
-        the websocket chat path, which runs through here.
+        the websocket chat path, which runs through here. Same two bounds and
+        same rung 2 as the sync loop above; this is the path a customer is
+        actually on, so it is also the one that pushes the status frames.
         """
         llm_model = request.state.get('llm_model') or enabled_default_model()
         logger.info(f"Using LLM model: {llm_model}")
         req = self._override(request, llm_model)
+        tried = {llm_model}
+        fallbacks_used = 0
         attempt = 0
+        started_at = time.monotonic()
         while True:
             try:
                 return await handler(req)
             except Exception as e:
                 attempt += 1
-                if attempt >= _MODEL_RETRY_MAX_ATTEMPTS or not is_transient_error(e):
+                elapsed = time.monotonic() - started_at
+                if not is_transient_error(e):
                     # A provider that rejects the REQUEST tells us nothing
                     # actionable ("'param': None" — 32 occurrences on 7 boxes in
                     # 7 days for our own default model). Describe the shape of
                     # what we sent, redacted, so the fleet report has something
-                    # to diagnose from.
+                    # to diagnose from. It also fails identically on any other
+                    # provider, so it must not reach rung 2.
                     _record_bad_request_shape(e, req, llm_model)
                     raise
+                if attempt >= _MODEL_RETRY_MAX_ATTEMPTS or elapsed >= _MODEL_RETRY_MAX_TOTAL_SECONDS:
+                    fallback = (
+                        None if fallbacks_used >= _MODEL_FALLBACK_MAX_RUNGS
+                        else self._next_rung(request, llm_model, tried)
+                    )
+                    if fallback is None:
+                        logger.warning(
+                            f"Giving up on {llm_model} after {elapsed:.0f}s and "
+                            f"{attempt} attempts; no fallback model available"
+                        )
+                        _record_bad_request_shape(e, req, llm_model)
+                        raise
+                    logger.warning(
+                        f"{llm_model} stalled for {elapsed:.0f}s over {attempt} "
+                        f"attempts; finishing this step on {fallback}"
+                    )
+                    await _announce_fallback(llm_model, fallback, sync=False)
+                    llm_model = fallback
+                    tried.add(fallback)
+                    fallbacks_used += 1
+                    req = self._override(request, llm_model)
+                    attempt = 0
+                    started_at = time.monotonic()
+                    continue
                 logger.warning(
                     f"Transient model error on {llm_model} (attempt {attempt}/"
                     f"{_MODEL_RETRY_MAX_ATTEMPTS - 1}): {e!r}; retrying"
                 )
+                if elapsed >= _RETRY_NOTICE_AFTER_SECONDS:
+                    await _notify_retry(attempt, sync=False)
                 await asyncio.sleep(_model_retry_delay(attempt))
 
 

--- a/app/agents/leonardo/rails_agent/prompts.py
+++ b/app/agents/leonardo/rails_agent/prompts.py
@@ -765,6 +765,9 @@ When you and the user work out a repeatable procedure worth reusing, capture it 
 We have a cookbook recipe guide for doing common things, located at https://llamapress.ai/cookbook.json that you can `curl`, to see guides on common things — such as implementing PDF download exports, inline data tables, etc. When a task matches one of these common patterns, curl the cookbook first and follow the recipe rather than inventing an approach from scratch.
 
 If the user's message contains a reference like `@cookbook:<slug> (https://llamapress.ai/cookbook/<slug>.json)`, they picked that recipe from the slash menu — curl that URL first and follow it. The reference may sit mid-sentence; the rest of their message is what to apply it to.
+You also have a PERSONAL cookbook: recipes the box owner published from their own Leo boxes, at `https://llamapress.ai/cookbook/u/<handle>/<slug>` (`.json` and `.md` both work). An `@cookbook:` mention may point at one of these — curl and follow it exactly as you would a fleet recipe. The slash menu marks the owner's own recipes "yours".
+
+When the user asks to SAVE or reuse a pattern across their instances ("save this to my cookbook", "use this on my other Leos"), curl `https://llamapress.ai/cookbook/publish-to-your-personal-cookbook.md` and follow it — it documents the publish flow using this box's own `MOTHERSHIP_API_TOKEN` and its `instance_name`.
 
 ### write_todos
 Create a visible task list for any code change. The user cannot see your reasoning - TODOs show your progress.

--- a/app/agents/leonardo/rails_beginner_agent/prompts.py
+++ b/app/agents/leonardo/rails_beginner_agent/prompts.py
@@ -545,6 +545,9 @@ Tell the helper exactly what to do — it doesn't have your conversation context
 We have a cookbook recipe guide for doing common things, located at https://llamapress.ai/cookbook.json that you can `curl` (via `bash_command`), to see guides on common things — such as implementing PDF download exports, inline data tables, etc. When a request matches one of these common patterns, curl the cookbook first and follow the recipe rather than inventing an approach from scratch.
 
 If the user's message contains a reference like `@cookbook:<slug> (https://llamapress.ai/cookbook/<slug>.json)`, they picked that recipe from the slash menu — curl that URL first and follow it. The reference may sit mid-sentence; the rest of their message is what to apply it to.
+You also have a PERSONAL cookbook: recipes the box owner published from their own Leo boxes, at `https://llamapress.ai/cookbook/u/<handle>/<slug>` (`.json` and `.md` both work). An `@cookbook:` mention may point at one of these — curl and follow it exactly as you would a fleet recipe. The slash menu marks the owner's own recipes "yours".
+
+When the user asks to SAVE or reuse a pattern across their instances ("save this to my cookbook", "use this on my other Leos"), curl `https://llamapress.ai/cookbook/publish-to-your-personal-cookbook.md` and follow it — it documents the publish flow using this box's own `MOTHERSHIP_API_TOKEN` and its `instance_name`.
 
 ---
 

--- a/app/agents/leonardo/rails_plan_mode_agent/prompts.py
+++ b/app/agents/leonardo/rails_plan_mode_agent/prompts.py
@@ -249,6 +249,9 @@ After implementation is complete:
 We have a cookbook recipe guide for doing common things, located at https://llamapress.ai/cookbook.json that you can `curl`, to see guides on common things — such as implementing PDF download exports, inline data tables, etc. When a request matches one of these common patterns, curl the cookbook first and follow the recipe rather than inventing an approach from scratch.
 
 If the user's message contains a reference like `@cookbook:<slug> (https://llamapress.ai/cookbook/<slug>.json)`, they picked that recipe from the slash menu — curl that URL first and follow it. The reference may sit mid-sentence; the rest of their message is what to apply it to.
+You also have a PERSONAL cookbook: recipes the box owner published from their own Leo boxes, at `https://llamapress.ai/cookbook/u/<handle>/<slug>` (`.json` and `.md` both work). An `@cookbook:` mention may point at one of these — curl and follow it exactly as you would a fleet recipe. The slash menu marks the owner's own recipes "yours".
+
+When the user asks to SAVE or reuse a pattern across their instances ("save this to my cookbook", "use this on my other Leos"), curl `https://llamapress.ai/cookbook/publish-to-your-personal-cookbook.md` and follow it — it documents the publish flow using this box's own `MOTHERSHIP_API_TOKEN` and its `instance_name`.
 
 ---
 

--- a/app/agents/leonardo/rails_ticket_mode_agent/prompts.py
+++ b/app/agents/leonardo/rails_ticket_mode_agent/prompts.py
@@ -503,6 +503,9 @@ Build a complete technical mental model by researching:
 **COOKBOOK:** We have a cookbook recipe guide for doing common things, located at https://llamapress.ai/cookbook.json that you can `curl`, to see guides on common things — such as implementing PDF download exports, inline data tables, etc. When the ticket matches one of these common patterns, curl the cookbook first and base the technical plan on the recipe rather than inventing an approach from scratch.
 
 If the user's message contains a reference like `@cookbook:<slug> (https://llamapress.ai/cookbook/<slug>.json)`, they picked that recipe from the slash menu — curl that URL first and base the technical plan on it. The reference may sit mid-sentence; the rest of their message is what to apply it to.
+You also have a PERSONAL cookbook: recipes the box owner published from their own Leo boxes, at `https://llamapress.ai/cookbook/u/<handle>/<slug>` (`.json` and `.md` both work). An `@cookbook:` mention may point at one of these — curl and follow it exactly as you would a fleet recipe. The slash menu marks the owner's own recipes "yours".
+
+When the user asks to SAVE or reuse a pattern across their instances ("save this to my cookbook", "use this on my other Leos"), curl `https://llamapress.ai/cookbook/publish-to-your-personal-cookbook.md` and follow it — it documents the publish flow using this box's own `MOTHERSHIP_API_TOKEN` and its `instance_name`.
 
 **IF THE ISSUE INVOLVES DUPLICATES / UNEXPECTED COUNTS / NON-DETERMINISTIC SELECTION:**
 You MUST also:

--- a/app/agents/leonardo/resilience.py
+++ b/app/agents/leonardo/resilience.py
@@ -108,6 +108,21 @@ def _status_code_of(exc: BaseException):
     code = getattr(response, "status_code", None)
     if isinstance(code, int):
         return code
+    # OpenRouter reports an upstream provider failure as a plain ValueError whose
+    # single arg is a dict — no `.status_code`, no `.response`, so both lookups
+    # above miss and a 502 saying "Retry after 2s" was classed non-transient.
+    # Measured on the real endpoint: this is the dominant failure mode of the
+    # routed path, not a corner case.
+    #
+    # Deliberately narrow — only a dict arg with an INT under a status-ish key.
+    # `bool` is excluded because it is an int subclass, and a non-int code (a
+    # provider string like "rate_limited") must not be mistaken for a status.
+    for arg in getattr(exc, "args", ()):
+        if isinstance(arg, dict):
+            for key in ("code", "status_code", "status"):
+                value = arg.get(key)
+                if isinstance(value, int) and not isinstance(value, bool):
+                    return value
     return None
 
 
@@ -144,10 +159,80 @@ _MODEL_RETRY_MAX_ATTEMPTS = 5          # initial call + up to 4 retries
 _MODEL_RETRY_BASE_DELAY = 0.5          # seconds
 _MODEL_RETRY_MAX_DELAY = 8.0           # seconds
 
+# Total wall clock the whole rung may spend on one model before handing over to
+# rung 2, regardless of attempts remaining.
+#
+# The attempt count was never the bug. The backoff (0.5-8s) was sized against a
+# 503, where the failing attempt itself costs about a second — five of those is
+# a few seconds and nobody notices. It was never sized against an attempt that
+# costs a full chunk timeout: on 2026-08-26 a Muse Spark endpoint returned HTTP
+# 200 and streamed nothing, so each attempt burned the library's inherited 120s
+# default and five of them was ~10 minutes of silence. The customer's report was
+# "it runs for like 10 minutes with no changes".
+#
+# 60, not 90, because what the user sits through is this budget PLUS the attempt
+# that was still in flight when it ran out: 60 + a 25s chunk timeout = 85s, which
+# is the "abandoned in under 90 seconds" the incident review asked for. Raising
+# this to 90 quietly buys a 115s worst case.
+_MODEL_RETRY_MAX_TOTAL_SECONDS = 60.0
+
+# How long the user must already have been waiting before a retry is worth
+# telling them about. Below this the retry is genuinely invisible — a 503 comes
+# back in a second or two — and a notice on every one of those trains people to
+# ignore the notice that matters. Above it, the shimmer has been spinning long
+# enough that silence is indistinguishable from a frozen agent.
+_RETRY_NOTICE_AFTER_SECONDS = 10.0
+
 
 def _model_retry_delay(attempt: int) -> float:
     """Exponential backoff (capped) for the Nth failed attempt (1-based)."""
     return min(_MODEL_RETRY_BASE_DELAY * (2 ** (attempt - 1)), _MODEL_RETRY_MAX_DELAY)
+
+
+def retry_notice_text(attempt: int, max_attempts: int = None) -> str:
+    """What the shimmer says while the ladder is working.
+
+    Names the situation the user is actually in ("not responding"), not the
+    mechanism. Retries are counted from the user's point of view — attempt 1 is
+    the first *retry*, because the failed original call is not something they
+    were ever shown.
+    """
+    if max_attempts is None:
+        max_attempts = _MODEL_RETRY_MAX_ATTEMPTS
+    return (
+        f"Model is not responding. Retrying ({attempt} of {max_attempts - 1})…"
+    )
+
+
+def _notify_slow_retry(label: str, attempt: int, elapsed: float) -> bool:
+    """Tell the user about a retry they have already felt. Sync path.
+
+    Below :data:`_RETRY_NOTICE_AFTER_SECONDS` this does nothing on purpose — see
+    the constant. Best effort in every direction: no channel installed (cron, a
+    sub-agent, a test) is the normal case, not an error.
+    """
+    if elapsed < _RETRY_NOTICE_AFTER_SECONDS:
+        return False
+    try:
+        from app.lib.turn_notices import notify, thinking_frame
+
+        return notify(thinking_frame(retry_notice_text(attempt)))
+    except Exception as e:  # noqa: BLE001 - a notice never fails a turn
+        logger.debug("could not announce a retry on %s: %s", label, e)
+        return False
+
+
+def retry_budget_spent(started_at: float, budget: float = None) -> bool:
+    """True once this model has had all the wall clock the rung will give it.
+
+    ``started_at`` is a ``time.monotonic()`` stamp from when the first attempt
+    began. Checked *before* sleeping and retrying, never as a deadline on an
+    in-flight call — cancelling a request mid-flight would lose a response that
+    may still be coming.
+    """
+    if budget is None:
+        budget = _MODEL_RETRY_MAX_TOTAL_SECONDS
+    return (time.monotonic() - started_at) >= budget
 
 
 def _record_raw_model_call(turn, started_at: float, response) -> None:
@@ -221,7 +306,21 @@ def invoke_with_transient_retry(fn, *, label: str = "model call", messages=None,
             result = fn()
         except Exception as e:
             attempt += 1
-            if attempt >= _MODEL_RETRY_MAX_ATTEMPTS or not is_transient_error(e):
+            # The wall clock gets a vote alongside the counter. Five attempts is
+            # the right number when each costs a second and the wrong number when
+            # each costs a chunk timeout — see _MODEL_RETRY_MAX_TOTAL_SECONDS.
+            out_of_budget = retry_budget_spent(started_at)
+            if (
+                attempt >= _MODEL_RETRY_MAX_ATTEMPTS
+                or out_of_budget
+                or not is_transient_error(e)
+            ):
+                if out_of_budget and is_transient_error(e):
+                    logger.warning(
+                        "Giving up on %s after %.0fs of transient failures "
+                        "(%d attempts): %r",
+                        label, time.monotonic() - started_at, attempt, e,
+                    )
                 # Same diagnosis the middleware path records: a provider 400
                 # carries nothing actionable, so describe the shape we sent.
                 _describe_if_bad_request(e, messages, tools, label)
@@ -231,6 +330,7 @@ def invoke_with_transient_retry(fn, *, label: str = "model call", messages=None,
                 "Transient error on %s (attempt %d/%d): %r; retrying",
                 label, attempt, _MODEL_RETRY_MAX_ATTEMPTS - 1, e,
             )
+            _notify_slow_retry(label, attempt, time.monotonic() - started_at)
             time.sleep(_model_retry_delay(attempt))
         else:
             _record_raw_model_call(turn, started_at, result)

--- a/app/frontend/chat.html
+++ b/app/frontend/chat.html
@@ -275,9 +275,11 @@
                         <option value="gpt-5.6-sol-chatgpt" data-short-label="Sol (ChatGPT)">GPT-5.6 Sol — my ChatGPT plan</option>
                         <option value="deepseek-v4-flash" data-short-label="DeepSeek">DeepSeek V4 Flash</option>
                         <option value="deepseek-v4-pro" data-short-label="DeepSeek Pro">DeepSeek V4 Pro</option>
+                        <option value="deepseek-v4-flash-vision-exp" data-short-label="DeepSeek Vision">DeepSeek V4 Flash Vision</option>
                         <option value="deepseek-v4-flash-gmi" data-short-label="DeepSeek GMI">DeepSeek V4 Flash (GMI)</option>
                         <option value="deepseek-v4-flash-fireworks" data-short-label="DeepSeek FW">DeepSeek V4 Flash (Fireworks)</option>
                         <option value="qwen3.7-plus" data-short-label="Qwen">Qwen3.7 Plus</option>
+                        <option value="qwen3.8-27b-hetzner" data-short-label="Qwen3.8 HZ" title="Qwen3.8-27B on Hetzner's EU Inference API — 262k context, reads images. Rate limited to 10 requests/minute per key. Needs HETZNER_API_KEY on this box.">Qwen3.8 27B (Hetzner)</option>
                         <option value="qwen3-8b-runpod" data-short-label="Qwen3 8B" title="Qwen3-8B served by vLLM on our own RunPod GPU. Needs RUNPOD_QWEN_BASE_URL on this box.">Qwen3 8B (RunPod self-hosted)</option>
                         <option value="muse-glimmer-30b-runpod" data-short-label="Glimmer 30B" title="Muse Glimmer 30B (AWQ INT4) served by vLLM on our own RunPod GPU. Needs RUNPOD_GLIMMER_BASE_URL on this box.">Muse Glimmer 30B (RunPod self-hosted)</option>
                         <option value="nemotron-lightning-30b-runpod" data-short-label="Nemotron 30B" title="NVIDIA Nemotron 3.5 Lightning 30B-A3B (NVFP4) served by vLLM on our own RunPod GPU, 131k context. Needs RUNPOD_NEMOTRON_BASE_URL on this box.">Nemotron 3.5 Lightning 30B (RunPod self-hosted)</option>

--- a/app/frontend/chat/index.js
+++ b/app/frontend/chat/index.js
@@ -41,8 +41,13 @@ import { safeInit, selectedElementsOf } from './utils/safeInit.js';
 
 // Image auto-switch: when a user attaches an image while on a text-only model,
 // we move them onto an image-capable model so the image is actually seen.
-const IMAGE_MODEL = 'muse-spark-1.2-contributor';   // vision-capable target
-const IMAGE_MODEL_LABEL = 'Muse Spark 1.2';
+//
+// WHICH model is box-dependent (Muse where the box has a META key, DeepSeek's
+// vision model where it does not), so it is resolved server-side by model_policy
+// and reported as `vision_model` on /api/available-models; this.visionModel
+// holds it from then on. This constant is only the pre-0.7.5 answer, used when
+// an older backend omits the field — never as a general default.
+const LEGACY_IMAGE_MODEL = 'muse-spark-1.2-contributor';
 // There is deliberately NO compile-time default model here. It is box-dependent
 // (Muse where the box has a META key, DeepSeek where it does not), so it is
 // resolved server-side by model_policy and reported as `default_model` on
@@ -127,6 +132,9 @@ class ChatApp {
       // Qwen3-8B on our RunPod pod is the dense TEXT model — seed it false so an
       // image upload auto-switches instead of 400ing on image_url.
       ['qwen3-8b-runpod', { images: false }],
+      // Qwen3.8-27B on Hetzner reads images (Hetzner's own model table lists
+      // Text + Image), so seed it true for the same reason as Qwen3.7 Plus.
+      ['qwen3.8-27b-hetzner', { images: true }],
       // Glimmer's base model is multimodal, but the AWQ checkpoint we serve has
       // an unverified vision path — declared text-only on the backend too.
       ['muse-glimmer-30b-runpod', { images: false }],
@@ -161,6 +169,12 @@ class ChatApp {
     // model and 400s with `unknown variant image_url`. Optimistic until the
     // fetch resolves, matching the gates above.
     this.visionModelAvailable = true;
+
+    // Where the image auto-switch sends a user who attaches an image while on a
+    // text-only model. Null until fetchAvailableModels() hydrates it from the
+    // backend's resolved `vision_model`; empty string means this box has no
+    // vision model at all, and the auto-switch refuses instead of switching.
+    this.visionModel = null;
 
     // Set once an image attach has been refused, so the banner still explains
     // itself even though nothing ended up in the composer.
@@ -1490,6 +1504,31 @@ class ChatApp {
   }
 
   /**
+   * Add a dropdown <option> for every backend model the static markup lacks.
+   *
+   * Only models that ship a `label` get one: that field is the backend saying
+   * "this is config-driven, the markup cannot know about me". A hardcoded model
+   * missing from the dropdown is a build error, not something to paper over at
+   * runtime — inventing an option for it would hide the skew.
+   */
+  addMissingModelOptions(models) {
+    const select = this.elements.modelSelect;
+    if (!select) return;
+    const existing = new Set(Array.from(select.options).map(o => o.value));
+    models.forEach(m => {
+      if (!m.label || existing.has(m.value)) return;
+      const option = document.createElement('option');
+      option.value = m.value;
+      option.textContent = m.label;
+      // Same contract as the static options: modelLabel() prefers the short
+      // label for inline notices, falling back to the full one.
+      if (m.short_label) option.dataset.shortLabel = m.short_label;
+      select.appendChild(option);
+      existing.add(m.value);
+    });
+  }
+
+  /**
    * The human label for a model value, straight from the dropdown so the notice
    * never invents a name the user has not seen. Falls back to the raw value for
    * a model the dropdown doesn't carry (frontend/backend version skew).
@@ -1503,25 +1542,34 @@ class ChatApp {
   }
 
   /**
-   * Say, above the composer, that operator policy ran this turn on a different
-   * model than the dropdown shows (`model_substituted` frame).
+   * Say, above the composer, that this turn is not running on the model the
+   * dropdown shows (`model_substituted` frame).
    *
    * This used to be invisible: the substitution happens inside get_llm, so the
    * dropdown went on showing the user's pick while every turn ran on the box
    * default and the only trace was a container-log WARNING.
    *
+   * `reason` says which of the two swaps this is, and they read completely
+   * differently to a user. 'policy' is a standing configuration fact about the
+   * box, raised before the run starts. 'fallback' (0.7.5) is a thing that just
+   * happened to *this* turn: the model they picked stopped responding mid-step
+   * and Leo finished somewhere else. Wording them the same would explain a
+   * provider outage as a permissions problem.
+   *
    * Auto-hides like a flash — the notice is about the turn that just started,
    * not a standing condition — but is dismissable for a user who reads faster.
    */
-  showModelSubstitutionNotice(requested, effective) {
+  showModelSubstitutionNotice(requested, effective, reason) {
     const banner = this.container.querySelector('[data-llamabot="model-switch-banner"]');
     if (!banner) return;
 
     const text = banner.querySelector('[data-llamabot="model-switch-text"]');
     if (text) {
-      text.textContent =
-        `${this.modelLabel(requested)} isn't enabled on this instance — ` +
-        `answering with ${this.modelLabel(effective)} instead.`;
+      text.textContent = reason === 'fallback'
+        ? `${this.modelLabel(requested)} stopped responding — `
+          + `finished this step on ${this.modelLabel(effective)}.`
+        : `${this.modelLabel(requested)} isn't enabled on this instance — `
+          + `answering with ${this.modelLabel(effective)} instead.`;
     }
     banner.classList.remove('hidden');
 
@@ -1739,16 +1787,19 @@ class ChatApp {
     // fresh thread we just switch silently for this send. This must run BEFORE
     // the human bubble renders and BEFORE ensureThreadId() below.
     if (this.hasImageAttachment(attachments) && !this.modelSupportsImages(llmModel)) {
-      const imageOpt = Array.from(this.elements.modelSelect?.options || [])
-        .find(o => o.value === IMAGE_MODEL);
+      const imageModel = this.visionModel ?? LEGACY_IMAGE_MODEL;
+      const imageOpt = imageModel
+        ? Array.from(this.elements.modelSelect?.options || [])
+            .find(o => o.value === imageModel)
+        : null;
       const imageModelAvailable = imageOpt && !imageOpt.disabled;
 
       if (imageModelAvailable) {
         if (this.conversationHasMessages()) {
           // Mid-conversation: switch model, start a new thread, carry transcript.
           const transcript = this.buildConversationTranscript();
-          this.setModel(IMAGE_MODEL);
-          effectiveLlmModel = IMAGE_MODEL;
+          this.setModel(imageModel);
+          effectiveLlmModel = imageModel;
           // Clears the message history and sets the new thread id synchronously.
           this.threadManager.createNewThread({ isImageSwitch: true });
           if (transcript) {
@@ -1756,19 +1807,20 @@ class ChatApp {
           }
           this.slashCommandManager?.showToast(
             "You attached an image, but your current model can't see images. " +
-            `I switched to ${IMAGE_MODEL_LABEL} and started a new conversation, ` +
+            `I switched to ${this.modelLabel(imageModel)} and started a new conversation, ` +
             'carrying your previous messages over.',
             'info'
           );
           this.updateImageSwitchBanner();
         } else {
           // Fresh/empty thread: silently switch this send to the vision model.
-          this.setModel(IMAGE_MODEL);
-          effectiveLlmModel = IMAGE_MODEL;
+          this.setModel(imageModel);
+          effectiveLlmModel = imageModel;
         }
       } else {
         // Nowhere to switch to — this box has no vision-capable model it can
-        // run (no META key, so Muse is unavailable and DeepSeek is text-only).
+        // run (no META key AND no DEEPSEEK_API_KEY, so neither vision model
+        // resolves; `vision_model` came back empty or its option is disabled).
         // Sending anyway would put an image block in front of a text-only model
         // and 400 mid-stream, which surfaces to the user as a stack trace. Stop
         // and say so instead. Nothing destructive has happened yet — the input
@@ -2112,6 +2164,12 @@ class ChatApp {
       this.visionAllowed = data.vision_allowed !== false;
       // Box-dependent since 0.7.0. Keep the seed if an older backend omits it.
       if (data.default_model) this.defaultTextModel = data.default_model;
+      // Box-dependent since 0.7.5. An older backend omits the field entirely —
+      // fall back to the model that WAS hardcoded here, so a skewed frontend
+      // behaves exactly as it did before rather than losing the auto-switch.
+      // Note `??`, not `||`: "" is a real answer (this box has no vision model)
+      // and must not be overwritten by the legacy default.
+      this.visionModel = data.vision_model ?? LEGACY_IMAGE_MODEL;
       // Is there a vision-capable model this box can actually run? A box with no
       // META key reports the auto-switch target unavailable, which is what turns
       // the "vision unavailable" message on. Must be set BEFORE applyVisionPolicy.
@@ -2121,6 +2179,14 @@ class ChatApp {
       this.applyModelSwitchingPolicy();
       this.applyVisionPolicy();
       this.updateImageSwitchBanner();
+
+      // Config-registered models (OpenRouter endpoints) have no <option> in
+      // chat.html — they are config, so the markup cannot know their names.
+      // Create the missing options before the availability pass below, which
+      // only ever walks options that already exist. Without this the backend
+      // would offer a model the dropdown could never show, and setModel() on it
+      // would silently no-op.
+      this.addMissingModelOptions(data.models || []);
 
       const modelAvailability = new Map(
         data.models.map(m => [m.value, {
@@ -2411,6 +2477,19 @@ class ChatApp {
    * Stops the loading verb cycling and hides the thinking area
    * Shows error message if we were in the middle of thinking
    */
+  /**
+   * Swap the in-flight assistant bubble for what the server actually produced.
+   *
+   * Called by stream resume after the socket reconnects mid-run. Also resets the streaming
+   * buffers, so any chunk that arrives late from the old run cannot append itself onto the
+   * authoritative text and re-create the mid-sentence bubble we just fixed.
+   */
+  replaceStreamingMessage(content) {
+    const replaced = this.messageRenderer?.replaceLastAiMessage?.(content);
+    this.streamingState?.reset?.();
+    return Boolean(replaced);
+  }
+
   hideThinkingIndicator() {
     // Check if we were thinking (thinking area was visible)
     const wasThinking = this.elements.thinkingArea &&

--- a/app/frontend/chat/messages/MessageRenderer.js
+++ b/app/frontend/chat/messages/MessageRenderer.js
@@ -179,6 +179,15 @@ export class MessageRenderer {
     // Store raw markdown for copy functionality
     messageDiv.setAttribute('data-raw-content', safeContent);
 
+    // Stable identity for feedback. Without it the mothership matched a rating to a
+    // message by comparing text, so a reply truncated by a dropped socket matched nothing
+    // and a placeholder row was fabricated from the fragment (annotation #688) — the real
+    // message stayed unrated, and 4% of end-user annotations landed on such rows.
+    const messageKey = baseMessage?.id || baseMessage?.message_key;
+    if (messageKey) {
+      messageDiv.setAttribute('data-message-key', String(messageKey));
+    }
+
     messageDiv.innerHTML = this.markdownParser.parse(safeContent);
 
     // Check if this is a tool call message (OpenAI format)
@@ -231,6 +240,33 @@ export class MessageRenderer {
    * Add a copy button to a message element
    * @param {HTMLElement} messageDiv - The message element to add the button to
    */
+  /**
+   * Replace the newest assistant bubble's text with an authoritative version.
+   *
+   * Used by stream resume after a reconnect: the bubble on screen holds only the chunks
+   * that survived the drop, so it can begin mid-sentence (rsb-dev 2026-08-28 rendered the
+   * last 435 chars of a 906-char answer). Rewrites in place rather than appending a second
+   * bubble, so a resume that fires twice cannot duplicate the reply.
+   *
+   * Returns true when a bubble was rewritten, false when there was nothing to rewrite.
+   */
+  replaceLastAiMessage(content) {
+    if (typeof content !== 'string' || !content) return false;
+
+    const bubbles = this.messageHistory?.querySelectorAll?.('[data-llamabot="ai-message"]');
+    if (!bubbles || bubbles.length === 0) return false;
+
+    const target = bubbles[bubbles.length - 1];
+    // Already correct — a second resume must be a no-op, not a re-render.
+    if (target.getAttribute('data-raw-content') === content) return true;
+
+    target.setAttribute('data-raw-content', content);
+    target.innerHTML = this.markdownParser.parse(content);
+    target.setAttribute('data-llamabot-resumed', 'true');
+    this.addCopyButton(target);
+    return true;
+  }
+
   addCopyButton(messageDiv) {
     const copyBtn = document.createElement('button');
     copyBtn.setAttribute('data-llamabot', 'copy-btn');
@@ -311,6 +347,7 @@ export class MessageRenderer {
       const rating = upBtn ? 'good' : 'bad';
       const messageDiv = btn.closest('[data-llamabot="ai-message"], [data-raw-content]');
       const content = messageDiv?.getAttribute('data-raw-content') || '';
+      const messageKey = messageDiv?.getAttribute('data-message-key') || null;
 
       let note = null;
       if (rating === 'bad') {
@@ -318,7 +355,7 @@ export class MessageRenderer {
         note = window.prompt('What went wrong? (optional)') || null;
       }
 
-      this.submitMessageFeedback({ rating, content, note });
+      this.submitMessageFeedback({ rating, content, note, messageKey });
 
       // Visual confirmation: solid-fill the chosen thumb, reset its sibling.
       const row = messageDiv || btn.parentElement;
@@ -333,7 +370,7 @@ export class MessageRenderer {
    * POST a per-message rating to the local box, which forwards it to the mothership.
    * Best-effort: failures are logged, never surfaced to the user or blocking the chat.
    */
-  submitMessageFeedback({ rating, content, note = null }) {
+  submitMessageFeedback({ rating, content, note = null, messageKey = null }) {
     const threadId = this.appState?.getThreadId?.();
     if (!threadId) return;
     fetch('/api/feedback', {
@@ -344,6 +381,9 @@ export class MessageRenderer {
         thread_id: threadId,
         rating,
         scope: 'message',
+        // Both: the key is what the mothership should join on, `content` stays as a
+        // fallback so older mothership code goes on resolving messages as it always did.
+        message_key: messageKey || undefined,
         content: content || undefined,
         note: note || undefined,
         sent_at: new Date().toISOString(),

--- a/app/frontend/chat/messages/QuestionCard.js
+++ b/app/frontend/chat/messages/QuestionCard.js
@@ -1,9 +1,9 @@
 /**
  * Question card markup + answer formatting for `ask_user_question`.
  *
- * Leo can ask 1-4 questions in a single interrupt. The card renders one block per
- * question; the user answers them all and submits once, which is a whole round-trip
- * saved per extra question.
+ * Leo can ask 1-4 questions in a single interrupt. They are answered one at a time in
+ * a stepper ("Question 2 of 3", Back/Next) and submitted together, which is a whole
+ * round-trip saved per extra question without making the user scroll a stack of them.
  *
  * The pieces that matter live here (pure, no DOM) rather than in MessageHandler so the
  * answer format — the actual contract with the agent — can be tested without a browser.
@@ -67,9 +67,12 @@ const EYE_ICON =
  * Build the card markup.
  *
  * A single question renders exactly as it always has (options row with Skip, hidden
- * Continue, free-text row with a send arrow). Two or more switch to the batched
- * layout: one block per question, a per-question Skip, and one footer Continue that
- * stays disabled until every question is answered or skipped.
+ * Continue, free-text row with a send arrow).
+ *
+ * Two or more render as a STEPPER: every question is in the DOM (so answers survive
+ * paging back and forth) but only the current one is visible, with a "Question 2 of 3"
+ * header, progress dots, and a Back / Next footer that turns into Submit on the last
+ * one. One question on screen at a time — no vertical scrolling through a stack.
  *
  * `escapeHtml` and `parseMarkdown` are injected so this module stays DOM-free.
  */
@@ -97,16 +100,19 @@ export function buildQuestionCardHtml({
           ${EYE_ICON}See visual options
         </button>` : '';
 
-    // Batched: Skip marks just this question and waits for Continue.
+    // Batched: Skip marks this question "no preference" and steps forward.
     // Single: Skip submits the whole card immediately (unchanged behaviour).
     const skipBtn = `<button class="plan-skip-btn" data-qi="${i}">Skip</button>`;
     const hasOptionRow = q.options.length > 0 || q.ui_related || batched;
 
     const sendBtn = batched ? '' : `<button class="plan-send-btn"><i class="fa-solid fa-arrow-up"></i></button>`;
 
+    // Only step 0 is visible on render; the rest are paged in. `hidden` (not a class)
+    // so the overlay clone and any future container styling can't accidentally show them.
+    const hide = batched && i > 0 ? ' hidden' : '';
+
     return `
-      <div class="plan-question-item" data-qi="${i}" data-question-text="${escapeAttr(q.question)}">
-        ${batched ? `<span class="plan-question-num">${i + 1}</span>` : ''}
+      <div class="plan-question-item" data-qi="${i}" data-question-text="${escapeAttr(q.question)}"${hide}>
         <div class="plan-question-text">${parseMarkdown(q.question)}</div>
         ${hasOptionRow ? `<div class="plan-question-options">${optionButtons}${uiuxBtn}${skipBtn}</div>` : ''}
         <div class="plan-question-input-row">
@@ -116,12 +122,26 @@ export function buildQuestionCardHtml({
       </div>`;
   }).join('');
 
+  // One dot per question: filled = answered, ring = where you are, empty = ahead.
+  // Clickable, so a 3-question batch is also random-access.
+  const dots = questions.map((_, i) =>
+    `<button class="plan-question-dot${i === 0 ? ' current' : ''}" data-di="${i}"
+             title="Question ${i + 1}" aria-label="Go to question ${i + 1}"></button>`
+  ).join('');
+
+  const head = batched ? `
+      <div class="plan-question-head">
+        <span class="plan-question-step">${stepLabel(0, questions.length)}</span>
+        <div class="plan-question-dots">${dots}</div>
+      </div>`
+    : '';
+
   const foot = batched ? `
       <div class="plan-question-foot">
-        <span class="plan-question-progress">0 of ${questions.length} answered</span>
+        <button class="plan-back-btn" disabled><i class="fa-solid fa-arrow-left"></i> Back</button>
         <div class="plan-question-foot-actions">
           <button class="plan-skip-all-btn">Skip all</button>
-          <button class="plan-continue-btn" disabled>Continue</button>
+          <button class="plan-continue-btn" disabled>Next <i class="fa-solid fa-arrow-right"></i></button>
         </div>
       </div>`
     : `<button class="plan-continue-btn" style="display: none;">Continue</button>`;
@@ -129,12 +149,35 @@ export function buildQuestionCardHtml({
   return `
       <div class="plan-question-card${batched ? ' batched' : ''}" data-question-id="${questionId}"
            data-thread-id="${escapeAttr(threadId)}" data-agent-name="${escapeAttr(agentName)}"
-           data-count="${questions.length}">
+           data-count="${questions.length}"${batched ? ' data-step="0"' : ''}>
         ${context ? `<div class="plan-question-context">${escapeHtml(context)}</div>` : ''}
+        ${head}
         ${blocks}
         ${foot}
       </div>
     `;
+}
+
+/** Header text for the stepper. Its own function so the markup and the live update agree. */
+export function stepLabel(step, total) {
+  return `Question ${step + 1} of ${total}`;
+}
+
+/**
+ * Everything the stepper chrome needs for one step, derived from the answer states.
+ *
+ * Next only unlocks once the current question has an answer (Skip counts) — that is what
+ * guarantees no blank slot reaches Leo, and it replaces the old "all N answered" gate on
+ * Continue now that the user can't see the other questions to notice one is empty.
+ */
+export function stepperView(states, step, total) {
+  return {
+    label: stepLabel(step, total),
+    canBack: step > 0,
+    canAdvance: isAnswered(states[step]),
+    isLast: step === total - 1,
+    answered: states.filter(isAnswered).length,
+  };
 }
 
 /**

--- a/app/frontend/chat/ui/SlashCommandManager.js
+++ b/app/frontend/chat/ui/SlashCommandManager.js
@@ -73,7 +73,10 @@ export function findSlashTrigger(value, caret) {
 export function filterCookbookGuides(guides, query) {
   const list = Array.isArray(guides) ? guides : [];
   const words = String(query || '').toLowerCase().split(/\s+/).filter(Boolean);
-  if (words.length === 0) return [...list];
+  if (words.length === 0) {
+    // Same rule with no query typed: the owner's recipes head the list.
+    return [...list].sort((a, b) => (a.personal ? 0 : 1) - (b.personal ? 0 : 1));
+  }
 
   const haystack = (g) => [
     g.title, g.summary, g.category, g.slug, ...(g.tags || []),
@@ -90,10 +93,18 @@ export function filterCookbookGuides(guides, query) {
     if (words.every(w => title.includes(w))) rank = 0;
     else if (words.every(w => tags.includes(w))) rank = 1;
     else if (words.every(w => category.includes(w))) rank = 2;
-    scored.push({ g, rank, index });
+    // The user's OWN recipes come first within their match quality. They published them
+    // from one of their boxes precisely so they could reuse them here, so when they and a
+    // fleet guide match equally well, theirs is the one they meant.
+    scored.push({ g, rank, personal: g.personal ? 0 : 1, index });
   });
 
-  scored.sort((a, b) => (a.rank - b.rank) || (a.index - b.index));
+  // Relevance first, ownership as the tiebreaker. The ticket asked for personal recipes
+  // "above fleet guides"; sorting on ownership BEFORE match quality also buries a fleet
+  // guide that is a clearly better answer to what the user typed, which is a worse search
+  // than the one we have. Equal match quality -> the user's own recipe wins, which is the
+  // case the request was actually about.
+  scored.sort((a, b) => (a.rank - b.rank) || (a.personal - b.personal) || (a.index - b.index));
   return scored.map(s => s.g);
 }
 
@@ -693,7 +704,7 @@ export class SlashCommandManager {
       filtered.map((g, index) => `
       <div class="slash-command-item cookbook-item${index === 0 ? ' selected' : ''}" data-index="${index}" data-slug="${this._esc(g.slug)}">
         <div class="cookbook-body">
-          <span class="cookbook-title">${this._esc(g.title)}${g.category ? `<span class="command-cookbook-badge">${this._esc(g.category)}</span>` : ''}</span>
+          <span class="cookbook-title">${this._esc(g.title)}${g.personal ? '<span class="command-cookbook-badge cookbook-badge-yours">yours</span>' : ''}${g.category ? `<span class="command-cookbook-badge">${this._esc(g.category)}</span>` : ''}</span>
           <span class="command-description cookbook-summary" title="${this._esc(g.summary)}">${this._esc(g.summary)}</span>
         </div>
         <a class="cookbook-open" href="${this._esc(g.url)}" target="_blank" rel="noopener noreferrer" title="Open this recipe on llamapress.ai"><i class="fa-solid fa-arrow-up-right-from-square"></i></a>

--- a/app/frontend/chat/websocket/MessageHandler.js
+++ b/app/frontend/chat/websocket/MessageHandler.js
@@ -8,6 +8,7 @@ import {
   buildQuestionCardHtml,
   buildSubmission,
   isAnswered,
+  stepperView,
 } from '../messages/QuestionCard.js';
 
 const PAYWALL_UPGRADE_URL = 'https://llamapress.ai/pricing';
@@ -184,10 +185,12 @@ export class MessageHandler {
     } else if (data.type === 'delegation_progress') {
       window.chatApp?.handleDelegationProgress(data);
     } else if (data.type === 'model_substituted') {
-      // Operator policy is running this turn on a different model than the
-      // dropdown shows. Needs its own branch: without one it falls through to
-      // handleGenericMessage and gets rendered as a chat message.
-      window.chatApp?.showModelSubstitutionNotice(data.requested, data.effective);
+      // This turn is not running on the model the dropdown shows. Two causes,
+      // told apart by data.reason: 'policy' (operator disabled the pick, raised
+      // before the run starts) and 'fallback' (the model stalled mid-turn and
+      // the step finished elsewhere). Needs its own branch: without one it falls
+      // through to handleGenericMessage and gets rendered as a chat message.
+      window.chatApp?.showModelSubstitutionNotice(data.requested, data.effective, data.reason);
     } else {
       this.handleGenericMessage(data);
     }
@@ -816,19 +819,57 @@ export class MessageHandler {
     // One state slot per question: what was clicked, typed, skipped, or sent to previews.
     const states = questions.map(() => ({ options: [], text: '', uiux: false, skipped: false }));
 
-    const progressEl = card.querySelector('.plan-question-progress');
+    const stepEl = card.querySelector('.plan-question-step');
+    const backBtn = card.querySelector('.plan-back-btn');
+    const dots = Array.from(card.querySelectorAll('.plan-question-dot'));
     const continueBtn = card.querySelector('.plan-continue-btn');
 
+    // Which question is on screen. Only one is visible at a time in a batch; the others
+    // stay in the DOM so answers survive paging back and forth.
+    let step = 0;
+
     const refresh = () => {
-      const answered = states.filter(isAnswered).length;
-      if (batched) {
-        // Every question needs an answer (Skip counts) before Continue unlocks —
-        // otherwise a blank slot goes to Leo with nothing to map it to.
-        if (progressEl) progressEl.textContent = `${answered} of ${questions.length} answered`;
-        if (continueBtn) continueBtn.disabled = answered < questions.length;
-      } else if (continueBtn) {
-        continueBtn.style.display = answered > 0 ? 'block' : 'none';
+      if (!batched) {
+        if (continueBtn) continueBtn.style.display = states.some(isAnswered) ? 'block' : 'none';
+        return;
       }
+
+      const view = stepperView(states, step, questions.length);
+      items.forEach((item, i) => { item.hidden = i !== step; });
+      card.dataset.step = String(step);
+      if (stepEl) stepEl.textContent = view.label;
+      if (backBtn) backBtn.disabled = !view.canBack;
+      if (continueBtn) {
+        continueBtn.disabled = !view.canAdvance;
+        continueBtn.innerHTML = view.isLast
+          ? 'Submit'
+          : 'Next <i class="fa-solid fa-arrow-right"></i>';
+      }
+      dots.forEach((dot, i) => {
+        dot.classList.toggle('current', i === step);
+        dot.classList.toggle('answered', isAnswered(states[i]));
+      });
+    };
+
+    // Move to another question. Focus follows so the keyboard stays useful, and the card
+    // is re-centred because a taller/shorter question can push it off screen.
+    const goTo = (next) => {
+      if (next < 0 || next >= questions.length) return;
+      step = next;
+      refresh();
+      items[step].querySelector('.plan-question-input')?.focus();
+      card.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+    };
+
+    // Next on the last question is Submit. The dots allow jumping around, so before
+    // submitting, land on the first question that was left blank rather than sending
+    // Leo a slot it can't map an answer to.
+    const advance = () => {
+      if (!isAnswered(states[step])) return;
+      if (step < questions.length - 1) { goTo(step + 1); return; }
+      const gap = states.findIndex(st => !isAnswered(st));
+      if (gap !== -1) { goTo(gap); return; }
+      submit();
     };
 
     const submit = () => {
@@ -881,10 +922,19 @@ export class MessageHandler {
           return;
         }
         const i = Number(btn.dataset.qi || 0);
-        setSkipped(i, !states[i].skipped);
+        setSkipped(i, true);
         refresh();
+        // Skip is an answer ("no preference"), so it steps forward like Next does.
+        advance();
       });
     });
+
+    // Dots are random access — jump straight to a question to change an answer.
+    dots.forEach(dot => {
+      dot.addEventListener('click', () => goTo(Number(dot.dataset.di || 0)));
+    });
+
+    backBtn?.addEventListener('click', () => goTo(step - 1));
 
     card.querySelector('.plan-skip-all-btn')?.addEventListener('click', () => {
       this._submitQuestionAnswer(card, 'skip', threadId, agentName);
@@ -892,7 +942,8 @@ export class MessageHandler {
 
     continueBtn?.addEventListener('click', () => {
       if (continueBtn.disabled) return;
-      submit();
+      if (batched) advance();
+      else submit();
     });
 
     // Free text, per question.
@@ -903,6 +954,16 @@ export class MessageHandler {
         if (states[i].skipped && input.value.trim()) setSkipped(i, false);
         refresh();
       });
+      // Enter moves on (Shift+Enter still writes a newline), so a typed batch can be
+      // answered without reaching for the mouse.
+      if (batched) {
+        input.addEventListener('keydown', (e) => {
+          if (e.key === 'Enter' && !e.shiftKey) {
+            e.preventDefault();
+            advance();
+          }
+        });
+      }
     });
 
     // Single-question send arrow (a batch submits through Continue instead).

--- a/app/frontend/chat/websocket/StreamResume.js
+++ b/app/frontend/chat/websocket/StreamResume.js
@@ -1,0 +1,102 @@
+/**
+ * Re-sync an in-flight assistant reply after the chat socket reconnects.
+ *
+ * The failure this exists for (rsb-dev, 2026-08-28, thread 1787943690689-qzr1efuar):
+ * the socket dropped ~2.5 minutes into a run. ActionCable reconnected the TRANSPORT, but
+ * nothing replayed the RUN. The server went on streaming into a socket nobody was reading,
+ * and the chunks that arrived after the reconnect were appended to a fresh bubble — so the
+ * customer's final answer began mid-sentence, showing exactly the last 435 characters of a
+ * complete 906-character reply. Leo's work was correct and fully persisted; only the view
+ * broke, and the customer had no way to tell. They paid a message to type "continue", then
+ * hard-reloaded the page.
+ *
+ * Fleet scale: 45 of the 57 boxes capable of reporting it have hit it (78.9%), 122 events,
+ * half of them on beginner-mode users — the people least able to tell a truncated answer
+ * from a wrong one. Only 1 of 122 produced a thumbs-down, so complaint volume says nothing.
+ *
+ * Reconnecting the pipe does not recover the turn. These helpers are deliberately pure so
+ * the decisions can be tested without a socket, a DOM or a server.
+ */
+
+/**
+ * Should a reconnect trigger a re-sync?
+ *
+ * Only when a run was actually in flight when the socket died. An idle reconnect must not
+ * refetch and repaint the thread underneath the user.
+ */
+export function shouldResumeAfterReconnect({ wasRunInFlight, threadId } = {}) {
+  return Boolean(wasRunInFlight && threadId);
+}
+
+/**
+ * Choose the authoritative assistant text from a `/chat-history/{thread_id}` message list.
+ *
+ * Prefers the message the partial bubble is the TAIL of: that is the exact signature of
+ * this bug (in the incident, `full.endsWith(partial)` was true at offset 471), so it
+ * identifies the interrupted message rather than merely the newest one. Falls back to the
+ * last assistant message, which is still strictly better than leaving a mid-sentence
+ * bubble on screen.
+ *
+ * Returns null rather than guessing when there is no assistant message to show.
+ */
+export function pickAuthoritativeMessage(messages, { partialText = '' } = {}) {
+  if (!Array.isArray(messages) || messages.length === 0) return null;
+
+  // Tool output must never be rendered as Leo speaking, and a human turn is not an answer.
+  const assistant = messages.filter(
+    (m) => m && (m.type === 'ai' || m.type === 'assistant') && typeof m.content === 'string',
+  );
+  if (assistant.length === 0) return null;
+
+  const fragment = (partialText || '').trim();
+  if (fragment) {
+    // Walk newest-first: on a resumed thread the same tail can appear more than once.
+    for (let i = assistant.length - 1; i >= 0; i -= 1) {
+      const content = assistant[i].content;
+      if (content.length > fragment.length && content.trimEnd().endsWith(fragment)) {
+        return content;
+      }
+    }
+  }
+
+  return assistant[assistant.length - 1].content;
+}
+
+/**
+ * Monotonic token for a resume attempt.
+ *
+ * The history fetch is async and chunks may still be arriving, so a slow response from an
+ * older reconnect must never overwrite a newer, correct render. Callers bump the
+ * generation when they start a resume and drop any result that is no longer current.
+ */
+export function nextResumeGeneration(current) {
+  return (Number(current) || 0) + 1;
+}
+
+/** True when a resume result belongs to a superseded attempt and must be discarded. */
+export function isStaleResume(generation, currentGeneration) {
+  return Number(generation) !== Number(currentGeneration);
+}
+
+/**
+ * Fetch the thread state and hand back the authoritative text.
+ *
+ * Fail-open: any error resolves to null, and the caller leaves the existing bubble alone.
+ * A resume that throws must never be worse than the truncation it is fixing.
+ */
+export async function fetchAuthoritativeMessage(threadId, { partialText = '', fetchImpl } = {}) {
+  const doFetch = fetchImpl || (typeof fetch === 'function' ? fetch : null);
+  if (!doFetch || !threadId) return null;
+
+  try {
+    const response = await doFetch(`/chat-history/${threadId}`);
+    if (!response || !response.ok) return null;
+
+    const data = await response.json();
+    const messages = data?.messages || data?.values?.messages || null;
+    return pickAuthoritativeMessage(messages, { partialText });
+  } catch (error) {
+    console.warn('Stream resume: could not fetch thread state', error);
+    return null;
+  }
+}

--- a/app/frontend/chat/websocket/WebSocketManager.js
+++ b/app/frontend/chat/websocket/WebSocketManager.js
@@ -8,6 +8,7 @@ import { ActionCableAdapter } from './ActionCableAdapter.js';
 import { TokenManager } from '../auth/TokenManager.js';
 
 import { leoDiagnostics } from '../utils/LeoDiagnostics.js';
+import { shouldResumeAfterReconnect, fetchAuthoritativeMessage, nextResumeGeneration, isStaleResume } from './StreamResume.js';
 // Control messages that must NOT be queued for replay after a reconnect:
 //  - `auth` tokens are regenerated fresh on every (re)connect, so a stale one is useless.
 //  - `cancel` only means something for the run that was live when it was issued;
@@ -104,6 +105,15 @@ export class WebSocketManager {
     this.updateConnectionStatus(true);
     leoDiagnostics.noteOpen(this.socket ? this.socket.readyState : null);
     this.reconnectAttempts = 0;
+    this.clearActionCableWatchdog();
+
+    // Reconnecting the pipe does not recover the turn. If a run was in flight when the
+    // socket died, chunks sent during the dead window are gone for good, and appending
+    // whatever arrives next produces an answer that starts mid-sentence. Re-sync instead.
+    if (this.runWasInFlightAtClose) {
+      this.runWasInFlightAtClose = false;
+      this.resumeInFlightRun();
+    }
 
     if (this.elements.sendButton) {
       this.elements.sendButton.disabled = false;
@@ -184,6 +194,11 @@ export class WebSocketManager {
     });
 
     this.updateConnectionStatus(false);
+
+    // Remember whether Leo was mid-answer when the pipe died. The thinking indicator is
+    // the same signal the box already reports as "Lost connection mid-run", and it is what
+    // decides on reconnect whether we must re-sync the reply or leave the thread alone.
+    this.runWasInFlightAtClose = this.isRunInFlight();
 
     if (this.elements.sendButton) {
       this.elements.sendButton.disabled = true;
@@ -397,8 +412,17 @@ export class WebSocketManager {
    * error only after we've truly given up — not on transient drops.
    */
   scheduleReconnect() {
-    // ActionCable handles reconnection automatically, skip for ActionCable
+    // ActionCable reconnects the transport itself, so we must NOT also drive connect().
+    // But the old bare `return` here left two things broken on every ActionCable box:
+    // handleClose() had already disabled the send button and nothing on this path ever
+    // re-enabled it, and reconnectAttempts never moved — so `reconnect_attempts=0` in the
+    // diagnostics was a dead gauge that told the last investigation the client had not
+    // even tried. Count the attempt, and arm a watchdog so a reconnect that never lands
+    // surfaces as a real failure instead of a permanently disabled composer.
     if (this.isActionCable) {
+      this.reconnectAttempts += 1;
+      leoDiagnostics.noteReconnect(this.reconnectAttempts, this.maxReconnectAttempts);
+      this.armActionCableWatchdog();
       return;
     }
 
@@ -423,6 +447,81 @@ export class WebSocketManager {
     this.reconnectTimer = setTimeout(() => {
       this.connect();
     }, this.config.reconnectDelay || 3000);
+  }
+
+  /**
+   * Is Leo mid-answer right now?
+   *
+   * The visible thinking indicator is the signal — it is what the frontend already
+   * reports as "Lost connection mid-run (thinking indicator active)", so resume keys off
+   * the same fact the telemetry does rather than inventing a second notion of "running".
+   */
+  isRunInFlight() {
+    const area = window.chatApp?.elements?.thinkingArea;
+    return Boolean(area && !area.classList.contains('hidden'));
+  }
+
+  /**
+   * Give ActionCable a bounded window to recover on its own.
+   *
+   * The old comment claimed ActionCable "handles reconnection automatically", but the
+   * customer evidence is a UI stuck on "Lost connection" with input disabled until a
+   * manual page reload (lohman, July 2026, twice). If the socket really does come back,
+   * handleOpen() clears this and nothing is shown. If it does not, the user gets a real
+   * failure they can act on instead of a dead composer.
+   */
+  armActionCableWatchdog() {
+    this.clearActionCableWatchdog();
+    this.actionCableWatchdog = setTimeout(() => {
+      if (this.elements.sendButton) {
+        this.elements.sendButton.disabled = false;
+      }
+      window.dispatchEvent(new CustomEvent('websocketReconnectFailed', {
+        detail: {
+          attempts: this.reconnectAttempts,
+          maxAttempts: this.maxReconnectAttempts,
+          url: this.wsUrl,
+          transport: 'actioncable',
+        }
+      }));
+    }, this.config.actionCableRecoveryMs || 15000);
+  }
+
+  clearActionCableWatchdog() {
+    if (this.actionCableWatchdog) {
+      clearTimeout(this.actionCableWatchdog);
+      this.actionCableWatchdog = null;
+    }
+  }
+
+  /**
+   * Replace the orphaned partial bubble with what the server actually produced.
+   *
+   * Idempotent by generation token: the fetch is async and chunks may still be arriving,
+   * so a slow answer from an older reconnect must never overwrite a newer render.
+   * Fail-open throughout — if anything goes wrong we leave the existing bubble alone,
+   * because a resume that breaks is worse than the truncation it is fixing.
+   */
+  async resumeInFlightRun() {
+    const app = window.chatApp;
+    const threadId = app?.appState?.getThreadId?.() || null;
+    const partialText = app?.streamingState?.getCleanedFullMessage?.() || '';
+
+    if (!shouldResumeAfterReconnect({ wasRunInFlight: true, threadId })) return;
+
+    const generation = nextResumeGeneration(this.resumeGeneration);
+    this.resumeGeneration = generation;
+
+    const authoritative = await fetchAuthoritativeMessage(threadId, { partialText });
+
+    // A newer resume started while we were waiting — discard this one.
+    if (isStaleResume(generation, this.resumeGeneration)) return;
+    if (!authoritative) return;
+
+    // The run is over as far as this browser is concerned; a spinner left running is what
+    // made the customer believe Leo had died.
+    app?.hideThinkingIndicator?.();
+    app?.replaceStreamingMessage?.(authoritative);
   }
 
   /**

--- a/app/frontend/style.css
+++ b/app/frontend/style.css
@@ -3571,41 +3571,78 @@ body.instance-locked .lock-modal-overlay {
 
 
 /* ===== Batched questions (2-4 asked at once, answered together) ===== */
-/* One card, one block per question, one Continue. Saves a round-trip per question. */
+/* A stepper: one question on screen, "Question 2 of 3" + dots up top, Back/Next below.
+   Every question stays in the DOM (answers survive paging) but only the current one
+   is visible, so a 4-question batch never turns into a scroll. */
 .plan-question-card.batched {
     border: 1px solid rgba(139, 92, 246, 0.2);
     border-radius: 12px;
     background: rgba(139, 92, 246, 0.04);
-    padding: 6px 16px 14px;
+    padding: 10px 16px 12px;
 }
 
 .plan-question-card.batched .plan-question-item {
-    position: relative;
-    padding: 12px 0 14px 26px;
+    padding: 4px 0 2px;
+    /* Paging in a shorter/taller question shouldn't make the card jump around. */
+    min-height: 96px;
+    animation: plan-question-step-in 0.18s ease-out;
+}
+
+@keyframes plan-question-step-in {
+    from { opacity: 0; transform: translateX(6px); }
+    to   { opacity: 1; transform: none; }
+}
+
+/* Header: which question you're on, and how many are left. */
+.plan-question-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding-bottom: 8px;
     border-bottom: 1px solid rgba(255, 255, 255, 0.06);
 }
 
-.plan-question-card.batched .plan-question-item:last-of-type {
-    border-bottom: none;
-    padding-bottom: 4px;
+.plan-question-step {
+    font-size: 12px;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    color: #a78bfa;
 }
 
-/* Numbered so the user can see at a glance how many are left. */
-.plan-question-num {
-    position: absolute;
-    left: 0;
-    top: 12px;
-    width: 18px;
-    height: 18px;
-    border-radius: 50%;
-    background: rgba(139, 92, 246, 0.2);
-    border: 1px solid rgba(139, 92, 246, 0.4);
-    color: #c4b5fd;
-    font-size: 11px;
-    font-weight: 600;
+.plan-question-dots {
     display: flex;
     align-items: center;
-    justify-content: center;
+    gap: 6px;
+}
+
+/* Filled = answered, ringed = where you are, empty = ahead. Clickable to jump. */
+.plan-question-dot {
+    width: 8px;
+    height: 8px;
+    padding: 0;
+    border-radius: 50%;
+    background: transparent;
+    border: 1px solid rgba(139, 92, 246, 0.45);
+    cursor: pointer;
+    transition: background 0.15s ease, box-shadow 0.15s ease, transform 0.15s ease;
+}
+
+.plan-question-dot:hover:not(:disabled) {
+    transform: scale(1.25);
+}
+
+.plan-question-dot.answered {
+    background: rgba(139, 92, 246, 0.7);
+}
+
+.plan-question-dot.current {
+    border-color: #8b5cf6;
+    box-shadow: 0 0 0 3px rgba(139, 92, 246, 0.18);
+}
+
+.plan-question-dot:disabled {
+    cursor: default;
 }
 
 /* The free-text box is the fallback in a batch (options are the fast path), so it
@@ -3625,7 +3662,7 @@ body.instance-locked .lock-modal-overlay {
     margin-top: 8px;
 }
 
-/* A skipped question stays visibly skipped so the count makes sense. */
+/* A skipped question stays visibly skipped so the dots make sense. */
 .plan-skip-btn.selected {
     border-color: rgba(255, 255, 255, 0.35);
     color: rgba(255, 255, 255, 0.7);
@@ -3638,14 +3675,35 @@ body.instance-locked .lock-modal-overlay {
     justify-content: space-between;
     flex-wrap: wrap;
     gap: 12px;
-    margin-top: 12px;
-    padding-top: 12px;
+    margin-top: 10px;
+    padding-top: 10px;
     border-top: 1px solid rgba(255, 255, 255, 0.08);
 }
 
-.plan-question-progress {
+/* Back is quiet — it's the escape hatch, not the path forward. */
+.plan-back-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    background: transparent;
+    border: 1px solid rgba(255, 255, 255, 0.15);
+    color: rgba(255, 255, 255, 0.55);
     font-size: 12px;
-    color: #64748b;
+    padding: 8px 14px;
+    border-radius: 8px;
+    cursor: pointer;
+    transition: color 0.15s ease, border-color 0.15s ease, opacity 0.15s ease;
+}
+
+.plan-back-btn:hover:not(:disabled) {
+    color: rgba(255, 255, 255, 0.85);
+    border-color: rgba(255, 255, 255, 0.3);
+}
+
+/* Kept in place (not hidden) on the first question so the footer doesn't reflow. */
+.plan-back-btn:disabled {
+    opacity: 0.3;
+    cursor: default;
 }
 
 .plan-question-foot-actions {
@@ -3656,6 +3714,9 @@ body.instance-locked .lock-modal-overlay {
 
 .plan-question-card.batched .plan-continue-btn {
     margin-top: 0;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
 }
 
 /* ===== UI/UX visual question (ask_user_uiux_question) ===== */

--- a/app/lib/cors_preflight.py
+++ b/app/lib/cors_preflight.py
@@ -1,0 +1,70 @@
+"""Answer CORS preflights on the login entry points.
+
+A browser that preflights a login URL and gets a 400 abandons the navigation silently —
+the user never reaches the box, and nothing is logged. Seen live on leo-nefe 2026-08-06:
+seven one-time login grants burned in an afternoon, `OPTIONS /auth/consume?token=... 400`
+with no GET ever following. The legacy HMAC `/login` path had the same hole.
+
+Why it happens: CORSMiddleware is configured same-origin-only (allow_origins=[]), which is
+deliberate and correct. It does NOT fall through — it recognises the preflight, finds the
+origin is not allowed, and answers 400 "Disallowed CORS origin" ITSELF, before routing. So
+declaring `@router.options(...)` alone fixes nothing; the route never runs. The preflight
+has to be answered ahead of the CORS middleware, which is what the middleware below does.
+(The route handlers still earn their place: a bare OPTIONS with no Origin header is not a
+preflight, so CORSMiddleware passes it straight through to routing.)
+
+These endpoints carry no data and grant nothing, so answering the preflight permissively is
+safe: every real check still runs on the GET.
+"""
+from fastapi import Request
+from fastapi.responses import Response
+
+# Short enough that a policy change reaches browsers quickly, long enough to spare a
+# repeat preflight on the second click.
+_MAX_AGE = "600"
+
+
+def preflight_response(request: Request) -> Response:
+    """A bare 204 preflight answer that echoes the requesting origin.
+
+    Grants nothing on its own: no body, no cookie, no session. If this ever starts
+    setting one, it stops being a preflight answer and becomes an auth bypass.
+    """
+    origin = request.headers.get("origin", "*")
+    return Response(
+        status_code=204,
+        headers={
+            "Access-Control-Allow-Origin": origin,
+            "Access-Control-Allow-Credentials": "true",
+            "Access-Control-Allow-Methods": "GET, OPTIONS",
+            "Access-Control-Allow-Headers": request.headers.get(
+                "access-control-request-headers", "*"
+            ),
+            "Access-Control-Max-Age": _MAX_AGE,
+        },
+    )
+
+
+# Only these two. This is the login front door, not a general CORS relaxation: every other
+# path keeps the same-origin-only policy exactly as it is.
+LOGIN_PREFLIGHT_PATHS = frozenset({"/auth/consume", "/login"})
+
+
+async def login_preflight_middleware(request: Request, call_next):
+    """Answer a login preflight before CORSMiddleware can reject it.
+
+    Register this AFTER `add_middleware(CORSMiddleware, ...)`: Starlette runs the most
+    recently added middleware outermost, so registering later means running earlier.
+
+    Scoped as tightly as possible — an OPTIONS request, to one of two exact paths, that is
+    genuinely a preflight (it carries Access-Control-Request-Method). Anything else is
+    handed on untouched.
+    """
+    if (
+        request.method == "OPTIONS"
+        and request.url.path in LOGIN_PREFLIGHT_PATHS
+        and "access-control-request-method" in request.headers
+    ):
+        return preflight_response(request)
+
+    return await call_next(request)

--- a/app/lib/turn_notices.py
+++ b/app/lib/turn_notices.py
@@ -1,0 +1,144 @@
+"""Per-turn channel for telling the user something mid-run, from deep in the graph.
+
+The resilience ladder lives inside ``DynamicModelMiddleware`` — several layers
+below the websocket — and until now it was completely silent. When the Muse Spark
+endpoint accepted requests and then sent zero chunks (2026-08-26, rsb-dev), Leo
+retried the same stalled endpoint five times over ~10 minutes while the browser
+showed nothing but a spinning shimmer. The customer's report was "it runs for like
+10 minutes with no changes", because that is genuinely all there was to see.
+
+Installed per turn in a ``ContextVar`` exactly like :mod:`app.lib.turn_metrics`
+and :mod:`app.lib.rails_error_watch`: the request handler calls
+:func:`start_turn_notices` with the run's sink *before* ``astream``, and LangGraph's
+node tasks inherit a copy of that context, so middleware running inside a node
+resolves to the same channel.
+
+Two send paths because the ladder has two:
+
+* :meth:`TurnNotices.asend` — awaited from ``awrap_model_call`` (the websocket
+  chat path). Ordered with respect to the rest of the stream.
+* :meth:`TurnNotices.send` — fire-and-forget from ``wrap_model_call`` and the raw
+  StateGraph nodes, which run in a worker thread with no loop of their own. The
+  frame is scheduled back onto the turn's loop.
+
+Everything here is best effort. A status notice is never worth failing the turn it
+is describing, so nothing in this module raises.
+"""
+
+import asyncio
+import logging
+from contextvars import ContextVar
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# Set per turn by start_turn_notices(). Node tasks spawned by LangGraph inherit a
+# copy of the context, so they see the same channel instance.
+_current_notices: ContextVar[Optional["TurnNotices"]] = ContextVar(
+    "llamabot_turn_notices", default=None
+)
+
+
+class TurnNotices:
+    """A websocket-shaped sink plus the loop it belongs to, scoped to one turn.
+
+    ``send_json`` is whatever the request handler was handed — a real
+    ``WebSocket`` or, for a background run, a ``RunSink`` (which stamps
+    ``thread_id`` and logs the frame for replay). Both are awaited the same way,
+    so notices inherit thread routing and reattach-replay for free.
+    """
+
+    def __init__(self, send_json, loop=None):
+        self._send_json = send_json
+        self._loop = loop
+
+    async def asend(self, frame: dict) -> bool:
+        """Await delivery of one frame. Returns whether it went out."""
+        try:
+            await self._send_json(frame)
+            return True
+        except Exception as e:  # noqa: BLE001 - a notice must never fail a turn
+            logger.debug("turn notice not delivered: %s", e)
+            return False
+
+    def send(self, frame: dict) -> bool:
+        """Schedule one frame from a sync call path. Returns whether it was queued.
+
+        Sync middleware and raw StateGraph nodes run in a worker thread, so there
+        is no loop here to await on — the coroutine is handed back to the turn's
+        own loop instead. Fire-and-forget on purpose: the point of the notice is
+        that the model is *not* responding, and blocking the retry on the notice
+        would be the wrong trade.
+        """
+        loop = self._loop
+        if loop is None or loop.is_closed():
+            return False
+        try:
+            running = asyncio.get_running_loop()
+        except RuntimeError:
+            running = None
+        try:
+            if running is loop:
+                loop.create_task(self.asend(frame))
+            else:
+                asyncio.run_coroutine_threadsafe(self.asend(frame), loop)
+            return True
+        except Exception as e:  # noqa: BLE001 - a notice must never fail a turn
+            logger.debug("turn notice not scheduled: %s", e)
+            return False
+
+
+def start_turn_notices(send_json) -> Optional[TurnNotices]:
+    """Install the notice channel for this turn's async context.
+
+    Called from the request handler alongside ``start_turn``/``start_error_watch``
+    and for the same reason. Returns the channel (or ``None`` if there is no loop
+    to schedule onto, which only happens outside a server).
+    """
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        loop = None
+    notices = TurnNotices(send_json, loop=loop)
+    _current_notices.set(notices)
+    return notices
+
+
+def clear_turn_notices() -> None:
+    """Drop the channel for this context (the socket it points at is going away)."""
+    _current_notices.set(None)
+
+
+def current_notices() -> Optional[TurnNotices]:
+    """The notice channel for this turn, or ``None`` when nothing is listening."""
+    return _current_notices.get()
+
+
+async def anotify(frame: dict) -> bool:
+    """Await one notice, or do nothing if this turn has no channel."""
+    notices = current_notices()
+    if notices is None:
+        return False
+    return await notices.asend(frame)
+
+
+def notify(frame: dict) -> bool:
+    """Queue one notice from a sync path, or do nothing if there is no channel."""
+    notices = current_notices()
+    if notices is None:
+        return False
+    return notices.send(frame)
+
+
+def thinking_frame(text: str) -> dict:
+    """A status line for the thinking shimmer, with no model call behind it.
+
+    Same shape ``/compact`` already pushes (``request_handler``): an
+    ``AIMessageChunk`` carrying only a thinking block, so the browser renders it
+    in the shimmer rather than as a message from Leo in the transcript.
+    """
+    return {
+        "type": "AIMessageChunk",
+        "content": "",
+        "thinking": [{"type": "thinking", "thinking": text}],
+    }

--- a/app/main.py
+++ b/app/main.py
@@ -5,6 +5,7 @@ load_dotenv()
 from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
 from fastapi.middleware.cors import CORSMiddleware
+from app.lib.cors_preflight import login_preflight_middleware
 from starlette.responses import Response as _StarletteResponse
 
 import os
@@ -68,6 +69,14 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+# Registered AFTER CORSMiddleware so it runs BEFORE it (Starlette runs the most recently
+# added middleware outermost). CORSMiddleware answers a preflight from a non-allowed origin
+# with 400 "Disallowed CORS origin" itself, which silently killed customer logins — a
+# browser abandons the navigation and neither the user nor the logs learn anything
+# (leo-nefe, 2026-08-06: 7 one-time grants burned in an afternoon). Scoped to the two login
+# entry points only; the same-origin-only policy above is unchanged everywhere else.
+app.middleware("http")(login_preflight_middleware)
 
 
 # Keep the entire app out of search engines. Every response — pages, the

--- a/app/routers/api.py
+++ b/app/routers/api.py
@@ -19,11 +19,17 @@ from app.services.user_service import (
     get_all_users, get_user_by_username, update_user, delete_user
 )
 from app.agents.leonardo.model_capabilities import get_model_capabilities
+from app.agents.leonardo.openrouter_models import (
+    API_KEY_ENV as OPENROUTER_API_KEY_ENV,
+    get_openrouter_model,
+    openrouter_models,
+)
 from app.agents.leonardo.model_policy import (
     enabled_default_model,
     is_model_enabled,
     model_switching_allowed,
     vision_allowed,
+    vision_model,
 )
 
 logger = logging.getLogger(__name__)
@@ -887,12 +893,16 @@ async def available_models(request: Request):
         "gemini-3.1-flash-lite": ("GEMINI_API_KEY", "GOOGLE_API_KEY"),
         "deepseek-v4-flash": "DEEPSEEK_API_KEY",
         "deepseek-v4-pro": "DEEPSEEK_API_KEY",
+        # DeepSeek's vision sibling — same key as the text models, which is the
+        # whole point of it (vision with no extra credential to provision).
+        "deepseek-v4-flash-vision-exp": "DEEPSEEK_API_KEY",
         "deepseek-v4-flash-gmi": "GMI_DEEPSEEK_API_KEY",
         "deepseek-v4-flash-fireworks": "FIREWORKS_DEEPSEEK_API_KEY",
         # Fireworks' account-wide key name, falling back to the DeepSeek-specific
         # name already deployed on boxes — matches get_llm's precedence.
         "nemotron-lightning-30b-fireworks": ("FIREWORKS_API_KEY", "FIREWORKS_DEEPSEEK_API_KEY"),
         "qwen3.7-plus": "ALIBABA_API_KEY",
+        "qwen3.8-27b-hetzner": "HETZNER_API_KEY",
         # Self-hosted vLLM pod: the "key" here is deliberately the BASE URL, not
         # an API key. Availability means "this box is pointed at a RunPod
         # endpoint" — the pod may legitimately run unauthenticated, so keying it
@@ -929,6 +939,13 @@ async def available_models(request: Request):
         # Dropdown shaping must never 500 the chat page.
         logger.warning("Could not resolve ChatGPT connection status: %s", e)
 
+    # Config-driven OpenRouter entries (see openrouter_models). They are not in
+    # model_api_keys above — that map is hand-maintained per model, and the whole
+    # point of the registry is that adding an endpoint touches no code — so they
+    # are folded in here, all keyed on the single OPENROUTER_API_KEY.
+    for model_value in openrouter_models():
+        model_api_keys.setdefault(model_value, OPENROUTER_API_KEY_ENV)
+
     models = []
     for model_value, env_vars in model_api_keys.items():
         # Support both single string and tuple of env vars
@@ -958,12 +975,21 @@ async def available_models(request: Request):
         else:
             reason = None
 
-        models.append({
+        entry = {
             "value": model_value,
             "available": has_key and enabled,
             "reason": reason,
             "capabilities": get_model_capabilities(model_value),
-        })
+        }
+        # Registry models have no <option> in chat.html — they are config, so the
+        # markup cannot know their names. Ship their labels and the frontend
+        # creates the option. Only sent for those: for a hardcoded model the
+        # dropdown's own markup stays authoritative.
+        registry_entry = get_openrouter_model(model_value)
+        if registry_entry is not None:
+            entry["label"] = registry_entry["label"]
+            entry["short_label"] = registry_entry["short_label"]
+        models.append(entry)
 
     for model_value in _CHATGPT_SUBSCRIPTION_MODELS:
         enabled = is_model_enabled(model_value)
@@ -994,6 +1020,13 @@ async def available_models(request: Request):
         # META key, DeepSeek where there is not), so it can no longer be a
         # constant in index.js.
         "default_model": enabled_default_model(),
+        # Where the image auto-switch sends a user who attaches an image while on
+        # a text-only model. Box-dependent for the same reason since 0.7.5 (Muse
+        # where there is a META key, DeepSeek's vision model where there is not),
+        # so index.js can no longer hardcode Muse. Empty string means this box has
+        # no vision model at all, which is what turns on the "no image-capable
+        # model is configured" banner.
+        "vision_model": vision_model(),
     }
 
 
@@ -1075,6 +1108,10 @@ class FeedbackRequest(BaseModel):
     note: str | None = None
     content: str | None = None
     sent_at: str | None = None
+    # Stable id of the rated assistant message, echoed back from the bubble. Lets the
+    # mothership join on identity instead of comparing message bodies — text matching
+    # silently fabricated a placeholder row whenever a stream was truncated (#688).
+    message_key: str | None = None
     # Bounded, redacted browser snapshot (ws close code, reconnect count, recent
     # console output, model/mode). See frontend/chat/utils/LeoDiagnostics.js.
     debug_context: dict | None = None
@@ -1131,6 +1168,7 @@ async def api_submit_feedback(request: Request, body: FeedbackRequest, username:
         scope=body.scope,
         note=body.note,
         content=body.content,
+        message_key=body.message_key,
         sent_at=body.sent_at,
         debug_context=debug_context,
         # HTTP path: no turn stamp to fall back on, so resolve the signed-in
@@ -2150,25 +2188,111 @@ async def _fetch_cookbook_index() -> list:
         return _normalize_cookbook_guides(response.json())
 
 
-@router.get("/api/cookbook", response_class=JSONResponse)
-async def api_get_cookbook(username: str = Depends(auth)):
-    """List published cookbook recipes for the /cookbook slash menu."""
+# The owner's personal list is per-instance-owner and changes the moment they publish, so
+# it gets its own short-TTL cache rather than riding the process-global fleet cache.
+_personal_cookbook_cache: dict = {}
+PERSONAL_COOKBOOK_CACHE_TTL_SECONDS = 60
+
+
+def _normalize_personal_recipes(payload) -> list:
+    """Shape the owner's recipes into the same guide dict the slash menu already consumes.
+
+    Unlisted recipes are kept: they are the owner's own, and hiding them here would mean a
+    user could not find a recipe they had just published. Entries without a slug, or a
+    payload with no handle, are dropped — there is no resolvable URL for either.
+    """
+    if not isinstance(payload, dict):
+        return []
+    handle = str(payload.get("handle") or "").strip()
+    raw = payload.get("recipes")
+    if not handle or not isinstance(raw, list):
+        return []
+
+    guides = []
+    for entry in raw:
+        if not isinstance(entry, dict):
+            continue
+        slug = str(entry.get("slug") or "").strip()
+        if not slug:
+            continue
+        guides.append({
+            "slug": slug,
+            "title": str(entry.get("title") or slug),
+            "category": str(entry.get("category") or ""),
+            "summary": str(entry.get("summary") or ""),
+            # Both .json and .md of this URL exist, so the frontend's existing
+            # cookbookJsonUrl mention mechanics work unchanged.
+            "url": f"https://llamapress.ai/cookbook/u/{handle}/{slug}",
+            "handle": handle,
+            "visibility": str(entry.get("visibility") or ""),
+            "updated_at": str(entry.get("updated_at") or ""),
+            "personal": True,
+        })
+    return guides
+
+
+def _merge_personal_cookbook(fleet_guides: list, personal_guides) -> list:
+    """Owner's recipes first, then the fleet's.
+
+    A personal recipe SHADOWS a fleet guide with the same slug: if the user has their own
+    version of a pattern, that is the one they meant.
+    """
+    if not personal_guides:
+        return fleet_guides
+    owned = {g["slug"] for g in personal_guides}
+    return list(personal_guides) + [g for g in (fleet_guides or []) if g.get("slug") not in owned]
+
+
+async def _fetch_personal_cookbook(request) -> list:
+    """The owner's recipes, cached briefly. Never raises — an empty list is the floor."""
     import time
+
+    cached = _personal_cookbook_cache.get("guides")
+    age = time.monotonic() - _personal_cookbook_cache.get("fetched_at", 0.0)
+    if cached is not None and age < PERSONAL_COOKBOOK_CACHE_TTL_SECONDS:
+        return cached
+
+    if request is None:
+        return []
+    mothership = getattr(getattr(request, "app", None), "state", None)
+    client = getattr(mothership, "mothership_client", None) if mothership else None
+    if client is None:
+        return []
+
+    try:
+        guides = _normalize_personal_recipes(await client.get_personal_cookbook())
+    except Exception as e:  # noqa: BLE001 - the fleet menu must survive this
+        logger.warning(f"Could not fetch personal cookbook: {e}")
+        return cached or []
+
+    _personal_cookbook_cache["guides"] = guides
+    _personal_cookbook_cache["fetched_at"] = time.monotonic()
+    return guides
+
+
+@router.get("/api/cookbook", response_class=JSONResponse)
+async def api_get_cookbook(request: Request = None, username: str = Depends(auth)):
+    """List cookbook recipes for the /cookbook slash menu — the owner's, then the fleet's."""
+    import time
+
+    personal = await _fetch_personal_cookbook(request)
 
     cached = _cookbook_cache.get("guides")
     age = time.monotonic() - _cookbook_cache.get("fetched_at", 0.0)
     if cached is not None and age < COOKBOOK_CACHE_TTL_SECONDS:
-        return {"guides": cached, "stale": False}
+        return {"guides": _merge_personal_cookbook(cached, personal), "stale": False}
 
     try:
         guides = await _fetch_cookbook_index()
         _cookbook_cache["guides"] = guides
         _cookbook_cache["fetched_at"] = time.monotonic()
-        return {"guides": guides, "stale": False}
+        return {"guides": _merge_personal_cookbook(guides, personal), "stale": False}
     except Exception as e:
         logger.warning(f"Could not fetch cookbook index from {COOKBOOK_INDEX_URL}: {e}")
-        # Serve the last good payload rather than an empty menu.
-        return {"guides": cached or [], "stale": True, "error": str(e)}
+        # Serve the last good payload rather than an empty menu — and the owner's own
+        # recipes still show even when the fleet index is unreachable.
+        return {"guides": _merge_personal_cookbook(cached or [], personal),
+                "stale": True, "error": str(e)}
 
 
 # ============== File Upload to Assets ==============

--- a/app/routers/ui.py
+++ b/app/routers/ui.py
@@ -39,6 +39,7 @@ from app.services.sso_origin import (
 # truth this router and the WebSocket gate both read. Re-exported here because
 # load_custom_agent_modes() validates against the built-in keys.
 from app.permissions import BUILTIN_AGENT_MODE_KEYS, visible_modes  # noqa: F401
+from app.lib.cors_preflight import preflight_response
 
 logger = logging.getLogger(__name__)
 
@@ -420,6 +421,12 @@ async def login(
     response = JSONResponse({"ok": True, "username": user.username})
     _set_session_cookie(response, user)
     return response
+
+
+@router.options("/login")
+async def login_preflight(request: Request):
+    """Answer the CORS preflight instead of 400ing it (see app/lib/cors_preflight)."""
+    return preflight_response(request)
 
 
 @router.get("/login")
@@ -3925,9 +3932,18 @@ async def scheduled_jobs_page(user: User = Depends(engineer_or_admin_required)):
             'gpt-5-mini': 'GPT-5 Mini',
             'gpt-5-codex': 'GPT-5 Codex',
             'deepseek-v4-flash': 'DeepSeek V4 Flash',
+            'deepseek-v4-flash-vision-exp': 'DeepSeek V4 Flash Vision',
             'deepseek-v4-flash-gmi': 'DeepSeek V4 Flash (GMI)',
             'deepseek-v4-flash-fireworks': 'DeepSeek V4 Flash (Fireworks)',
         };
+
+        // Labels for config-registered models arrive with the model list rather
+        // than the static map above. Cached on load so a saved job still renders
+        // a real name after a reload.
+        let dynamicModelLabels = {};
+        function modelLabelFromList(value) {
+            return dynamicModelLabels[value] || value;
+        }
 
         function prettyAgentLabel(name) {
             return name.replace(/_/g, ' ').replace(/\\b\\w/g, c => c.toUpperCase());
@@ -3953,8 +3969,12 @@ async def scheduled_jobs_page(user: User = Depends(engineer_or_admin_required)):
                 const data = await response.json();
                 const sel = document.getElementById('jobModel');
                 const models = data.models || [];
+                models.forEach(m => { if (m.label) dynamicModelLabels[m.value] = m.label; });
                 sel.innerHTML = models.map(m => {
-                    const label = MODEL_LABELS[m.value] || m.value;
+                    // m.label is sent for config-registered (OpenRouter) models,
+                    // which MODEL_LABELS below cannot know about; the static map
+                    // stays authoritative for the hardcoded ones.
+                    const label = MODEL_LABELS[m.value] || m.label || m.value;
                     const suffix = m.available ? '' : ' (No API Key)';
                     const disabled = m.available ? '' : 'disabled';
                     const title = m.reason ? ` title="${m.reason}"` : '';
@@ -4131,7 +4151,7 @@ async def scheduled_jobs_page(user: User = Depends(engineer_or_admin_required)):
             ensureOptionPresent(
                 document.getElementById('jobModel'),
                 job.llm_model,
-                MODEL_LABELS[job.llm_model] || job.llm_model
+                MODEL_LABELS[job.llm_model] || modelLabelFromList(job.llm_model)
             );
             document.getElementById('jobPrompt').value = job.prompt;
             document.getElementById('jobCron').value = job.cron_expression;

--- a/app/routers/unified_login.py
+++ b/app/routers/unified_login.py
@@ -45,6 +45,7 @@ from app.services.sso_origin import (
     resolve_sso_origin,
 )
 from app.services.user_service import get_user_by_username, hash_password
+from app.lib.cors_preflight import preflight_response
 
 logger = logging.getLogger(__name__)
 
@@ -259,6 +260,12 @@ def _login_page_with_error(mothership: MothershipClient, request: Request) -> HT
     else:
         html = html.replace("</body>", f'<div id="message">{banner}</div></body>')
     return HTMLResponse(content=html)
+
+
+@router.options("/auth/consume")
+async def auth_consume_preflight(request: Request):
+    """Answer the CORS preflight instead of 400ing it (see app/lib/cors_preflight)."""
+    return preflight_response(request)
 
 
 @router.get("/auth/consume")

--- a/app/services/mothership_client.py
+++ b/app/services/mothership_client.py
@@ -166,6 +166,7 @@ class MothershipClient:
         tool_call_id: Optional[str] = None,
         timings: Optional[dict] = None,
         user: Optional[dict] = None,
+        message_key: Optional[str] = None,
     ) -> Optional[dict]:
         """
         POST /api/leonardo/report_message
@@ -212,6 +213,11 @@ class MothershipClient:
                     payload["tool_call_id"] = tool_call_id
                 if timings:
                     payload["timings"] = timings
+                # Stable per-message key so feedback can join on identity rather than on
+                # comparing message bodies — a stream truncated by a dropped socket does
+                # not match and used to fabricate a placeholder row (annotation #688).
+                if message_key:
+                    payload["message_key"] = message_key
                 reported_user = self._resolve_user(user)
                 if reported_user:
                     payload["user"] = reported_user
@@ -245,6 +251,7 @@ class MothershipClient:
         sent_at: Optional[str] = None,
         debug_context: Optional[dict] = None,
         user: Optional[dict] = None,
+        message_key: Optional[str] = None,
     ) -> Optional[dict]:
         """
         POST /api/leonardo/submit_feedback
@@ -269,8 +276,16 @@ class MothershipClient:
                 }
                 if note:
                     payload["note"] = note
+                # Sent alongside the key, never instead of it: the mothership matched on
+                # exact text equality, so a stream truncated by a dropped socket matched
+                # nothing and fabricated a placeholder row (annotation #688). Kept so
+                # older mothership code keeps resolving messages the way it always did.
                 if content:
                     payload["content"] = content
+                # The stable join key. Omitted rather than sent as null — a null must not
+                # look like a real key the mothership can join on.
+                if message_key:
+                    payload["message_key"] = message_key
                 if sent_at:
                     payload["sent_at"] = sent_at
                 if debug_context:
@@ -295,6 +310,37 @@ class MothershipClient:
             return None
         except Exception as e:
             logger.warning(f"submit_feedback unexpected error: {e}")
+            return None
+
+    async def get_personal_cookbook(self) -> Optional[dict]:
+        """GET /api/leonardo/cookbook_recipes — the box OWNER's own recipes.
+
+        Every LlamaPress user has a personal cookbook of user-namespaced recipes published
+        from their own boxes, so a pattern built on one Leo is reusable on their others.
+        This returns the owner's list INCLUDING unlisted recipes, which the public
+        /cookbook/u/<handle>.json index deliberately omits.
+
+        `instance_name` goes as a QUERY PARAM: the mothership reads params[:instance_name]
+        on this GET, not a JSON body.
+
+        Returns None on anything unusual — no mothership config (local dev, ejected boxes),
+        a bad token, a network blip. Personal recipes enrich the slash menu; they must never
+        be able to empty it.
+        """
+        if not self.config.get("mothership_api_token") or not self.config.get("instance_name"):
+            return None
+
+        try:
+            async with httpx.AsyncClient(timeout=5.0) as client:
+                response = await client.get(
+                    f"{self.config['mothership_url']}/api/leonardo/cookbook_recipes",
+                    params={"instance_name": self.config["instance_name"]},
+                    headers={"Authorization": f"Bearer {self.config['mothership_api_token']}"},
+                )
+                response.raise_for_status()
+                return response.json()
+        except Exception as e:  # noqa: BLE001 - an enhancement must never break the menu
+            logger.warning(f"Could not fetch personal cookbook: {e}")
             return None
 
     async def check_paywall(self) -> Optional[dict]:

--- a/app/tests/js/batched_questions.test.mjs
+++ b/app/tests/js/batched_questions.test.mjs
@@ -1,4 +1,5 @@
-// Batched ask_user_question: 1-4 questions in one card, answered in one round-trip.
+// Batched ask_user_question: 1-4 questions in one card, answered one at a time in a
+// stepper, submitted in one round-trip.
 //
 // The properties worth pinning are the ones the AGENT depends on and that would rot
 // silently: that a batch answer maps each answer back to its question, that a
@@ -15,6 +16,8 @@ import {
   buildQuestionCardHtml,
   buildSubmission,
   isAnswered,
+  stepLabel,
+  stepperView,
   uiuxRequestDirective,
 } from '../../frontend/chat/messages/QuestionCard.js';
 
@@ -62,16 +65,40 @@ test('drops blank questions rather than rendering an empty block', () => {
 
 // ---------------------------------------------------------------- markup
 
-test('renders one block per question, numbered, in a batch', () => {
+test('renders one block per question but shows only the first', () => {
   const html = render([
     { question: 'Which pages?', options: ['All'], ui_related: false },
     { question: 'What style?', options: [], ui_related: true },
     { question: 'Send email?', options: ['Yes', 'No'], ui_related: false },
   ]);
+  // All three are in the DOM — that is what lets answers survive Back/Next...
   assert.equal(html.match(/class="plan-question-item"/g).length, 3);
   assert.match(html, /data-count="3"/);
   assert.match(html, /class="plan-question-card batched"/);
-  assert.match(html, /0 of 3 answered/);
+  // ...but the user only ever sees one, which is the whole point of the stepper.
+  assert.equal((html.match(/plan-question-item"[^>]*hidden/g) || []).length, 2);
+  assert.match(html, /data-question-text="Which pages\?"(?![^>]*hidden)/);
+  assert.match(html, /Question 1 of 3/);
+});
+
+test('the stepper chrome ships with the card: dots, Back, Next', () => {
+  const html = render([
+    { question: 'A?', options: [], ui_related: false },
+    { question: 'B?', options: [], ui_related: false },
+    { question: 'C?', options: [], ui_related: false },
+  ]);
+  // [ "] so the .plan-question-dots wrapper doesn't count as a dot.
+  assert.equal((html.match(/class="plan-question-dot[ "]/g) || []).length, 3);
+  assert.match(html, /data-di="2"/);
+  // Back is disabled rather than absent, so the footer doesn't reflow on step 1.
+  assert.match(html, /class="plan-back-btn" disabled/);
+  assert.match(html, /class="plan-continue-btn" disabled>Next/);
+});
+
+test('a single question gets no stepper chrome at all', () => {
+  const html = render([{ question: 'Which pages?', options: [], ui_related: false }]);
+  assert.doesNotMatch(html, /plan-question-dot|plan-back-btn|plan-question-step/);
+  assert.doesNotMatch(html, /hidden/, 'the only question is never paged away');
 });
 
 test('the visual-options chip is per-question, not per-card', () => {
@@ -202,4 +229,39 @@ test('Continue gating counts skips as answered', () => {
   assert.equal(isAnswered({ ...blank(), options: ['A'] }), true);
   assert.equal(isAnswered({ ...blank(), text: '  ' }), false, 'whitespace is not an answer');
   assert.equal(isAnswered({ ...blank(), text: 'x' }), true);
+});
+
+
+// ---------------------------------------------------------------- stepper
+
+test('the step label is 1-based', () => {
+  assert.equal(stepLabel(0, 3), 'Question 1 of 3');
+  assert.equal(stepLabel(2, 3), 'Question 3 of 3');
+});
+
+test('Next stays locked until the question on screen is answered', () => {
+  // This gate is what replaced "all N answered" on the old Continue: with the other
+  // questions off screen, the user can't see a blank one to notice it.
+  const states = [blank(), blank(), blank()];
+  assert.equal(stepperView(states, 0, 3).canAdvance, false);
+  states[0].options = ['All'];
+  assert.equal(stepperView(states, 0, 3).canAdvance, true);
+});
+
+test('a skip unlocks Next just like an answer does', () => {
+  const states = [{ ...blank(), skipped: true }, blank()];
+  assert.equal(stepperView(states, 0, 2).canAdvance, true);
+});
+
+test('Back is dead on the first question, and the last one is the submit step', () => {
+  const states = [blank(), blank(), blank()];
+  assert.equal(stepperView(states, 0, 3).canBack, false);
+  assert.equal(stepperView(states, 1, 3).canBack, true);
+  assert.equal(stepperView(states, 1, 3).isLast, false);
+  assert.equal(stepperView(states, 2, 3).isLast, true);
+});
+
+test('the view reports how many questions are answered, for the dots', () => {
+  const states = [{ ...blank(), options: ['A'] }, { ...blank(), skipped: true }, blank()];
+  assert.equal(stepperView(states, 2, 3).answered, 2);
 });

--- a/app/tests/js/cookbook_slash_command.test.mjs
+++ b/app/tests/js/cookbook_slash_command.test.mjs
@@ -294,3 +294,46 @@ test('recipes are fetched from the backend proxy, not llamapress.ai directly', a
   assert.deepEqual(urls, ['/api/cookbook']);
   assert.equal(manager.cookbookGuides.length, 3);
 });
+
+// ── Personal cookbook (0.7.5) ────────────────────────────────────────────────
+// Every LlamaPress user now has a personal cookbook of recipes published from their own
+// boxes. A recipe published on one Leo must be findable on their others, and be
+// distinguishable from a fleet guide at a glance.
+
+test('the owner\'s own recipes rank above fleet guides', () => {
+  const guides = [
+    { slug: 'fleet-toggle', title: 'Toggle', category: 'ui' },
+    { slug: 'my-toggle', title: 'Toggle', category: 'ui', personal: true },
+  ];
+
+  const filtered = filterCookbookGuides(guides, 'toggle');
+
+  assert.equal(filtered[0].slug, 'my-toggle', 'the user published this one for exactly this');
+});
+
+test('personal recipes lead the list even with no query typed', () => {
+  const guides = [
+    { slug: 'fleet-a', title: 'A' },
+    { slug: 'mine', title: 'B', personal: true },
+  ];
+
+  assert.equal(filterCookbookGuides(guides, '')[0].slug, 'mine');
+});
+
+test('a personal recipe still loses to a better fleet match', () => {
+  // Ownership breaks ties; it does not override relevance being wrong.
+  const guides = [
+    { slug: 'mine', title: 'Something else', category: 'pdf', personal: true },
+    { slug: 'fleet-pdf', title: 'PDF export', category: 'docs' },
+  ];
+
+  assert.equal(filterCookbookGuides(guides, 'pdf')[0].slug, 'fleet-pdf');
+});
+
+test('the mention URL mechanics are unchanged for a personal recipe', () => {
+  // .json and .md both exist under /cookbook/u/<handle>/<slug>, so nothing special needed.
+  const guide = { slug: 'glow-toggle', title: 'Glow', personal: true,
+                  url: 'https://llamapress.ai/cookbook/u/kody/glow-toggle' };
+
+  assert.equal(cookbookJsonUrl(guide), 'https://llamapress.ai/cookbook/u/kody/glow-toggle.json');
+});

--- a/app/tests/js/dynamic_model_options.test.mjs
+++ b/app/tests/js/dynamic_model_options.test.mjs
@@ -1,0 +1,106 @@
+// Config-registered models need a dropdown <option> the markup can't contain (0.7.5).
+//
+// OpenRouter entries live in a host-mounted JSON file, so chat.html cannot know
+// their names — but the availability pass in fetchAvailableModels() only ever
+// walks options that ALREADY exist. Without a creation step the backend would
+// offer a model the dropdown could never show, and setModel() on it would
+// silently no-op, leaving the user on the previous model with no error.
+//
+// The rule under test: an option is created for every backend model carrying a
+// `label`, and for no others — `label` is the backend saying "I am config-driven".
+// A hardcoded model missing from the markup is a build error, and inventing an
+// option for it at runtime would paper over genuine frontend/backend skew.
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { readFileSync } from 'node:fs';
+
+const APP_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const INDEX_JS = readFileSync(resolve(APP_ROOT, 'frontend', 'chat', 'index.js'), 'utf8');
+
+/**
+ * addMissingModelOptions as index.js defines it, against a minimal <select>.
+ * Exercised in isolation because importing index.js pulls in the whole app.
+ */
+function makeSelect(existingValues) {
+  const options = existingValues.map(v => ({ value: v, dataset: {}, textContent: v }));
+  return {
+    options,
+    appendChild: (o) => options.push(o),
+  };
+}
+
+function addMissingModelOptions(select, models) {
+  // Mirrors the method body; `document.createElement` is stubbed to a plain object.
+  const existing = new Set(Array.from(select.options).map(o => o.value));
+  models.forEach(m => {
+    if (!m.label || existing.has(m.value)) return;
+    const option = { value: m.value, dataset: {}, textContent: '' };
+    option.value = m.value;
+    option.textContent = m.label;
+    if (m.short_label) option.dataset.shortLabel = m.short_label;
+    select.appendChild(option);
+    existing.add(m.value);
+  });
+}
+
+test('a labelled model absent from the markup gets an option', () => {
+  const select = makeSelect(['deepseek-v4-flash']);
+  addMissingModelOptions(select, [
+    { value: 'deepseek-flash-0731-relace', label: 'DeepSeek V4 Flash 0731 (Relace fp4)', short_label: 'DS 0731 Relace' },
+  ]);
+  const added = select.options.find(o => o.value === 'deepseek-flash-0731-relace');
+  assert.ok(added, 'the config-registered model never reached the dropdown');
+  assert.equal(added.textContent, 'DeepSeek V4 Flash 0731 (Relace fp4)');
+  assert.equal(added.dataset.shortLabel, 'DS 0731 Relace');
+});
+
+test('a model already in the markup is left alone', () => {
+  // Duplicating it would give the user two entries for one model, and the
+  // availability pass would then only mark one of them.
+  const select = makeSelect(['deepseek-v4-flash']);
+  addMissingModelOptions(select, [{ value: 'deepseek-v4-flash', label: 'Renamed' }]);
+  assert.equal(select.options.length, 1);
+  assert.equal(select.options[0].textContent, 'deepseek-v4-flash', 'existing markup stays authoritative');
+});
+
+test('a model with no label is never invented', () => {
+  // Hardcoded models ship no label. One missing from the markup is real skew and
+  // must stay visible as such, not be silently patched over at runtime.
+  const select = makeSelect(['deepseek-v4-flash']);
+  addMissingModelOptions(select, [{ value: 'gpt-5-codex' }]);
+  assert.equal(select.options.length, 1);
+});
+
+test('a model with no short_label still gets an option', () => {
+  const select = makeSelect([]);
+  addMissingModelOptions(select, [{ value: 'x', label: 'X Model' }]);
+  assert.equal(select.options.length, 1);
+  assert.equal(select.options[0].dataset.shortLabel, undefined);
+});
+
+test('duplicates within one payload are added once', () => {
+  const select = makeSelect([]);
+  addMissingModelOptions(select, [
+    { value: 'x', label: 'X' },
+    { value: 'x', label: 'X again' },
+  ]);
+  assert.equal(select.options.length, 1);
+});
+
+test('options are created BEFORE the availability pass', () => {
+  // Order matters: the availability loop walks existing options only, so a
+  // model created after it would never be greyed out when its key is missing.
+  const creationAt = INDEX_JS.indexOf('this.addMissingModelOptions(data.models');
+  const availabilityAt = INDEX_JS.indexOf('const modelAvailability = new Map(');
+  assert.ok(creationAt > 0, 'addMissingModelOptions is not called from the fetch');
+  assert.ok(availabilityAt > 0, 'availability map not found');
+  assert.ok(creationAt < availabilityAt, 'options must be created before availability is applied');
+});
+
+test('the method guards a missing select', () => {
+  // fetchAvailableModels runs on pages where the dropdown may not be mounted.
+  assert.match(INDEX_JS, /addMissingModelOptions\(models\) \{\s*\n\s*const select = this\.elements\.modelSelect;\s*\n\s*if \(!select\) return;/);
+});

--- a/app/tests/js/model_substitution_notice.test.mjs
+++ b/app/tests/js/model_substitution_notice.test.mjs
@@ -45,7 +45,7 @@ test('the swap frame has its own branch, above the transcript fallback', () => {
   const branchAt = MESSAGE_HANDLER.indexOf("data.type === 'model_substituted'");
   const fallbackAt = MESSAGE_HANDLER.indexOf('this.handleGenericMessage(data)');
   assert.ok(branchAt < fallbackAt, 'the frame must be handled before the generic fallback');
-  assert.match(MESSAGE_HANDLER, /showModelSubstitutionNotice\(data\.requested, data\.effective\)/);
+  assert.match(MESSAGE_HANDLER, /showModelSubstitutionNotice\(data\.requested, data\.effective, data\.reason\)/);
 });
 
 test('the notice renders above the composer, not as a corner toast', () => {
@@ -56,18 +56,18 @@ test('the notice renders above the composer, not as a corner toast', () => {
   const bannerAt = CHAT_HTML.indexOf('data-llamabot="model-switch-banner"');
   const inputAt = CHAT_HTML.indexOf('data-llamabot="message-input"');
   assert.ok(bannerAt < inputAt, 'the banner must sit above the message input');
-  assert.match(INDEX_JS, /showModelSubstitutionNotice\(requested, effective\)/);
+  assert.match(INDEX_JS, /showModelSubstitutionNotice\(requested, effective, reason\)/);
 });
 
 test('the notice names both models, and says which one is answering', () => {
-  const start = INDEX_JS.indexOf('showModelSubstitutionNotice(requested, effective)');
+  const start = INDEX_JS.indexOf('showModelSubstitutionNotice(requested, effective, reason)');
   const body = INDEX_JS.slice(start, start + 1200);
   assert.match(body, /modelLabel\(requested\)/);
   assert.match(body, /modelLabel\(effective\)/);
 });
 
 test('the notice clears itself, and a second one restarts the clock', () => {
-  const start = INDEX_JS.indexOf('showModelSubstitutionNotice(requested, effective)');
+  const start = INDEX_JS.indexOf('showModelSubstitutionNotice(requested, effective, reason)');
   const body = INDEX_JS.slice(start, start + 1200);
   assert.match(body, /clearTimeout\(this\.modelSwitchNoticeTimer\)/,
     'a repeat notice must not be hidden early by the previous timer');
@@ -96,4 +96,33 @@ test('a frontend-side swap raises the same notice as a backend one', () => {
 test('a manual pick is still persisted', () => {
   // Guard the fix from over-correcting into "we never save the model".
   assert.match(INDEX_JS, /setCookie\('llmModel', e\.target\.value, this\.config\.cookieExpiryDays\)/);
+});
+
+
+// --- 0.7.5: the same frame now also reports a mid-turn failure fallback -----
+//
+// When a provider accepts the request and then streams nothing, the resilience
+// ladder finishes the step on another model (DynamicModelMiddleware rung 2). It
+// reuses `model_substituted` rather than inventing a frame — but a user reads
+// "isn't enabled on this instance" as a permissions problem, which is the wrong
+// explanation for a provider outage. `reason` is what keeps the two apart.
+
+test('a mid-turn fallback is worded as an outage, not as a policy block', () => {
+  const start = INDEX_JS.indexOf('showModelSubstitutionNotice(requested, effective, reason)');
+  const body = INDEX_JS.slice(start, start + 1600);
+  assert.match(body, /reason === 'fallback'/,
+    'both swaps would otherwise get the "not enabled on this instance" wording');
+  assert.match(body, /stopped responding/);
+  assert.match(body, /isn't enabled on this instance/,
+    'the policy wording must survive — it is still the common case');
+});
+
+test('a swap with no reason still renders (older backends, frontend repair)', () => {
+  // fetchAvailableModels' own repair calls this with two arguments, and a box
+  // running an older image sends the frame without the field. Neither may throw
+  // or render "undefined" at the user.
+  const start = INDEX_JS.indexOf('showModelSubstitutionNotice(requested, effective, reason)');
+  const body = INDEX_JS.slice(start, start + 1600);
+  assert.match(body, /reason === 'fallback'\s*\n?\s*\?/,
+    'must be a ternary defaulting to the policy wording, not an if/else on truthiness');
 });

--- a/app/tests/js/stream_resume_after_reconnect.test.mjs
+++ b/app/tests/js/stream_resume_after_reconnect.test.mjs
@@ -1,0 +1,155 @@
+// A dropped socket must not leave the customer reading a truncated answer (0.7.5).
+//
+// rsb-dev, 2026-08-28, thread 1787943690689-qzr1efuar: the socket died mid-run, the server
+// kept streaming into a socket nobody read, and the chunks that arrived AFTER the reconnect
+// were appended to a fresh bubble. The customer saw an answer starting mid-sentence —
+// exactly the last 435 chars of a complete 906-char reply, the first 471 lost. The work was
+// correct and fully persisted server-side; only their VIEW broke, and they had no way to
+// know. 45 of the 57 boxes that can report this have hit it (78.9%).
+//
+// The rule under test: on reconnect while a run was in flight, re-sync the in-flight bubble
+// against the server instead of appending live chunks to a gap.
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { readFileSync } from 'node:fs';
+
+import {
+  shouldResumeAfterReconnect,
+  pickAuthoritativeMessage,
+  nextResumeGeneration,
+  isStaleResume,
+} from '../../frontend/chat/websocket/StreamResume.js';
+
+const APP_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const WS_MANAGER = readFileSync(
+  resolve(APP_ROOT, 'frontend', 'chat', 'websocket', 'WebSocketManager.js'), 'utf8');
+const RENDERER = readFileSync(
+  resolve(APP_ROOT, 'frontend', 'chat', 'messages', 'MessageRenderer.js'), 'utf8');
+const INDEX_JS = readFileSync(resolve(APP_ROOT, 'frontend', 'chat', 'index.js'), 'utf8');
+
+// The real numbers from the incident.
+const FULL = 'A'.repeat(471) + ' updates from the server.\n- Pagination stays in-frame.';
+const PARTIAL = FULL.slice(471);
+
+test('resumes when the socket dropped while a run was in flight', () => {
+  assert.equal(shouldResumeAfterReconnect({ wasRunInFlight: true, threadId: 't1' }), true);
+});
+
+test('does not resume when no run was in flight', () => {
+  // An idle reconnect must not refetch and repaint the thread under the user.
+  assert.equal(shouldResumeAfterReconnect({ wasRunInFlight: false, threadId: 't1' }), false);
+});
+
+test('does not resume without a thread to resume into', () => {
+  assert.equal(shouldResumeAfterReconnect({ wasRunInFlight: true, threadId: null }), false);
+});
+
+test('picks the server message that the partial text is the tail of', () => {
+  // This is the incident's own signature: full.end_with?(frag) was true at offset 471.
+  const messages = [
+    { type: 'human', content: 'fix the column sort' },
+    { type: 'ai', content: 'an earlier unrelated answer' },
+    { type: 'ai', content: FULL },
+  ];
+
+  const picked = pickAuthoritativeMessage(messages, { partialText: PARTIAL });
+
+  assert.equal(picked, FULL);
+  assert.ok(picked.length > PARTIAL.length, 'must recover the lost head, not keep the tail');
+});
+
+test('falls back to the last assistant message when nothing matches the fragment', () => {
+  // The fragment can be unmatchable — a chunk boundary mid-token, or markdown the renderer
+  // rewrote. The last assistant message is still strictly better than a mid-sentence bubble.
+  const messages = [
+    { type: 'ai', content: 'older' },
+    { type: 'ai', content: 'the newest complete answer' },
+  ];
+
+  assert.equal(
+    pickAuthoritativeMessage(messages, { partialText: 'nothing like this' }),
+    'the newest complete answer',
+  );
+});
+
+test('ignores tool and human messages when choosing the answer', () => {
+  const messages = [
+    { type: 'ai', content: 'the answer' },
+    { type: 'tool', content: 'tool output that must never be rendered as Leo speaking' },
+    { type: 'human', content: 'continue' },
+  ];
+
+  assert.equal(pickAuthoritativeMessage(messages, { partialText: '' }), 'the answer');
+});
+
+test('returns null rather than guessing when there is no assistant message', () => {
+  assert.equal(pickAuthoritativeMessage([{ type: 'human', content: 'hi' }], {}), null);
+  assert.equal(pickAuthoritativeMessage([], {}), null);
+  assert.equal(pickAuthoritativeMessage(null, {}), null);
+});
+
+test('a late resume from a superseded generation is discarded', () => {
+  // The fetch is async and chunks may still be arriving. Without this, a slow response
+  // from an older reconnect can overwrite a newer, correct render.
+  const gen = nextResumeGeneration(0);
+  const newer = nextResumeGeneration(gen);
+
+  assert.equal(isStaleResume(gen, newer), true, 'older generation must be dropped');
+  assert.equal(isStaleResume(newer, newer), false, 'current generation must apply');
+});
+
+test('resume is wired into the reconnect path, not just defined', () => {
+  assert.match(WS_MANAGER, /StreamResume/,
+    'WebSocketManager must use the resume module on reconnect');
+});
+
+test('the ActionCable close path no longer dead-ends', () => {
+  // handleClose() disabled the send button and then returned early for ActionCable, so
+  // nothing re-enabled it and reconnect_attempts stayed 0 forever — a dead gauge that
+  // told the last investigation the client never even tried.
+  // Anchor on the METHOD DEFINITION, not the `this.scheduleReconnect()` call site above it.
+  const defIndex = WS_MANAGER.indexOf('\n  scheduleReconnect(');
+  assert.ok(defIndex !== -1, 'scheduleReconnect() should still exist');
+  const body = WS_MANAGER.slice(defIndex, defIndex + 600);
+
+  assert.doesNotMatch(
+    body,
+    /if \(this\.isActionCable\) \{\s*return;\s*\}/,
+    'the bare ActionCable early return is what left the UI stuck with input disabled',
+  );
+  assert.match(WS_MANAGER, /noteReconnect/,
+    'reconnect attempts must be counted on every transport, or the instrument lies');
+});
+
+test('the resume rewrites the existing bubble instead of adding a second one', () => {
+  // Appending would leave the truncated bubble on screen above the corrected one, which
+  // reads as Leo answering twice — worse than the bug.
+  assert.match(RENDERER, /replaceLastAiMessage\(content\)/);
+  assert.match(RENDERER, /bubbles\[bubbles\.length - 1\]/,
+    'must target the newest assistant bubble');
+  assert.match(RENDERER, /if \(target\.getAttribute\('data-raw-content'\) === content\) return true;/,
+    'a second resume with the same text must be a no-op');
+});
+
+test('resuming clears the streaming buffers so late chunks cannot re-truncate', () => {
+  const fn = INDEX_JS.slice(INDEX_JS.indexOf('replaceStreamingMessage(content)'));
+  assert.match(fn.slice(0, 300), /streamingState\?\.reset\?\.\(\)/,
+    'a chunk arriving after the resume would otherwise append onto the corrected text');
+});
+
+test('the thinking indicator is cleared on resync', () => {
+  // It kept spinning after the drop in the incident, which is what made the customer
+  // believe Leo had died and reload the page.
+  const fn = WS_MANAGER.slice(WS_MANAGER.indexOf('async resumeInFlightRun()'));
+  assert.match(fn.slice(0, 1200), /hideThinkingIndicator/);
+});
+
+test('an idle reconnect does not repaint the thread', () => {
+  // Anchor on the definition, not the `this.handleOpen()` call sites above it.
+  const fn = WS_MANAGER.slice(WS_MANAGER.indexOf('\n  handleOpen() {'));
+  assert.match(fn.slice(0, 900), /if \(this\.runWasInFlightAtClose\)/,
+    'resume must be gated on a run actually having been in flight');
+});

--- a/app/tests/js/vision_model_follows_server.test.mjs
+++ b/app/tests/js/vision_model_follows_server.test.mjs
@@ -1,0 +1,84 @@
+// The image auto-switch target is box-dependent (0.7.5).
+//
+// Until now `index.js` hardcoded `const IMAGE_MODEL = 'muse-spark-1.2-contributor'`,
+// so on a box with no META key the auto-switch had nowhere to go: attaching an
+// image hit the "no image-capable model is configured" refusal even after
+// DeepSeek gained a vision model that box could run on the key it already had.
+//
+// The rule under test: the target FOLLOWS the server's `vision_model` — the same
+// contract `default_model` already has — and nothing in the frontend names the
+// vision model as a general default, so the two can no longer drift apart.
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { readFileSync } from 'node:fs';
+
+const APP_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const INDEX_JS = readFileSync(resolve(APP_ROOT, 'frontend', 'chat', 'index.js'), 'utf8');
+const CHAT_HTML = readFileSync(resolve(APP_ROOT, 'frontend', 'chat.html'), 'utf8');
+
+const MUSE = 'muse-spark-1.2-contributor';
+const DS_VISION = 'deepseek-v4-flash-vision-exp';
+
+/** The auto-switch block, sliced out so assertions can't match elsewhere. */
+const autoSwitchBlock = INDEX_JS.slice(
+  INDEX_JS.indexOf('--- Auto-switch model when an image is attached'),
+  INDEX_JS.indexOf('--- end auto-switch ---'),
+);
+
+test('the auto-switch block was actually found', () => {
+  // Guard the slice itself — a rename would make every assertion below vacuous.
+  assert.ok(autoSwitchBlock.length > 200, 'auto-switch block not found in index.js');
+});
+
+test('the switch target comes from the backend, not a constant', () => {
+  assert.match(INDEX_JS, /this\.visionModel = data\.vision_model/);
+  assert.match(autoSwitchBlock, /this\.visionModel/);
+  assert.doesNotMatch(
+    autoSwitchBlock,
+    /['"]muse-spark-1\.2-contributor['"]/,
+    'the auto-switch must not name a model id — it is box-dependent',
+  );
+});
+
+test('an empty vision_model is preserved, not replaced by the legacy default', () => {
+  // `??`, never `||`: "" is the backend saying this box has NO vision model, and
+  // `||` would quietly hand it Muse, putting an image in front of a model the
+  // box has no key for (401 on every send).
+  assert.match(INDEX_JS, /data\.vision_model \?\? LEGACY_IMAGE_MODEL/);
+  assert.doesNotMatch(INDEX_JS, /data\.vision_model \|\| /);
+});
+
+test('an older backend that omits the field keeps the pre-0.7.5 behaviour', () => {
+  assert.match(INDEX_JS, /LEGACY_IMAGE_MODEL = 'muse-spark-1\.2-contributor'/);
+  // ...and it is only ever a skew fallback, never the general default: the two
+  // uses are the fetch fallback and the send-path guard.
+  assert.equal(
+    (INDEX_JS.match(/LEGACY_IMAGE_MODEL/g) || []).length,
+    3,
+    'declaration + fetch fallback + send-path guard',
+  );
+});
+
+test('the switch notice names the model the user is actually moved to', () => {
+  // Was a hardcoded IMAGE_MODEL_LABEL string, which would now lie on a DeepSeek
+  // box. modelLabel() reads the label off the dropdown option instead.
+  assert.doesNotMatch(INDEX_JS, /IMAGE_MODEL_LABEL/);
+  assert.match(autoSwitchBlock, /this\.modelLabel\(imageModel\)/);
+});
+
+test('the vision model is offered in the dropdown so the switch has an option', () => {
+  // setModel() drives the <select>; a target with no <option> silently no-ops.
+  const block = CHAT_HTML.split('data-llamabot="model-select"')[1].split('</select>')[0];
+  assert.ok(block.includes(`value="${DS_VISION}"`), `${DS_VISION} missing from the dropdown`);
+  assert.ok(block.includes(`value="${MUSE}"`), `${MUSE} missing from the dropdown`);
+});
+
+test('a disabled target still refuses instead of sending', () => {
+  // The refusal path is what stops an image reaching a text-only model and
+  // 400ing mid-stream as a stack trace in the user's face.
+  assert.match(autoSwitchBlock, /imageModelAvailable/);
+  assert.match(autoSwitchBlock, /this\.refuseImageAttachment\(\)/);
+});

--- a/app/tests/js/vision_model_unavailable.test.mjs
+++ b/app/tests/js/vision_model_unavailable.test.mjs
@@ -53,11 +53,16 @@ test('the operator vision switch still wins on a Muse box', () => {
   assert.equal(visionUsable(false, true), false);
 });
 
-test('the auto-switch target is Muse, not gpt-5-nano', () => {
-  assert.match(INDEX_JS, /const IMAGE_MODEL = 'muse-spark-1\.2-contributor'/);
+test('the auto-switch target is a backend-resolved vision model, not gpt-5-nano', () => {
+  // 0.7.5: the target stopped being a constant (it is Muse on a META-keyed box,
+  // DeepSeek's vision model on a DeepSeek-only one), so what is pinned here is
+  // that it comes from the backend at all — see vision_model_follows_server for
+  // the full contract. The gpt-5-nano guard survives unchanged: whatever the
+  // target is, it must never be a model outside the enabled set.
+  assert.match(INDEX_JS, /this\.visionModel = data\.vision_model/);
   assert.doesNotMatch(
     INDEX_JS,
-    /const IMAGE_MODEL = 'gpt-5-nano'/,
+    /IMAGE_MODEL = 'gpt-5-nano'/,
     'gpt-5-nano is out of the default enabled set — switching to it would land on a disabled model',
   );
 });
@@ -68,7 +73,10 @@ test('the switch toast names the model the user is actually moved to', () => {
     /I switched to GPT-5 Nano/,
     'the toast must not name a model we no longer switch to',
   );
-  assert.match(INDEX_JS, /IMAGE_MODEL_LABEL/);
+  // Was the IMAGE_MODEL_LABEL constant; since the target is box-dependent, a
+  // constant label would name the wrong model on a DeepSeek box. modelLabel()
+  // reads it off the dropdown option actually being switched to.
+  assert.match(INDEX_JS, /this\.modelLabel\(imageModel\)/);
 });
 
 test('an unavailable image model refuses the send instead of falling through', () => {

--- a/app/tests/test_bad_request_parameters.py
+++ b/app/tests/test_bad_request_parameters.py
@@ -1,0 +1,103 @@
+"""A rejected model request must say what we actually sent (0.7.5, P1-3).
+
+Fleet telemetry, 7 days: 33 BadRequestError rows, which the 2026-08-25 follow-up split into
+three genuinely different conditions that had been counted as one:
+
+  * 15 (9 boxes)  "The request contains invalid parameters. Check the request body..."
+                  — the real P1-3. The provider names no `param`, so the message alone is
+                  useless and we log nothing about the request we sent.
+  * 8  (3 boxes)  "This model's maximum context length is 1048576 tokens..." — the 1M
+                  ceiling, not a bad request at all.
+  * 10            "`messages` must contain at least one message with role `user` or `tool`"
+                  — malformed history, which is P1-4's class and already handled.
+
+0.7.4 added log_bad_request_shape(), but it describes the MESSAGES. "Invalid parameters" is
+about the request PARAMETERS — temperature, max_tokens, tool_choice, response_format — and
+those were never recorded. This adds them, redacted, and classifies the three shapes so the
+mothership stops averaging three different bugs together.
+"""
+import pytest
+
+from app.agents.leonardo.message_invariants import (
+    classify_bad_request,
+    redact_request_params,
+)
+
+
+class _Boom(Exception):
+    def __init__(self, message):
+        super().__init__(message)
+        self.status_code = 400
+
+
+INVALID_PARAMS = "The request contains invalid parameters. Check the request body and try again."
+CONTEXT_LEN = (
+    "This model's maximum context length is 1048576 tokens. However, you requested 1048669 tokens."
+)
+BAD_HISTORY = "`messages` must contain at least one message with role `user` or `tool`"
+
+
+def test_invalid_parameters_is_its_own_class():
+    assert classify_bad_request(_Boom(INVALID_PARAMS)) == "invalid_parameters"
+
+
+def test_context_length_is_not_reported_as_a_bad_request():
+    """It is the 1M ceiling. Counting it as P1-3 is what made P1-3 look bigger than it is."""
+    assert classify_bad_request(_Boom(CONTEXT_LEN)) == "context_length_exceeded"
+
+
+def test_malformed_history_is_attributed_to_the_repair_path():
+    assert classify_bad_request(_Boom(BAD_HISTORY)) == "malformed_history"
+
+
+def test_an_unrecognised_400_is_labelled_unknown_not_guessed():
+    assert classify_bad_request(_Boom("something new from a provider")) == "unknown"
+
+
+def test_request_params_are_recorded_because_the_provider_names_none():
+    params = redact_request_params({
+        "temperature": 0.7,
+        "max_tokens": 4096,
+        "tool_choice": "auto",
+        "response_format": {"type": "json_object"},
+        "top_p": 1,
+    })
+
+    assert params["temperature"] == 0.7
+    assert params["max_tokens"] == 4096
+    assert params["tool_choice"] == "auto"
+    assert params["response_format"] == {"type": "json_object"}
+
+
+def test_credentials_never_reach_the_log():
+    """This payload goes to the mothership; a key in it would be a disclosure, not a clue."""
+    params = redact_request_params({
+        "api_key": "sk-live-abcdef123456",
+        "temperature": 0.2,
+        "default_headers": {"Authorization": "Bearer sk-live-abcdef123456"},
+        "base_url": "https://api.provider.example/v1",
+    })
+
+    flat = repr(params)
+    assert "sk-live-abcdef123456" not in flat
+    assert params["temperature"] == 0.2
+    # The base_url is diagnostic (it says WHICH gateway rejected us) and carries no secret.
+    assert params["base_url"] == "https://api.provider.example/v1"
+
+
+def test_message_bodies_are_not_copied_into_the_params_blob():
+    """The message shape is logged separately; duplicating content here risks user data."""
+    params = redact_request_params({
+        "messages": [{"role": "user", "content": "my private business plan"}],
+        "temperature": 0.1,
+    })
+
+    assert "my private business plan" not in repr(params)
+
+
+def test_unknown_keys_are_kept_but_values_are_bounded():
+    """A future provider parameter should still show up — that is the whole point."""
+    params = redact_request_params({"some_new_flag": "x" * 5000})
+
+    assert "some_new_flag" in params
+    assert len(str(params["some_new_flag"])) <= 512

--- a/app/tests/test_feedback_message_key.py
+++ b/app/tests/test_feedback_message_key.py
@@ -1,0 +1,102 @@
+"""Feedback must identify the rated message by a key, not by comparing its text.
+
+Mothership annotation #688 (rsb-dev, 2026-08-28): the chat socket dropped mid-run, so the
+browser held only the last 435 characters of a complete 906-character answer. The thumbs-down
+sent that DOM text as `content`, and the mothership's resolve_feedback_message matches on
+exact string equality — it matched nothing, fell through to build_placeholder_message, and
+CREATED a new instance_messages row from the partial text. The annotation now points at a
+fabricated fragment with no model, no tokens and no tool calls, while the real message shows
+as unrated.
+
+17 of 424 end-user annotations in the last 30 days (4%) landed on such a row, and the bias is
+not random: a broken stream is precisely what causes the mismatch. We are systematically
+losing the feedback on our worst runs.
+
+The fix is a stable key on the assistant turn, sent by BOTH report_message and
+submit_feedback, so the mothership can join exactly. `content` keeps being sent so older
+mothership code goes on working.
+"""
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services.mothership_client import MothershipClient
+
+
+def _client():
+    client = MothershipClient()
+    client.config = {
+        "instance_name": "leo-test",
+        "mothership_url": "https://llamapress.ai",
+        "mothership_api_token": "token",
+    }
+    return client
+
+
+def _captured_payload(mock_post):
+    assert mock_post.await_count == 1, "expected exactly one POST"
+    return mock_post.await_args.kwargs["json"]
+
+
+@pytest.fixture
+def post_ok():
+    response = MagicMock()
+    response.raise_for_status = MagicMock()
+    response.json = MagicMock(return_value={"ok": True})
+
+    with patch("httpx.AsyncClient") as ac:
+        instance = ac.return_value.__aenter__.return_value
+        instance.post = AsyncMock(return_value=response)
+        yield instance.post
+
+
+def test_report_message_sends_the_message_key(post_ok):
+    client = _client()
+    with patch.object(MothershipClient, "reporting_enabled", True):
+        asyncio.run(client.report_message(
+            thread_id="t1",
+            role="assistant",
+            content="the full 906 char answer",
+            sent_at="2026-08-28T19:07:56Z",
+            message_key="msg-abc123",
+        ))
+
+    assert _captured_payload(post_ok)["message_key"] == "msg-abc123"
+
+
+def test_submit_feedback_sends_the_same_key(post_ok):
+    client = _client()
+    with patch.object(MothershipClient, "reporting_enabled", True):
+        asyncio.run(client.submit_feedback(
+            thread_id="t1",
+            rating="bad",
+            content="…the truncated 435 char tail",
+            message_key="msg-abc123",
+        ))
+
+    payload = _captured_payload(post_ok)
+    assert payload["message_key"] == "msg-abc123"
+
+
+def test_content_is_still_sent_so_older_mothership_code_keeps_working(post_ok):
+    client = _client()
+    with patch.object(MothershipClient, "reporting_enabled", True):
+        asyncio.run(client.submit_feedback(
+            thread_id="t1",
+            rating="bad",
+            content="…the truncated 435 char tail",
+            message_key="msg-abc123",
+        ))
+
+    payload = _captured_payload(post_ok)
+    assert payload["content"] == "…the truncated 435 char tail"
+
+
+def test_key_is_omitted_when_absent_rather_than_sent_as_null(post_ok):
+    """A null key must not look like a real key the mothership can join on."""
+    client = _client()
+    with patch.object(MothershipClient, "reporting_enabled", True):
+        asyncio.run(client.submit_feedback(thread_id="t1", rating="good"))
+
+    assert "message_key" not in _captured_payload(post_ok)

--- a/app/tests/test_frontend_dynamic_model_options_js.py
+++ b/app/tests/test_frontend_dynamic_model_options_js.py
@@ -1,0 +1,28 @@
+"""Run the Node tests for config-registered dropdown options (0.7.5).
+
+Without this wrapper the .mjs suite never runs in CI — the pipeline only invokes
+node through these pytest shims, and the --experimental-default-type=module flag
+is load-bearing on the container's node 18.
+"""
+
+import subprocess
+from pathlib import Path
+
+
+def test_dynamic_model_options_node_suite():
+    app_root = Path(__file__).resolve().parents[1]
+    result = subprocess.run(
+        [
+            "node",
+            "--experimental-default-type=module",
+            "--test",
+            "tests/js/dynamic_model_options.test.mjs",
+        ],
+        cwd=app_root,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode == 0, f"{result.stdout}\n{result.stderr}"

--- a/app/tests/test_frontend_model_substitution_notice_js.py
+++ b/app/tests/test_frontend_model_substitution_notice_js.py
@@ -1,0 +1,32 @@
+"""Run the Node tests for the model-swap banner.
+
+The .mjs suite has existed since 0.7.0 but never had one of these shims, so it
+has never run in CI — the pipeline only invokes node through these pytest
+wrappers. Added with the 0.7.5 change that gives the frame a `reason`, which is
+exactly the kind of signature change the suite is there to catch.
+
+The --experimental-default-type=module flag is load-bearing on the container's
+node 18 (it otherwise reads the imported .js sources as CommonJS).
+"""
+
+import subprocess
+from pathlib import Path
+
+
+def test_model_substitution_notice_node_suite():
+    app_root = Path(__file__).resolve().parents[1]
+    result = subprocess.run(
+        [
+            "node",
+            "--experimental-default-type=module",
+            "--test",
+            "tests/js/model_substitution_notice.test.mjs",
+        ],
+        cwd=app_root,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode == 0, f"{result.stdout}\n{result.stderr}"

--- a/app/tests/test_frontend_stream_resume_js.py
+++ b/app/tests/test_frontend_stream_resume_js.py
@@ -1,0 +1,29 @@
+"""Run the Node tests for stream resume after a reconnect (0.7.5).
+
+Without this wrapper the .mjs suite never runs in CI — the pipeline only invokes node
+through these pytest shims, and --experimental-default-type=module is load-bearing on the
+container's node 18 (it otherwise reads the imported .js sources as CommonJS and every
+named import fails).
+"""
+
+import subprocess
+from pathlib import Path
+
+
+def test_stream_resume_node_suite():
+    app_root = Path(__file__).resolve().parents[1]
+    result = subprocess.run(
+        [
+            "node",
+            "--experimental-default-type=module",
+            "--test",
+            "tests/js/stream_resume_after_reconnect.test.mjs",
+        ],
+        cwd=app_root,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode == 0, f"{result.stdout}\n{result.stderr}"

--- a/app/tests/test_frontend_vision_model_follows_server_js.py
+++ b/app/tests/test_frontend_vision_model_follows_server_js.py
@@ -1,0 +1,29 @@
+"""Run the Node tests for the box-resolved image auto-switch target (0.7.5).
+
+Without this wrapper the .mjs suite never runs in CI — the pipeline only invokes
+node through these pytest shims, and the --experimental-default-type=module flag
+is load-bearing on the container's node 18 (it otherwise reads the imported .js
+sources as CommonJS and every named import fails).
+"""
+
+import subprocess
+from pathlib import Path
+
+
+def test_vision_model_follows_server_node_suite():
+    app_root = Path(__file__).resolve().parents[1]
+    result = subprocess.run(
+        [
+            "node",
+            "--experimental-default-type=module",
+            "--test",
+            "tests/js/vision_model_follows_server.test.mjs",
+        ],
+        cwd=app_root,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode == 0, f"{result.stdout}\n{result.stderr}"

--- a/app/tests/test_llm_factory_retry_ownership.py
+++ b/app/tests/test_llm_factory_retry_ownership.py
@@ -89,7 +89,7 @@ def test_fireworks_deepseek_routes_to_fireworks_endpoint_and_key(monkeypatch):
 
     assert captured["api_base"] == "https://api.fireworks.ai/inference/v1"
     assert captured["api_key"] == "fw-test-key"
-    assert captured["model"] == "accounts/fireworks/models/deepseek-v4-flash"
+    assert captured["model"] == "accounts/fireworks/models/deepseek-v4-flash-0731"
 
 
 def test_deepseek_direct_does_not_point_at_third_party(monkeypatch):

--- a/app/tests/test_login_preflight.py
+++ b/app/tests/test_login_preflight.py
@@ -66,8 +66,15 @@ def test_preflight_grants_nothing_on_its_own(client, path):
 
 
 @pytest.mark.parametrize("path", ["/auth/consume", "/login"])
-def test_get_still_rejects_a_bad_token(client, path):
-    """Answering OPTIONS must not loosen the GET."""
+def test_get_still_rejects_a_bad_token(client, path, monkeypatch):
+    """Answering OPTIONS must not loosen the GET.
+
+    The secret is set explicitly: without it, GET /login short-circuits to 503
+    ("magic-link sign-in not configured") before the token is ever verified, which
+    passes on a configured dev box and fails in CI without testing anything.
+    """
+    monkeypatch.setenv("LLAMAPRESS_AI_LOGIN_SECRET", "test-secret-not-a-real-one")
+
     response = client.get(f"{path}?token=not-a-real-token", follow_redirects=False)
 
     assert response.status_code != 204

--- a/app/tests/test_login_preflight.py
+++ b/app/tests/test_login_preflight.py
@@ -1,0 +1,74 @@
+"""A CORS preflight on a login entry point must not 400.
+
+Mothership incident, leo-nefe 2026-08-06 (Rich Rayl, paying, live on a call): the browser
+sent `OPTIONS /auth/consume?token=...` before following the login URL, LlamaBot answered
+400, no GET ever followed, and the one-time grant expired unused. He burned 7 grants in an
+afternoon. The user saw nothing and neither did the logs.
+
+Cause: CORSMiddleware is configured same-origin-only (allow_origins=[]), which is correct,
+so it does not answer the preflight; the request falls through to a router where only GET
+is declared, and FastAPI rejects the method. The same shape ate logins on the legacy HMAC
+`/login` path too, for a long time.
+
+The mothership shipped the primary fix (no cross-origin redirect at all). This is the
+belt-and-braces half: a preflight that still happens — a bookmark, an embed, another tool
+opening the link — must not hard-fail.
+"""
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+PREFLIGHT_HEADERS = {
+    "Origin": "https://llamapress.ai",
+    "Access-Control-Request-Method": "GET",
+}
+
+
+@pytest.mark.parametrize("path", ["/auth/consume", "/login"])
+def test_preflight_is_answered_not_rejected(client, path):
+    response = client.options(path, headers=PREFLIGHT_HEADERS)
+
+    assert response.status_code == 204, (
+        f"OPTIONS {path} returned {response.status_code}; a browser treats a failed "
+        "preflight as a hard failure and abandons the login with no error and no log line."
+    )
+
+
+@pytest.mark.parametrize("path", ["/auth/consume", "/login"])
+def test_preflight_echoes_the_requesting_origin(client, path):
+    response = client.options(path, headers=PREFLIGHT_HEADERS)
+
+    assert response.headers.get("access-control-allow-origin") == "https://llamapress.ai"
+    assert response.headers.get("access-control-allow-credentials") == "true"
+    assert "GET" in response.headers.get("access-control-allow-methods", "")
+
+
+@pytest.mark.parametrize("path", ["/auth/consume", "/login"])
+def test_preflight_grants_nothing_on_its_own(client, path):
+    """The preflight answer must stay a preflight answer.
+
+    It carries no data and performs no login; every real check still happens on the GET.
+    A 204 that also set a session cookie would turn this belt-and-braces fix into an
+    authentication bypass.
+    """
+    response = client.options(path, headers=PREFLIGHT_HEADERS)
+
+    assert response.status_code == 204
+    assert not response.content
+    assert "set-cookie" not in {k.lower() for k in response.headers}
+
+
+@pytest.mark.parametrize("path", ["/auth/consume", "/login"])
+def test_get_still_rejects_a_bad_token(client, path):
+    """Answering OPTIONS must not loosen the GET."""
+    response = client.get(f"{path}?token=not-a-real-token", follow_redirects=False)
+
+    assert response.status_code != 204
+    assert response.status_code < 500

--- a/app/tests/test_model_policy.py
+++ b/app/tests/test_model_policy.py
@@ -233,20 +233,30 @@ def test_switching_locked_pins_default_only(monkeypatch):
 def test_switching_locked_with_vision_off_closes_the_vision_model(monkeypatch):
     """Only observable on a box whose vision model differs from its default.
 
-    Since 0.7.0 the vision model IS the default (both Muse), so on a META-keyed
-    box the vision clause never decides anything. A box with no META key is where
-    they diverge — default deepseek, vision model Muse — and there the clause is
-    exactly what the VISION_MODEL_ALLOWED gate controls.
+    Since 0.7.0 the vision model IS the default on a META-keyed box (both Muse),
+    so there the vision clause never decides anything. A box with no META key is
+    where they diverge — default deepseek-v4-flash, vision model DeepSeek's
+    vision sibling since 0.7.5 — and there the clause is exactly what the
+    VISION_MODEL_ALLOWED gate controls.
+
+    Asserts on ``vision_model()``, not the ``VISION_MODEL`` constant: since 0.7.5
+    the constant is only the PREFERRED vision model, while the clause under test
+    gates whichever one this box can actually build.
     """
     monkeypatch.delenv("META_API_KEY", raising=False)
     monkeypatch.delenv("MODEL_API_KEY", raising=False)
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "test-key")
     monkeypatch.setenv("MODEL_SWITCHING_ALLOWED", "false")
+    box_vision_model = model_policy.vision_model()
+    assert box_vision_model != model_policy.default_text_model(), (
+        "this test is vacuous unless the box's vision model differs from its default"
+    )
 
     monkeypatch.setenv("VISION_MODEL_ALLOWED", "false")
-    assert model_policy.is_model_enabled(model_policy.VISION_MODEL) is False
+    assert model_policy.is_model_enabled(box_vision_model) is False
 
     monkeypatch.setenv("VISION_MODEL_ALLOWED", "true")
-    assert model_policy.is_model_enabled(model_policy.VISION_MODEL) is True
+    assert model_policy.is_model_enabled(box_vision_model) is True
 
 
 def test_switching_locked_keeps_vision_model_when_vision_on(monkeypatch):
@@ -255,7 +265,7 @@ def test_switching_locked_keeps_vision_model_when_vision_on(monkeypatch):
     monkeypatch.setenv("MODEL_SWITCHING_ALLOWED", "false")
     monkeypatch.setenv("VISION_MODEL_ALLOWED", "true")
     assert model_policy.is_model_enabled(DEFAULT_LLM_MODEL) is True
-    assert model_policy.is_model_enabled(model_policy.VISION_MODEL) is True
+    assert model_policy.is_model_enabled(model_policy.vision_model()) is True
     # ...but no other model opens up.
     assert model_policy.is_model_enabled("gpt-5-codex") is False
 

--- a/app/tests/test_model_registry_consistency.py
+++ b/app/tests/test_model_registry_consistency.py
@@ -23,6 +23,24 @@ from app.agents.leonardo.model_capabilities import MODEL_CAPABILITIES
 from app.agents.leonardo.model_policy import _KNOWN_MODELS
 
 
+def _model_dispatch_source(llm_factory) -> str:
+    """The source text where get_llm decides which client to build.
+
+    Both halves, because 0.7.5 split construction into ``_build_client`` so the
+    stall guard (``_apply_stream_chunk_timeout``) could be applied in ONE place
+    instead of at eleven ``ChatOpenAI(`` call sites. The policy gate stayed in
+    ``get_llm``; the per-model branches moved. These structural guards care about
+    the dispatch, not about which of the two functions currently holds it.
+    """
+    import inspect
+
+    return inspect.getsource(llm_factory.get_llm) + inspect.getsource(
+        llm_factory._build_client
+    )
+
+
+
+
 CHAT_HTML = Path(__file__).resolve().parents[1] / "frontend" / "chat.html"
 
 
@@ -112,7 +130,7 @@ def test_dropdown_model_builds_a_real_client(model, monkeypatch):
 
     from app.agents.leonardo import llm_factory
 
-    src = inspect.getsource(llm_factory.get_llm)
+    src = _model_dispatch_source(llm_factory)
     # The subscription models are dispatched as a set membership test rather than
     # one `==` branch each, because they share a single credential-backed client.
     dispatched = (
@@ -161,7 +179,7 @@ def test_luna_builds_an_openai_client_with_the_exact_api_id(monkeypatch):
 
     from app.agents.leonardo import llm_factory
 
-    src = inspect.getsource(llm_factory.get_llm)
+    src = _model_dispatch_source(llm_factory)
     branch = src.split(f'model_name == "{LUNA}"', 1)[1].split("if model_name ==", 1)[0]
     assert 'model="gpt-5.6-luna"' in branch
     assert 'model="gpt-5.6"' not in branch, "the bare gpt-5.6 alias routes to Sol, not Luna"
@@ -208,7 +226,7 @@ def test_muse_builds_an_openai_compatible_client_against_the_meta_endpoint():
 
     from app.agents.leonardo import llm_factory
 
-    src = inspect.getsource(llm_factory.get_llm)
+    src = _model_dispatch_source(llm_factory)
     branch = src.split(f'model_name == "{MUSE}"', 1)[1].split("if model_name ==", 1)[0]
     assert "ChatOpenAI(" in branch
     assert "https://api.meta.ai/v1" in branch
@@ -226,7 +244,7 @@ def test_muse_pins_the_contributor_tier_id():
 
     from app.agents.leonardo import llm_factory
 
-    src = inspect.getsource(llm_factory.get_llm)
+    src = _model_dispatch_source(llm_factory)
     branch = src.split(f'model_name == "{MUSE}"', 1)[1].split("if model_name ==", 1)[0]
     assert '"muse-spark-1.2-contributor"' in branch
 
@@ -300,7 +318,7 @@ def test_muse_contributor_tier_stays_escapable():
 
     from app.agents.leonardo import llm_factory
 
-    src = inspect.getsource(llm_factory.get_llm)
+    src = _model_dispatch_source(llm_factory)
     branch = src.split(f'model_name == "{MUSE}"', 1)[1]
     assert 'os.getenv("META_MUSE_MODEL"' in branch, (
         "the model id must stay overridable per box, or a compliance box has no "
@@ -379,7 +397,7 @@ def test_runpod_qwen_pod_url_is_never_hardcoded():
 
     from app.agents.leonardo import llm_factory
 
-    src = inspect.getsource(llm_factory.get_llm)
+    src = _model_dispatch_source(llm_factory)
     branch = src.split(f'model_name == "{RUNPOD_QWEN}"', 1)[1].split("if model_name ==", 1)[0]
     assert 'os.getenv("RUNPOD_QWEN_BASE_URL")' in branch
     assert "proxy.runpod.net" not in branch, "the pod URL must not be committed"
@@ -493,7 +511,7 @@ def test_glimmer_pod_url_is_never_hardcoded():
 
     from app.agents.leonardo import llm_factory
 
-    src = inspect.getsource(llm_factory.get_llm)
+    src = _model_dispatch_source(llm_factory)
     branch = src.split(f'model_name == "{GLIMMER}"', 1)[1].split("if model_name ==", 1)[0]
     assert 'os.getenv("RUNPOD_GLIMMER_BASE_URL")' in branch
     assert "proxy.runpod.net" not in branch, "the pod URL must not be committed"
@@ -633,7 +651,7 @@ def test_nemotron_pod_url_is_never_hardcoded():
 
     from app.agents.leonardo import llm_factory
 
-    src = inspect.getsource(llm_factory.get_llm)
+    src = _model_dispatch_source(llm_factory)
     branch = src.split(f'model_name == "{NEMOTRON}"', 1)[1].split("if model_name ==", 1)[0]
     assert 'os.getenv("RUNPOD_NEMOTRON_BASE_URL")' in branch
     assert "proxy.runpod.net" not in branch, "the pod URL must not be committed"
@@ -836,3 +854,150 @@ def test_nemotron_fw_is_not_the_fleet_default():
     from app.agents.leonardo.llm_factory import DEFAULT_LLM_MODEL
 
     assert NEMOTRON_FW != DEFAULT_LLM_MODEL
+
+
+# --------------------------------------------------------------------------
+# DeepSeek V4 Flash Vision (experimental) — 0.7.5
+# --------------------------------------------------------------------------
+
+DS_VISION = "deepseek-v4-flash-vision-exp"
+
+
+def test_ds_vision_is_offered_in_the_dropdown():
+    assert DS_VISION in _dropdown_models()
+
+
+def test_ds_vision_supports_images_only():
+    """Images yes; no video, and PDFs only via DeepSeek's separate Files API,
+    which we don't use — so declaring pdf:True would send a `file` block the
+    chat-completions endpoint rejects."""
+    assert MODEL_CAPABILITIES[DS_VISION] == {
+        "images": True, "video": False, "pdf": False,
+    }
+
+
+def test_ds_vision_is_the_only_deepseek_entry_with_vision():
+    """The text entries must stay text-only. DeepSeek 400s an image sent to them
+    ("This model does not support image"), and MODEL_CAPABILITIES is what stops
+    the frontend offering the upload and the stripper leaving it in history."""
+    for text_model in (
+        "deepseek-v4-flash",
+        "deepseek-v4-pro",
+        "deepseek-v4-flash-gmi",
+        "deepseek-v4-flash-fireworks",
+    ):
+        assert MODEL_CAPABILITIES[text_model]["images"] is False
+
+
+def test_ds_vision_uses_the_deepseek_key():
+    assert DS_VISION in _api_key_map()
+    assert _api_key_map()[DS_VISION] is True
+
+
+def test_ds_vision_is_known_to_the_policy():
+    assert DS_VISION in _KNOWN_MODELS
+
+
+def test_ds_vision_builds_a_reasoning_client_with_the_exact_api_id():
+    """The client must be ChatDeepSeekWithReasoning, not a bare ChatDeepSeek:
+    the model streams reasoning_content deltas like its text siblings (verified
+    live), and a plain client drops the thinking on the floor."""
+    import inspect
+
+    from app.agents.leonardo import llm_factory
+
+    src = _model_dispatch_source(llm_factory)
+    branch = src.split(f'model_name == "{DS_VISION}"', 1)[1].split("if model_name ==", 1)[0]
+    assert f'model="{DS_VISION}"' in branch
+    assert "ChatDeepSeekWithReasoning(" in branch
+
+
+def test_ds_vision_goes_to_deepseek_direct_not_a_reseller():
+    """No api_base override — it is only on DeepSeek's own API, unlike the text
+    model, which has GMI and Fireworks siblings."""
+    import inspect
+
+    from app.agents.leonardo import llm_factory
+
+    src = _model_dispatch_source(llm_factory)
+    branch = src.split(f'model_name == "{DS_VISION}"', 1)[1].split("if model_name ==", 1)[0]
+    assert "api_base" not in branch
+
+
+def test_ds_vision_is_covered_by_the_deepseek_reasoning_middleware():
+    """DeepSeek direct is the strict one about assistant messages carrying
+    reasoning_content. The middleware used to gate on the literal string
+    "deepseek-v4-flash", which silently skipped every other direct model —
+    including v4-pro, which shipped that way for several releases."""
+    from app.agents.leonardo.llm_factory import DEEPSEEK_DIRECT_MODELS
+
+    assert DS_VISION in DEEPSEEK_DIRECT_MODELS
+    assert "deepseek-v4-pro" in DEEPSEEK_DIRECT_MODELS
+    # The resellers must NOT be in it: they reject nothing, and injecting an
+    # empty reasoning_content there would be a pointless message rewrite.
+    assert "deepseek-v4-flash-gmi" not in DEEPSEEK_DIRECT_MODELS
+    assert "deepseek-v4-flash-fireworks" not in DEEPSEEK_DIRECT_MODELS
+
+
+def test_ds_vision_is_not_the_fleet_default():
+    """Adding an option must not change what the fleet actually runs."""
+    from app.agents.leonardo.llm_factory import DEFAULT_LLM_MODEL, FALLBACK_TEXT_MODEL
+
+    assert DS_VISION != DEFAULT_LLM_MODEL
+    assert DS_VISION != FALLBACK_TEXT_MODEL
+
+
+# --------------------------------------------------------------------------
+# Qwen3.8 27B (Hetzner Inference API)
+# --------------------------------------------------------------------------
+
+HETZNER_QWEN = "qwen3.8-27b-hetzner"
+
+
+def test_hetzner_qwen_is_offered_in_the_dropdown():
+    assert HETZNER_QWEN in _dropdown_models()
+
+
+def test_hetzner_qwen_supports_images_but_not_video_or_pdf():
+    """Hetzner's published model table lists this one as Text + Image."""
+    assert MODEL_CAPABILITIES[HETZNER_QWEN] == {
+        "images": True,
+        "video": False,
+        "pdf": False,
+    }
+
+
+def test_hetzner_qwen_uses_the_hetzner_key():
+    assert HETZNER_QWEN in _api_key_map()
+
+
+def test_hetzner_qwen_is_known_to_the_policy():
+    assert HETZNER_QWEN in _KNOWN_MODELS
+
+
+def test_hetzner_qwen_builds_an_openai_compatible_client_against_hetzner():
+    """OpenAI-compatible gateway, so ChatOpenAI + a base_url.
+
+    The base_url is NOT optional: without it ChatOpenAI silently talks to
+    api.openai.com, which has never heard of `Qwen3.8-27B`.
+    """
+    from app.agents.leonardo import llm_factory
+
+    src = _model_dispatch_source(llm_factory)
+    branch = src.split(f'model_name == "{HETZNER_QWEN}"', 1)[1].split(
+        "if model_name ==", 1
+    )[0]
+    assert "ChatOpenAI(" in branch
+    assert "https://inference.hetzner.com/api/v1" in branch
+    assert '"Qwen3.8-27B"' in branch
+
+
+def test_hetzner_qwen_is_not_the_default_model():
+    """Adding an option must not change what the fleet actually runs.
+
+    Especially this one: the Hetzner API is free/experimental and rate limited
+    to 10 requests per minute per key, which one agentic turn can exhaust.
+    """
+    from app.agents.leonardo.llm_factory import DEFAULT_LLM_MODEL
+
+    assert HETZNER_QWEN != DEFAULT_LLM_MODEL

--- a/app/tests/test_model_stall_resilience.py
+++ b/app/tests/test_model_stall_resilience.py
@@ -1,0 +1,694 @@
+"""A model that accepts the request and then sends nothing must not eat the turn.
+
+The 2026-08-26 incident (rsb-dev, Muse Spark): the endpoint returned HTTP 200 and
+then produced zero streaming chunks. ``langchain_openai``'s *default* 120s
+``stream_chunk_timeout`` fired, rung 1 classified it transient — correctly — and
+retried the same stalled endpoint. Five attempts x 120s = ~10 minutes of a spinning
+shimmer, and the customer's only report was "it runs for like 10 minutes with no
+changes". A 503 on the same classifier retries in a second and is invisible; the
+zero-chunk variant cost 120s per attempt. Same rung, wildly different user impact.
+
+Three things were missing, and these tests pin all three:
+
+  1. **A wall-clock cap.** The retry *count* was fine; nobody sized the budget
+     against an attempt that costs two minutes.
+  2. **Rung 2.** There was nowhere else to go — ``with_fallbacks`` appears nowhere
+     in ``app/``, so Leo retried the one endpoint that was down.
+  3. **Any sign of life.** A retry was completely silent.
+
+Assertions here are about structure and bounds, never about wording or timing on
+the runner: real sleeps are driven to tiny monkeypatched budgets so the mechanism
+is what is measured, and the *sizing* is asserted as arithmetic.
+"""
+
+import asyncio
+import time
+
+import pytest
+
+from app.agents.leonardo.rails_agent import middleware as mw
+
+
+# ---------------------------------------------------------------------------
+# Doubles
+# ---------------------------------------------------------------------------
+
+class _Model:
+    """Enough of a chat model that _override/bind_tools downstream still work."""
+
+    def __init__(self, name):
+        self.name = name
+
+    def bind_tools(self, *a, **k):
+        return self
+
+
+class _Req:
+    """Records which model each override selected, in order."""
+
+    def __init__(self, model_name="muse-spark-1.2-contributor", messages=None):
+        self.state = {"llm_model": model_name}
+        self.model = None
+        self.messages = messages or []
+        self.selected = []
+
+    def override(self, **kw):
+        model = kw.get("model")
+        if model is not None:
+            self.model = model
+            self.selected.append(getattr(model, "name", model))
+        return self
+
+
+class _Image:
+    """A user message carrying an image block, the way the websocket builds one."""
+
+    content = [
+        {"type": "text", "text": "what is in this screenshot?"},
+        {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}},
+    ]
+
+
+def _stall(model="muse-spark-1.2-contributor"):
+    """The exact exception langchain_openai raises for a zero-chunk stream.
+
+    A ``TimeoutError`` subclass, so ``is_transient_error`` classifies it transient
+    — which is correct and deliberately not what this ticket changes.
+    """
+    return TimeoutError(
+        f"No streaming chunk received for 25.0s (model={model}, chunks_received=0)."
+    )
+
+
+@pytest.fixture
+def no_backoff(monkeypatch):
+    """Retry immediately — the backoff is not what any of this is measuring.
+
+    Zeroes the *delay* rather than patching ``time.sleep``/``asyncio.sleep``.
+    Those are global, so patching them also silences the deliberate stall inside
+    the test handlers, and the clock the budget reads never advances.
+    """
+    monkeypatch.setattr(mw, "_model_retry_delay", lambda attempt: 0)
+
+
+@pytest.fixture
+def models_build(monkeypatch):
+    monkeypatch.setattr(mw, "get_llm", lambda name: _Model(name))
+
+
+@pytest.fixture
+def no_fallback(monkeypatch):
+    """A box where rung 2 has nowhere to go, so rung 1's bound is what shows."""
+    monkeypatch.setattr(mw, "fallback_model", lambda *a, **k: None)
+
+
+# ---------------------------------------------------------------------------
+# Acceptance 1 — a stalled model is abandoned on a wall clock, not a counter
+# ---------------------------------------------------------------------------
+
+def test_the_retry_budget_is_sized_against_a_stalling_attempt():
+    """The arithmetic that was never done.
+
+    ``_MODEL_RETRY_MAX_ATTEMPTS`` alone bounds nothing useful: multiplied by the
+    cost of a *stalling* attempt it is ten minutes. The budget has to be the thing
+    that binds, and the worst case (budget already spent, one attempt still in
+    flight) has to land under the 90s the incident review asked for.
+    """
+    from app.agents.leonardo.llm_factory import stream_chunk_timeout_s
+    from app.agents.leonardo.resilience import (
+        _MODEL_RETRY_MAX_ATTEMPTS,
+        _MODEL_RETRY_MAX_TOTAL_SECONDS,
+    )
+
+    attempt_cost = stream_chunk_timeout_s()
+    assert _MODEL_RETRY_MAX_ATTEMPTS * attempt_cost > _MODEL_RETRY_MAX_TOTAL_SECONDS, (
+        "the attempt counter still bounds the loop before the clock does, which is "
+        "the bug: five stalling attempts is ~10 minutes of silence"
+    )
+    assert _MODEL_RETRY_MAX_TOTAL_SECONDS + attempt_cost <= 90, (
+        "worst case is the budget plus the attempt that was in flight when it ran "
+        "out; that total is what the user actually sits through"
+    )
+
+
+def test_the_chunk_timeout_is_chosen_not_inherited():
+    """120s was ``langchain_openai``'s default, not a decision anyone made.
+
+    Not disabled, either — a disabled chunk timeout is how a turn hangs forever.
+    """
+    from app.agents.leonardo.llm_factory import stream_chunk_timeout_s
+
+    value = stream_chunk_timeout_s()
+    assert value is not None and value > 0, "a disabled chunk timeout hangs forever"
+    assert value <= 30, "no healthy first chunk takes this long; 120s is the bug"
+
+
+def test_the_chunk_timeout_is_overridable(monkeypatch):
+    monkeypatch.setenv("LANGCHAIN_OPENAI_STREAM_CHUNK_TIMEOUT_S", "7.5")
+    from app.agents.leonardo.llm_factory import stream_chunk_timeout_s
+
+    assert stream_chunk_timeout_s() == 7.5
+
+
+def test_every_built_client_carries_the_chunk_timeout(monkeypatch):
+    """Applied centrally, and NOT left to the environment.
+
+    ``langchain_openai`` reads the same env var itself, so "just set it in the
+    container" looks like a fix — until you meet a box whose .env nobody edited,
+    which is every box in the fleet. With the var unset the library's answer is
+    120.0; ours has to be the one that ships. There are 11 ``ChatOpenAI(`` call
+    sites in llm_factory, so this is applied in one place, not eleven.
+    """
+    monkeypatch.delenv("LANGCHAIN_OPENAI_STREAM_CHUNK_TIMEOUT_S", raising=False)
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "test-key-not-a-real-credential")
+    from app.agents.leonardo.llm_factory import get_llm, stream_chunk_timeout_s
+
+    client = get_llm("deepseek-v4-flash")
+    assert client.stream_chunk_timeout == stream_chunk_timeout_s()
+    assert client.stream_chunk_timeout != 120.0, "still the inherited default"
+
+
+def test_an_operator_override_reaches_the_client(monkeypatch):
+    monkeypatch.setenv("LANGCHAIN_OPENAI_STREAM_CHUNK_TIMEOUT_S", "9")
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "test-key-not-a-real-credential")
+    from app.agents.leonardo.llm_factory import get_llm
+
+    assert get_llm("deepseek-v4-flash").stream_chunk_timeout == 9.0
+
+
+def test_a_stalling_model_is_abandoned_before_the_attempt_cap(
+    monkeypatch, models_build, no_fallback
+):
+    """The behavioural half: the loop stops on the clock, with attempts to spare.
+
+    Real time, a tiny budget — the mechanism is what is under test, and the size
+    of the real budget is pinned arithmetically above.
+    """
+    monkeypatch.setattr(mw, "_MODEL_RETRY_MAX_TOTAL_SECONDS", 0.05)
+    monkeypatch.setattr(mw, "_model_retry_delay", lambda attempt: 0)
+
+    calls = {"n": 0}
+
+    def handler(req):
+        calls["n"] += 1
+        time.sleep(0.03)        # a stalling attempt: it costs real wall clock
+        raise _stall()
+
+    with pytest.raises(TimeoutError):
+        mw.DynamicModelMiddleware().wrap_model_call(_Req(), handler)
+
+    assert calls["n"] < mw._MODEL_RETRY_MAX_ATTEMPTS, (
+        f"burned the whole attempt budget ({calls['n']} calls) — the wall clock "
+        "never got a vote, which is the ~600s incident"
+    )
+
+
+def test_a_stalling_model_is_abandoned_before_the_attempt_cap_async(
+    monkeypatch, models_build, no_fallback
+):
+    """Same bound on the websocket path, which is where customers actually are."""
+    monkeypatch.setattr(mw, "_MODEL_RETRY_MAX_TOTAL_SECONDS", 0.05)
+    monkeypatch.setattr(mw, "_model_retry_delay", lambda attempt: 0)
+
+    calls = {"n": 0}
+
+    async def handler(req):
+        calls["n"] += 1
+        await asyncio.sleep(0.03)
+        raise _stall()
+
+    with pytest.raises(TimeoutError):
+        asyncio.run(mw.DynamicModelMiddleware().awrap_model_call(_Req(), handler))
+
+    assert calls["n"] < mw._MODEL_RETRY_MAX_ATTEMPTS
+
+
+def test_the_raw_node_ladder_is_bounded_too(monkeypatch):
+    """``invoke_with_transient_retry`` is the same rung for agents that never
+    touch the middleware (beginner, ai_builder). It had the same missing cap."""
+    from app.agents.leonardo import resilience
+
+    monkeypatch.setattr(resilience, "_MODEL_RETRY_MAX_TOTAL_SECONDS", 0.05)
+    monkeypatch.setattr(resilience, "_model_retry_delay", lambda attempt: 0)
+
+    calls = {"n": 0}
+
+    def fn():
+        calls["n"] += 1
+        time.sleep(0.03)
+        raise _stall()
+
+    with pytest.raises(TimeoutError):
+        resilience.invoke_with_transient_retry(fn, label="test")
+
+    assert calls["n"] < resilience._MODEL_RETRY_MAX_ATTEMPTS
+
+
+# ---------------------------------------------------------------------------
+# Acceptance 2 + 3 — rung 2, resolved from policy
+# ---------------------------------------------------------------------------
+
+def test_the_turn_completes_on_the_fallback_model(monkeypatch, models_build, no_backoff):
+    """The whole point: a stalled primary must not end the turn."""
+    monkeypatch.setattr(mw, "fallback_model", lambda *a, **k: "deepseek-v4-flash")
+
+    req = _Req("muse-spark-1.2-contributor")
+
+    def handler(r):
+        if r.model.name == "muse-spark-1.2-contributor":
+            raise _stall()
+        return "answered"
+
+    assert mw.DynamicModelMiddleware().wrap_model_call(req, handler) == "answered"
+    assert req.selected[0] == "muse-spark-1.2-contributor"
+    assert req.selected[-1] == "deepseek-v4-flash"
+
+
+def test_the_turn_completes_on_the_fallback_model_async(
+    monkeypatch, models_build, no_backoff
+):
+    monkeypatch.setattr(mw, "fallback_model", lambda *a, **k: "deepseek-v4-flash")
+
+    req = _Req("muse-spark-1.2-contributor")
+
+    async def handler(r):
+        if r.model.name == "muse-spark-1.2-contributor":
+            raise _stall()
+        return "answered"
+
+    out = asyncio.run(mw.DynamicModelMiddleware().awrap_model_call(req, handler))
+    assert out == "answered"
+    assert req.selected[-1] == "deepseek-v4-flash"
+
+
+def test_the_fallback_is_tried_once_and_then_the_turn_fails(
+    monkeypatch, models_build, no_backoff
+):
+    """Escalation stays inside one turn and does not walk the whole registry.
+
+    Without a cap the resolver hands back the box default, whose own fallback is
+    the primary again — an endless loop between two dead endpoints.
+    """
+    monkeypatch.setattr(mw, "_MODEL_RETRY_MAX_TOTAL_SECONDS", 0.01)
+    seen = []
+
+    def _resolver(primary, **kw):
+        seen.append(primary)
+        return {"muse-spark-1.2-contributor": "deepseek-v4-flash"}.get(
+            primary, "muse-spark-1.2-contributor"
+        )
+
+    monkeypatch.setattr(mw, "fallback_model", _resolver)
+
+    def handler(r):
+        raise _stall()
+
+    with pytest.raises(TimeoutError):
+        mw.DynamicModelMiddleware().wrap_model_call(_Req(), handler)
+
+    assert len(seen) == 1, f"escalated more than one rung: {seen}"
+
+
+def test_a_deterministic_error_never_reaches_the_fallback(
+    monkeypatch, models_build, no_backoff
+):
+    """Rung 2 is for a provider that is down, not for a request we got wrong.
+
+    A 400 fails identically everywhere; sending it to a second provider only buys
+    a second 400 and another 25 seconds. ``is_transient_error`` stays untouched —
+    this is the behaviour that depends on it.
+    """
+    monkeypatch.setattr(mw, "fallback_model", lambda *a, **k: "deepseek-v4-flash")
+    calls = {"n": 0}
+
+    def handler(r):
+        calls["n"] += 1
+        raise TypeError("unexpected keyword argument 'cache_control'")
+
+    with pytest.raises(TypeError):
+        mw.DynamicModelMiddleware().wrap_model_call(_Req(), handler)
+
+    assert calls["n"] == 1
+
+
+def test_the_middleware_asks_policy_for_the_fallback():
+    """Structural guard, same one ``test_no_agent_hardcodes_a_fallback_model``
+    exists for: a literal model id here reintroduces the 0.7.0 bug where the
+    fleet default was silently ignored."""
+    import inspect
+
+    src = inspect.getsource(mw)
+    assert "fallback_model(" in src
+    assert "from app.agents.leonardo.model_policy import" in src or hasattr(
+        mw, "fallback_model"
+    )
+
+
+@pytest.fixture
+def a_two_model_box(monkeypatch):
+    """A box that can build both fail-open models and has no operator overrides.
+
+    Every knob is pinned, not merely deleted: MODEL_SWITCHING_ALLOWED in
+    particular is left set by other suites, and when it is off the policy pins
+    the box to its single default — which reads here as "the fallback resolver is
+    broken" rather than "the environment leaked".
+    """
+    from app.agents.leonardo import model_policy
+
+    monkeypatch.setenv("META_API_KEY", "test-key-not-a-real-credential")
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "test-key-not-a-real-credential")
+    monkeypatch.setenv("MODEL_SWITCHING_ALLOWED", "true")
+    monkeypatch.delenv("ENABLED_MODELS", raising=False)
+    monkeypatch.delenv("DISABLED_MODELS", raising=False)
+    monkeypatch.setattr(model_policy, "_read_instance_config", lambda: None)
+    return model_policy
+
+
+def test_the_fallback_is_a_different_enabled_model(a_two_model_box):
+    model_policy = a_two_model_box
+
+    chosen = model_policy.fallback_model("muse-spark-1.2-contributor")
+    assert chosen == "deepseek-v4-flash"
+    assert model_policy.is_model_enabled(chosen)
+
+
+def test_the_fallback_is_never_the_model_that_just_stalled(monkeypatch):
+    from app.agents.leonardo import model_policy
+
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "test-key-not-a-real-credential")
+    monkeypatch.setenv("MODEL_SWITCHING_ALLOWED", "true")
+    monkeypatch.delenv("META_API_KEY", raising=False)
+    monkeypatch.delenv("MODEL_API_KEY", raising=False)
+    monkeypatch.delenv("ENABLED_MODELS", raising=False)
+    monkeypatch.delenv("DISABLED_MODELS", raising=False)
+    monkeypatch.setattr(model_policy, "_read_instance_config", lambda: None)
+
+    # DeepSeek is the box default here, so the naive "fall back to the default"
+    # answer would hand back the endpoint that just failed.
+    assert model_policy.fallback_model("deepseek-v4-flash") != "deepseek-v4-flash"
+
+
+def test_there_is_no_fallback_when_policy_leaves_nothing_to_fall_back_to(monkeypatch):
+    """A box pinned to one model has no rung 2, and must say so rather than
+    inventing a model ``get_llm`` would only substitute straight back."""
+    from app.agents.leonardo import model_policy
+
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "test-key-not-a-real-credential")
+    monkeypatch.setenv("MODEL_SWITCHING_ALLOWED", "false")
+    monkeypatch.delenv("META_API_KEY", raising=False)
+    monkeypatch.delenv("MODEL_API_KEY", raising=False)
+    monkeypatch.setattr(model_policy, "_read_instance_config", lambda: None)
+
+    assert model_policy.fallback_model("deepseek-v4-flash") is None
+
+
+def test_an_image_turn_never_falls_back_to_a_model_that_cannot_see(monkeypatch):
+    """The vision routing rule survives the fallback. Falling back to a blind
+    model answers the question about the screenshot without the screenshot."""
+    from app.agents.leonardo import model_capabilities, model_policy
+
+    monkeypatch.setenv("META_API_KEY", "test-key-not-a-real-credential")
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "test-key-not-a-real-credential")
+    monkeypatch.setenv("VISION_MODEL_ALLOWED", "true")
+    monkeypatch.setenv("MODEL_SWITCHING_ALLOWED", "true")
+    monkeypatch.delenv("ENABLED_MODELS", raising=False)
+    monkeypatch.delenv("DISABLED_MODELS", raising=False)
+    monkeypatch.setattr(model_policy, "_read_instance_config", lambda: None)
+
+    chosen = model_policy.fallback_model(
+        "muse-spark-1.2-contributor", needs_vision=True
+    )
+    if chosen is not None:
+        assert model_capabilities.get_model_capabilities(chosen).get("images") is True
+
+
+def test_an_image_request_asks_for_a_vision_fallback(monkeypatch, models_build, no_backoff):
+    """And the middleware actually notices the image on the request."""
+    asked = {}
+
+    def _resolver(primary, **kw):
+        asked.update(kw)
+        return None
+
+    monkeypatch.setattr(mw, "fallback_model", _resolver)
+
+    def handler(r):
+        raise _stall()
+
+    with pytest.raises(TimeoutError):
+        mw.DynamicModelMiddleware().wrap_model_call(
+            _Req(messages=[_Image()]), handler
+        )
+
+    assert asked.get("needs_vision") is True
+
+
+def test_a_real_langchain_image_message_is_recognised():
+    """Not just the hand-rolled double above.
+
+    LangChain normalizes ``image_url`` to ``image`` in ``content_blocks``, so a
+    detector that only knows one of the two spellings silently answers "no image
+    here" and lets rung 2 pick a model that cannot see.
+    """
+    from langchain_core.messages import HumanMessage
+
+    request = _Req(
+        messages=[
+            HumanMessage(
+                content=[
+                    {"type": "text", "text": "what is in this screenshot?"},
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": "data:image/png;base64,AAAA"},
+                    },
+                ]
+            )
+        ]
+    )
+    assert mw._request_carries_an_image(request) is True
+    assert mw._request_carries_an_image(_Req(messages=[HumanMessage("plain text")])) is False
+
+
+def test_a_text_request_does_not_ask_for_a_vision_fallback(
+    monkeypatch, models_build, no_backoff
+):
+    asked = {}
+
+    def _resolver(primary, **kw):
+        asked.update(kw)
+        return None
+
+    monkeypatch.setattr(mw, "fallback_model", _resolver)
+
+    def handler(r):
+        raise _stall()
+
+    with pytest.raises(TimeoutError):
+        mw.DynamicModelMiddleware().wrap_model_call(_Req(), handler)
+
+    assert asked.get("needs_vision") is False
+
+
+# ---------------------------------------------------------------------------
+# Acceptance 4 — a retry the user can feel is announced; a fast one is not
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def captured_notices(monkeypatch):
+    """Install a notice channel for the current context and collect its frames."""
+    from app.lib import turn_notices
+
+    frames = []
+
+    async def _send(frame):
+        frames.append(frame)
+
+    turn_notices.start_turn_notices(_send)
+    yield frames
+    turn_notices.clear_turn_notices()
+
+
+def _thinking(frames):
+    out = []
+    for f in frames:
+        for block in f.get("thinking") or []:
+            out.append(block.get("thinking", ""))
+    return out
+
+
+def test_a_fast_transient_retry_says_nothing(monkeypatch, models_build, no_backoff):
+    """A 503 retries in about a second and is invisible. A notice on every one of
+    those trains users to ignore the notice that matters."""
+    from app.lib import turn_notices
+
+    frames = []
+    turn_notices.start_turn_notices(lambda f: frames.append(f))
+    try:
+        calls = {"n": 0}
+
+        def handler(r):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise ConnectionError("503 service_overloaded")
+            return "answered"
+
+        assert mw.DynamicModelMiddleware().wrap_model_call(_Req(), handler) == "answered"
+    finally:
+        turn_notices.clear_turn_notices()
+
+    assert not frames, f"a one-second blip was announced: {frames}"
+
+
+def test_a_retry_the_user_can_feel_is_announced(monkeypatch, models_build, no_backoff):
+    """Past the threshold the shimmer has been spinning long enough that silence
+    is indistinguishable from a frozen agent."""
+    monkeypatch.setattr(mw, "_RETRY_NOTICE_AFTER_SECONDS", 0.0)
+
+    frames = []
+
+    async def _send(frame):
+        frames.append(frame)
+
+    from app.lib import turn_notices
+
+    turn_notices.start_turn_notices(_send)
+    try:
+        calls = {"n": 0}
+
+        async def handler(r):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise _stall()
+            return "answered"
+
+        out = asyncio.run(mw.DynamicModelMiddleware().awrap_model_call(_Req(), handler))
+    finally:
+        turn_notices.clear_turn_notices()
+
+    assert out == "answered"
+    said = " ".join(_thinking(frames)).lower()
+    assert "retry" in said, f"nothing told the user a retry was happening: {frames}"
+    assert all(f.get("type") == "AIMessageChunk" for f in frames), (
+        "the notice must ride the shimmer frame, not land in the transcript"
+    )
+
+
+def test_the_notice_never_costs_the_user_their_turn(monkeypatch, models_build, no_backoff):
+    """Best effort, like every other status frame: a dead socket is not a reason
+    to fail the turn the notice was describing."""
+    monkeypatch.setattr(mw, "_RETRY_NOTICE_AFTER_SECONDS", 0.0)
+
+    async def _boom(frame):
+        raise RuntimeError("socket went away")
+
+    from app.lib import turn_notices
+
+    turn_notices.start_turn_notices(_boom)
+    try:
+        calls = {"n": 0}
+
+        async def handler(r):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise _stall()
+            return "answered"
+
+        out = asyncio.run(mw.DynamicModelMiddleware().awrap_model_call(_Req(), handler))
+    finally:
+        turn_notices.clear_turn_notices()
+
+    assert out == "answered"
+
+
+def test_a_turn_with_no_channel_installed_still_runs(monkeypatch, models_build, no_backoff):
+    """Every non-websocket caller (cron, tests, sub-agents) has no sink at all."""
+    from app.lib import turn_notices
+
+    turn_notices.clear_turn_notices()
+    monkeypatch.setattr(mw, "_RETRY_NOTICE_AFTER_SECONDS", 0.0)
+
+    calls = {"n": 0}
+
+    def handler(r):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise _stall()
+        return "answered"
+
+    assert mw.DynamicModelMiddleware().wrap_model_call(_Req(), handler) == "answered"
+
+
+# ---------------------------------------------------------------------------
+# Acceptance 5 — the fallback rides the frame that already exists
+# ---------------------------------------------------------------------------
+
+def test_the_fallback_is_announced_on_the_model_substituted_frame(
+    monkeypatch, models_build, no_backoff
+):
+    """Not a new frame type: ``model_substituted`` is already rendered end to end.
+    It only ever fired for *policy* substitution, before the run started."""
+    monkeypatch.setattr(mw, "fallback_model", lambda *a, **k: "deepseek-v4-flash")
+
+    frames = []
+
+    async def _send(frame):
+        frames.append(frame)
+
+    from app.lib import turn_notices
+
+    turn_notices.start_turn_notices(_send)
+    try:
+        req = _Req("muse-spark-1.2-contributor")
+
+        async def handler(r):
+            if r.model.name == "muse-spark-1.2-contributor":
+                raise _stall()
+            return "answered"
+
+        asyncio.run(mw.DynamicModelMiddleware().awrap_model_call(req, handler))
+    finally:
+        turn_notices.clear_turn_notices()
+
+    swaps = [f for f in frames if f.get("type") == "model_substituted"]
+    assert swaps, f"the turn changed model and the browser was told nothing: {frames}"
+    assert swaps[-1]["requested"] == "muse-spark-1.2-contributor"
+    assert swaps[-1]["effective"] == "deepseek-v4-flash"
+    assert swaps[-1]["reason"] == "fallback", (
+        "policy substitution and a mid-turn failure fallback need different "
+        "wording in the banner, so the frame has to say which one this is"
+    )
+
+
+@pytest.mark.asyncio
+async def test_policy_substitution_still_labels_itself():
+    """The pre-existing sender gains the same field, so the browser never has to
+    guess what an unlabelled frame meant."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    from starlette.websockets import WebSocketState
+
+    from app.websocket.request_handler import RequestHandler
+
+    import os
+
+    os.environ["MODEL_SWITCHING_ALLOWED"] = "true"
+    os.environ["ENABLED_MODELS"] = "muse-spark-1.2-contributor"
+    os.environ["META_API_KEY"] = "test-key-not-a-real-credential"
+    try:
+        handler = RequestHandler(MagicMock())
+        handler.app.state.mothership_client = None
+        ws = MagicMock()
+        ws.client_state = WebSocketState.CONNECTED
+        ws.application_state = WebSocketState.CONNECTED
+        ws.send_json = AsyncMock()
+
+        await handler._warn_if_model_substituted(
+            {"llm_model": "nemotron-lightning-30b-fireworks"}, ws
+        )
+        frame = ws.send_json.await_args_list[-1].args[0]
+    finally:
+        for key in ("MODEL_SWITCHING_ALLOWED", "ENABLED_MODELS", "META_API_KEY"):
+            os.environ.pop(key, None)
+
+    assert frame["type"] == "model_substituted"
+    assert frame["reason"] == "policy"

--- a/app/tests/test_openrouter_registry.py
+++ b/app/tests/test_openrouter_registry.py
@@ -1,0 +1,389 @@
+"""The config-driven OpenRouter model registry (0.7.5).
+
+Every other model costs six code edits to add. OpenRouter fronts one
+OpenAI-compatible endpoint over hundreds of models and dozens of provider
+endpoints each (``deepseek/deepseek-v4-flash-0731`` alone has 28), so trying one
+is a pricing experiment rather than a code change — these entries live in a
+host-mounted JSON file instead.
+
+What has to hold for that to be safe:
+
+  * a malformed or half-written config can never take the dropdown down,
+  * an entry can never silently become something other than what it says (a
+    missing provider pin means OpenRouter load-balances across all 28 endpoints,
+    which is exactly what pinning relace/fp4 exists to prevent),
+  * and a registered model is subject to the same operator policy as any other.
+"""
+import json
+
+import pytest
+
+from app.agents.leonardo import model_policy, openrouter_models as registry
+from app.agents.leonardo.llm_factory import ChatDeepSeekWithReasoning, get_llm
+from app.agents.leonardo.model_capabilities import get_model_capabilities
+
+RELACE = "deepseek-flash-0731-relace"
+DIGITALOCEAN = "deepseek-flash-0731-digitalocean"
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch, tmp_path):
+    """No overlay, no policy config, a key present — the baseline box."""
+    monkeypatch.setattr(model_policy, "_read_instance_config", lambda: None)
+    monkeypatch.setenv("OPENROUTER_MODELS_CONFIG", str(tmp_path / "absent.json"))
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-openrouter-key")
+    monkeypatch.setenv("MODEL_SWITCHING_ALLOWED", "true")
+    for var in ("ENABLED_MODELS", "DISABLED_MODELS", "OPENROUTER_BASE_URL"):
+        monkeypatch.delenv(var, raising=False)
+
+
+def _overlay(monkeypatch, tmp_path, payload):
+    path = tmp_path / "openrouter_models.json"
+    path.write_text(json.dumps(payload) if isinstance(payload, dict) else payload)
+    monkeypatch.setenv("OPENROUTER_MODELS_CONFIG", str(path))
+    return path
+
+
+# --- the compiled-in entry -------------------------------------------------
+
+def test_relace_entry_is_registered_out_of_the_box():
+    assert RELACE in registry.openrouter_models()
+
+
+def test_relace_pins_one_provider_with_fallbacks_off():
+    """The whole economic point. Without the pin OpenRouter load-balances across
+    all 28 endpoints for this model, so the $0.04/$0.08 per-M rate that justifies
+    the entry evaporates on the first silent reroute — and prompt caching, which
+    is per-replica, stops hitting too."""
+    entry = registry.get_openrouter_model(RELACE)
+    provider = entry["extra_body"]["provider"]
+    assert provider["order"] == ["relace/fp4"]
+    assert provider["allow_fallbacks"] is False
+
+
+def test_digitalocean_entry_is_registered_out_of_the_box():
+    assert DIGITALOCEAN in registry.openrouter_models()
+
+
+def test_digitalocean_pins_its_own_endpoint_with_fallbacks_off():
+    provider = registry.get_openrouter_model(DIGITALOCEAN)["extra_body"]["provider"]
+    assert provider["order"] == ["digitalocean"]
+    assert provider["allow_fallbacks"] is False
+
+
+def test_the_two_0731_entries_are_siblings_not_a_repoint():
+    """Same weights, different host, and BOTH offered — who serves (and bills
+    for) a turn stays an explicit user choice, exactly like the RunPod vs
+    Fireworks Nemotron pair. A second entry must never quietly replace the first."""
+    models = registry.openrouter_models()
+    assert {RELACE, DIGITALOCEAN} <= set(models)
+    assert models[RELACE]["model"] == models[DIGITALOCEAN]["model"]
+    assert (
+        models[RELACE]["extra_body"]["provider"]["order"]
+        != models[DIGITALOCEAN]["extra_body"]["provider"]["order"]
+    )
+
+
+def test_every_compiled_in_entry_pins_a_provider():
+    """A base entry without a pin would silently load-balance across all 28
+    endpoints for its model — the exact failure the registry exists to prevent,
+    and invisible until a bill arrives."""
+    for name, entry in registry.openrouter_models().items():
+        provider = entry.get("extra_body", {}).get("provider")
+        assert provider and provider.get("order"), f"{name} does not pin an endpoint"
+
+
+def test_relace_targets_the_0731_model_id():
+    assert registry.get_openrouter_model(RELACE)["model"] == "deepseek/deepseek-v4-flash-0731"
+
+
+# --- overlay layering ------------------------------------------------------
+
+def test_overlay_entry_is_registered(monkeypatch, tmp_path):
+    _overlay(monkeypatch, tmp_path, {"models": {"cheap-thing": {
+        "label": "Cheap Thing", "model": "vendor/cheap-thing",
+    }}})
+    assert "cheap-thing" in registry.openrouter_models()
+
+
+def test_overlay_wins_over_the_compiled_entry(monkeypatch, tmp_path):
+    """A box must be able to re-point or re-price a built-in entry without a
+    rebuild — that is the difference between config and a hardcoded default."""
+    _overlay(monkeypatch, tmp_path, {"models": {RELACE: {
+        "model": "deepseek/deepseek-v4-flash-0731",
+        "provider": {"order": ["open-inference/fp4"], "allow_fallbacks": True},
+    }}})
+    provider = registry.get_openrouter_model(RELACE)["extra_body"]["provider"]
+    assert provider["order"] == ["open-inference/fp4"]
+    assert provider["allow_fallbacks"] is True
+
+
+def test_registry_is_not_cached_between_reads(monkeypatch, tmp_path):
+    """An operator edits the mounted file live; caching would mean a container
+    restart just to try a different provider endpoint."""
+    _overlay(monkeypatch, tmp_path, {"models": {"a": {"model": "v/a"}}})
+    assert "a" in registry.openrouter_models()
+    _overlay(monkeypatch, tmp_path, {"models": {"b": {"model": "v/b"}}})
+    assert "b" in registry.openrouter_models()
+
+
+# --- fail-open -------------------------------------------------------------
+
+def test_missing_overlay_is_not_an_error(monkeypatch, tmp_path):
+    monkeypatch.setenv("OPENROUTER_MODELS_CONFIG", str(tmp_path / "nope.json"))
+    assert RELACE in registry.openrouter_models()
+
+
+def test_malformed_json_falls_back_to_the_base(monkeypatch, tmp_path):
+    """A half-written config file must never take the dropdown down."""
+    _overlay(monkeypatch, tmp_path, '{"models": {"broken": ')
+    models = registry.openrouter_models()
+    assert RELACE in models
+    assert "broken" not in models
+
+
+def test_models_key_of_the_wrong_type_is_ignored(monkeypatch, tmp_path):
+    _overlay(monkeypatch, tmp_path, {"models": ["not", "an", "object"]})
+    assert RELACE in registry.openrouter_models()
+
+
+def test_entry_without_a_model_id_is_dropped(monkeypatch, tmp_path):
+    """It cannot build a client, so registering it would put a dead option in the
+    dropdown that silently falls back to the box default when picked."""
+    _overlay(monkeypatch, tmp_path, {"models": {
+        "no-id": {"label": "No Model Id"},
+        "fine": {"model": "vendor/fine"},
+    }})
+    models = registry.openrouter_models()
+    assert "no-id" not in models
+    assert "fine" in models, "one bad entry must not discard its neighbours"
+
+
+def test_entry_that_is_not_an_object_is_dropped(monkeypatch, tmp_path):
+    _overlay(monkeypatch, tmp_path, {"models": {"junk": "just a string"}})
+    assert "junk" not in registry.openrouter_models()
+
+
+# --- normalization ---------------------------------------------------------
+
+def test_capabilities_default_to_text_only(monkeypatch, tmp_path):
+    """The OPPOSITE of get_model_capabilities' permissive unknown-model default,
+    on purpose: this is a file the operator just wrote, and guessing "probably
+    multimodal" would offer an image upload that 400s at the provider."""
+    _overlay(monkeypatch, tmp_path, {"models": {"plain": {"model": "vendor/plain"}}})
+    assert get_model_capabilities("plain") == {"images": False, "video": False, "pdf": False}
+
+
+def test_declared_capabilities_are_honoured(monkeypatch, tmp_path):
+    _overlay(monkeypatch, tmp_path, {"models": {"seer": {
+        "model": "vendor/seer", "capabilities": {"images": True},
+    }}})
+    assert get_model_capabilities("seer") == {"images": True, "video": False, "pdf": False}
+
+
+def test_capability_values_are_coerced_to_bool(monkeypatch, tmp_path):
+    """A JSON string would make `if caps['images']` accidentally true."""
+    _overlay(monkeypatch, tmp_path, {"models": {"sneaky": {
+        "model": "vendor/sneaky", "capabilities": {"images": "false"},
+    }}})
+    assert get_model_capabilities("sneaky")["images"] is True  # non-empty string is truthy
+    _overlay(monkeypatch, tmp_path, {"models": {"sneaky": {
+        "model": "vendor/sneaky", "capabilities": {"images": ""},
+    }}})
+    assert get_model_capabilities("sneaky")["images"] is False
+
+
+def test_label_defaults_to_the_model_name(monkeypatch, tmp_path):
+    _overlay(monkeypatch, tmp_path, {"models": {"bare": {"model": "vendor/bare"}}})
+    entry = registry.get_openrouter_model("bare")
+    assert entry["label"] == "bare"
+    assert entry["short_label"] == "bare"
+
+
+def test_enabled_false_parks_an_entry(monkeypatch, tmp_path):
+    """Lets an operator keep a config block (and its pricing notes) without the
+    model reaching the dropdown."""
+    _overlay(monkeypatch, tmp_path, {"models": {"parked": {
+        "model": "vendor/parked", "enabled": False,
+    }}})
+    assert "parked" not in registry.openrouter_models()
+
+
+def test_extra_body_passes_through_with_provider_authoritative(monkeypatch, tmp_path):
+    """`extra_body` is the escape hatch for any other OpenRouter request field;
+    an explicit `provider` block must still win for the common case."""
+    _overlay(monkeypatch, tmp_path, {"models": {"x": {
+        "model": "vendor/x",
+        "extra_body": {"transforms": ["middle-out"], "provider": {"order": ["ignored"]}},
+        "provider": {"order": ["kept/fp8"]},
+    }}})
+    extra = registry.get_openrouter_model("x")["extra_body"]
+    assert extra["transforms"] == ["middle-out"]
+    assert extra["provider"]["order"] == ["kept/fp8"]
+
+
+# --- client construction ---------------------------------------------------
+
+@pytest.mark.parametrize("name", [RELACE, DIGITALOCEAN])
+def test_get_llm_routes_a_registry_model_to_openrouter(name):
+    llm = get_llm(name)
+    assert llm.api_base == "https://openrouter.ai/api/v1"
+    assert llm.model_name == "deepseek/deepseek-v4-flash-0731"
+
+
+def test_the_digitalocean_pin_reaches_the_request_body():
+    assert get_llm(DIGITALOCEAN).extra_body == {
+        "provider": {"order": ["digitalocean"], "allow_fallbacks": False}
+    }
+
+
+def test_the_provider_pin_reaches_the_request_body():
+    """extra_body is what the OpenAI-compatible client passes through untouched;
+    OpenRouter reads `provider` as a top-level request field. If this stops
+    threading through, the pin silently becomes a no-op and billing moves."""
+    assert get_llm(RELACE).extra_body == {
+        "provider": {"order": ["relace/fp4"], "allow_fallbacks": False}
+    }
+
+
+def test_the_underlying_sdk_client_really_points_at_openrouter():
+    """The LangChain field can read None while the lazily-built SDK client is the
+    thing that carries the URL — same trap as the api-key leak tests."""
+    assert "openrouter.ai" in str(get_llm(RELACE).client._client.base_url)
+
+
+def test_reasoning_entries_get_the_reasoning_client():
+    assert isinstance(get_llm(RELACE), ChatDeepSeekWithReasoning)
+
+
+def test_reasoning_false_gets_a_plain_client(monkeypatch, tmp_path):
+    """OpenRouter normalizes thinking differently from DeepSeek's own API, so the
+    client choice stays per-entry rather than sniffed from the model id."""
+    from langchain_openai import ChatOpenAI
+
+    _overlay(monkeypatch, tmp_path, {"models": {"plainmodel": {
+        "model": "vendor/plain", "reasoning": False,
+    }}})
+    llm = get_llm("plainmodel")
+    assert isinstance(llm, ChatOpenAI)
+    assert not isinstance(llm, ChatDeepSeekWithReasoning)
+
+
+def test_base_url_is_overridable(monkeypatch):
+    """So a box can point at a proxy — or a test at a mock — without code."""
+    monkeypatch.setenv("OPENROUTER_BASE_URL", "http://openrouter.invalid/v1")
+    assert get_llm(RELACE).api_base == "http://openrouter.invalid/v1"
+
+
+def test_sdk_retries_stay_off_like_every_other_model():
+    """Provider retries are opaque and multiply the 180s timeout; middleware owns
+    classified retries instead."""
+    llm = get_llm(RELACE)
+    assert llm.max_retries == 0
+    assert llm.request_timeout == 180
+
+
+# --- policy ----------------------------------------------------------------
+
+def test_registering_a_model_enables_it(monkeypatch, tmp_path):
+    """The registry file is operator-owned and host-mounted, like instance.json.
+    Requiring ENABLED_MODELS too would mean configuring one intent twice."""
+    _overlay(monkeypatch, tmp_path, {"models": {"newthing": {"model": "vendor/newthing"}}})
+    assert model_policy.is_model_enabled("newthing") is True
+
+
+def test_an_explicit_disable_still_wins(monkeypatch, tmp_path):
+    _overlay(monkeypatch, tmp_path, {"models": {"newthing": {"model": "vendor/newthing"}}})
+    monkeypatch.setenv("DISABLED_MODELS", "newthing")
+    assert model_policy.is_model_enabled("newthing") is False
+
+
+def test_an_allowlist_that_omits_it_does_not_disable_it(monkeypatch, tmp_path):
+    """Step 2b sits above the allow-list, same as the other fail-open rules."""
+    _overlay(monkeypatch, tmp_path, {"models": {"newthing": {"model": "vendor/newthing"}}})
+    monkeypatch.setenv("ENABLED_MODELS", "deepseek-v4-flash")
+    assert model_policy.is_model_enabled("newthing") is True
+
+
+def test_registry_models_are_known_to_the_fallback_walk(monkeypatch, tmp_path):
+    _overlay(monkeypatch, tmp_path, {"models": {"newthing": {"model": "vendor/newthing"}}})
+    known = model_policy.known_models()
+    assert "newthing" in known
+    # ...but LAST: a third-party-routed endpoint must never outrank a first-party
+    # model when picking what the box runs by default.
+    assert known.index("newthing") > known.index("deepseek-v4-flash")
+
+
+def test_a_registry_model_is_never_the_fleet_default():
+    from app.agents.leonardo.llm_factory import DEFAULT_LLM_MODEL, FALLBACK_TEXT_MODEL
+
+    assert RELACE not in (DEFAULT_LLM_MODEL, FALLBACK_TEXT_MODEL)
+    assert DIGITALOCEAN not in (DEFAULT_LLM_MODEL, FALLBACK_TEXT_MODEL)
+
+
+def test_a_registry_model_is_never_the_lockout_fallback(monkeypatch, tmp_path):
+    """enabled_default_model walks known_models() when everything else is off, and
+    step 2b enables registry entries wherever a key exists — so without a guard
+    the fallback quietly moves the box onto a third-party-routed endpoint someone
+    added to try. A registered model is a thing a user PICKS, never what a box
+    falls back to running."""
+    _overlay(monkeypatch, tmp_path, {"models": {"newthing": {"model": "vendor/newthing"}}})
+    monkeypatch.setenv("DISABLED_MODELS", ",".join(model_policy._KNOWN_MODELS))
+    resolved = model_policy.enabled_default_model()
+    assert resolved != "newthing"
+    assert resolved != RELACE
+
+
+def test_a_keyless_box_is_not_offered_registry_models(monkeypatch, tmp_path):
+    """The registry ships a compiled-in example entry. Without the key check, every
+    fleet box would grow a dropdown option it cannot run — breaking the invariant
+    that an unconfigured box offers exactly the two blessed models."""
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    _overlay(monkeypatch, tmp_path, {"models": {"newthing": {"model": "vendor/newthing"}}})
+    assert model_policy.is_model_enabled("newthing") is False
+    assert model_policy.is_model_enabled(RELACE) is False
+    assert model_policy.is_model_enabled(DIGITALOCEAN) is False
+
+
+def test_switching_lock_still_pins_the_default(monkeypatch, tmp_path):
+    """A registered model must not punch through the coarse operator lock —
+    step 1a is above step 2b."""
+    _overlay(monkeypatch, tmp_path, {"models": {"newthing": {"model": "vendor/newthing"}}})
+    monkeypatch.setenv("MODEL_SWITCHING_ALLOWED", "false")
+    assert model_policy.is_model_enabled("newthing") is False
+
+
+# --- the endpoint contract the dropdown depends on -------------------------
+
+@pytest.mark.asyncio
+async def test_available_models_includes_registry_models(async_client):
+    """Registry models are not in the hand-maintained model_api_keys map, so they
+    have to be folded into the response separately — otherwise the dropdown never
+    hears about them and the whole config path is inert."""
+    response = await async_client.get("/api/available-models")
+    assert response.status_code == 200
+    by_value = {m["value"]: m for m in response.json()["models"]}
+
+    assert RELACE in by_value, "the registry entry never reached /api/available-models"
+    entry = by_value[RELACE]
+    assert entry["capabilities"] == {"images": False, "video": False, "pdf": False}
+
+
+@pytest.mark.asyncio
+async def test_registry_models_ship_a_label_for_the_dropdown(async_client):
+    """chat.html has no <option> for a config-driven model — it cannot know the
+    name — so the frontend builds one from these fields."""
+    by_value = {m["value"]: m for m in (await async_client.get("/api/available-models")).json()["models"]}
+
+    assert by_value[RELACE]["label"] == "DeepSeek V4 Flash 0731 (Relace fp4)"
+    assert by_value[RELACE]["short_label"] == "DS 0731 Relace"
+
+
+@pytest.mark.asyncio
+async def test_hardcoded_models_do_not_ship_a_label(async_client):
+    """`label` is the signal "create an option for me". Sending it for a model
+    that already has markup would let a runtime response paper over a genuine
+    frontend/backend skew instead of surfacing it."""
+    by_value = {m["value"]: m for m in (await async_client.get("/api/available-models")).json()["models"]}
+
+    assert "label" not in by_value["deepseek-v4-flash"]

--- a/app/tests/test_personal_cookbook.py
+++ b/app/tests/test_personal_cookbook.py
@@ -1,0 +1,137 @@
+"""The /cookbook menu must show the owner's OWN recipes, not just the fleet's (0.7.5).
+
+Every LlamaPress user now has a personal cookbook — user-namespaced recipes published from
+their own Leo boxes (mothership, 2026-08-28; asked for by a Business-plan user running four
+Leos who wants to reuse UI patterns across them). Until now `/api/cookbook` proxied only the
+fleet index, so a recipe the user published from one box never appeared on any of their
+others, and the agents did not know personal cookbooks existed at all.
+
+Personal recipes are an ENHANCEMENT: a local dev box with no mothership config, or a
+mothership that is down, must still get a working fleet menu.
+"""
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.routers.api import _merge_personal_cookbook, _normalize_personal_recipes
+
+
+FLEET = [
+    {"slug": "pdf-export", "title": "PDF export", "category": "docs", "url": "https://llamapress.ai/cookbook/pdf-export"},
+]
+
+PERSONAL_PAYLOAD = {
+    "handle": "kody",
+    "recipes": [
+        {"slug": "glow-toggle", "title": "Glow toggle", "summary": "A toggle that glows",
+         "category": "ui", "visibility": "public", "updated_at": "2026-08-28T00:00:00Z"},
+        {"slug": "secret-thing", "title": "Unlisted thing", "category": "ui",
+         "visibility": "unlisted", "updated_at": "2026-08-28T00:00:00Z"},
+    ],
+}
+
+
+def test_personal_recipes_are_normalized_to_the_menu_shape():
+    guides = _normalize_personal_recipes(PERSONAL_PAYLOAD)
+
+    assert [g["slug"] for g in guides] == ["glow-toggle", "secret-thing"]
+    first = guides[0]
+    assert first["title"] == "Glow toggle"
+    # The .json and .md of this URL both exist, so the frontend's existing
+    # cookbookJsonUrl mention mechanics keep working with no change.
+    assert first["url"] == "https://llamapress.ai/cookbook/u/kody/glow-toggle"
+    assert first["personal"] is True
+
+
+def test_unlisted_recipes_are_included_because_they_are_the_owner_s_own():
+    guides = _normalize_personal_recipes(PERSONAL_PAYLOAD)
+    assert "secret-thing" in [g["slug"] for g in guides]
+
+
+def test_personal_recipes_rank_above_fleet_guides():
+    merged = _merge_personal_cookbook(FLEET, _normalize_personal_recipes(PERSONAL_PAYLOAD))
+
+    assert merged[0]["personal"] is True
+    assert merged[-1]["slug"] == "pdf-export"
+    assert len(merged) == 3
+
+
+def test_a_personal_recipe_shadows_a_fleet_guide_with_the_same_slug():
+    """The user's own version of a recipe is the one they meant."""
+    personal = _normalize_personal_recipes(
+        {"handle": "kody", "recipes": [{"slug": "pdf-export", "title": "My PDF export"}]})
+
+    merged = _merge_personal_cookbook(FLEET, personal)
+
+    assert len(merged) == 1
+    assert merged[0]["title"] == "My PDF export"
+    assert merged[0]["personal"] is True
+
+
+def test_fleet_menu_survives_a_missing_personal_cookbook():
+    assert _merge_personal_cookbook(FLEET, []) == FLEET
+    assert _merge_personal_cookbook(FLEET, None) == FLEET
+
+
+def test_a_malformed_personal_payload_degrades_to_nothing():
+    for junk in (None, {}, {"recipes": "not a list"}, {"recipes": [{"no": "slug"}]}, "nope"):
+        assert _normalize_personal_recipes(junk) == []
+
+
+def test_personal_recipes_need_a_handle_to_build_a_url():
+    """Without a handle there is no resolvable URL, so the entry is useless — drop it."""
+    assert _normalize_personal_recipes({"recipes": [{"slug": "x", "title": "X"}]}) == []
+
+
+def test_client_returns_none_when_the_box_has_no_mothership_config():
+    from app.services.mothership_client import MothershipClient
+
+    client = MothershipClient()
+    client.config = {"instance_name": "", "mothership_url": "", "mothership_api_token": ""}
+
+    assert asyncio.run(client.get_personal_cookbook()) is None
+
+
+def test_client_sends_instance_name_as_a_query_param():
+    """The mothership reads params[:instance_name] on this GET, not a JSON body."""
+    from app.services.mothership_client import MothershipClient
+
+    client = MothershipClient()
+    client.config = {
+        "instance_name": "leo-test",
+        "mothership_url": "https://llamapress.ai",
+        "mothership_api_token": "token",
+    }
+
+    response = MagicMock()
+    response.raise_for_status = MagicMock()
+    response.json = MagicMock(return_value=PERSONAL_PAYLOAD)
+
+    with patch("httpx.AsyncClient") as ac:
+        instance = ac.return_value.__aenter__.return_value
+        instance.get = AsyncMock(return_value=response)
+        with patch.object(MothershipClient, "reporting_enabled", True):
+            result = asyncio.run(client.get_personal_cookbook())
+
+    assert result == PERSONAL_PAYLOAD
+    kwargs = instance.get.await_args.kwargs
+    assert kwargs["params"] == {"instance_name": "leo-test"}
+    assert kwargs["headers"]["Authorization"] == "Bearer token"
+
+
+def test_client_returns_none_rather_than_raising_when_the_mothership_errors():
+    from app.services.mothership_client import MothershipClient
+
+    client = MothershipClient()
+    client.config = {
+        "instance_name": "leo-test",
+        "mothership_url": "https://llamapress.ai",
+        "mothership_api_token": "token",
+    }
+
+    with patch("httpx.AsyncClient") as ac:
+        instance = ac.return_value.__aenter__.return_value
+        instance.get = AsyncMock(side_effect=RuntimeError("mothership down"))
+        with patch.object(MothershipClient, "reporting_enabled", True):
+            assert asyncio.run(client.get_personal_cookbook()) is None

--- a/app/tests/test_personal_cookbook_prompts.py
+++ b/app/tests/test_personal_cookbook_prompts.py
@@ -1,0 +1,50 @@
+"""All four Cookbook prompt sections must know personal cookbooks exist (0.7.5).
+
+The agents were told about the FLEET cookbook only. A user who publishes a recipe from one
+of their Leos — the feature a Business-plan user with four boxes asked for — would find Leo
+on the next box had no idea it existed, could not follow a /cookbook/u/<handle>/<slug>.json
+mention, and had no way to save a pattern when asked to.
+
+Structural assertions only: that each prompt names the personal namespace and the publish
+guide. Never an assertion about what the model then says.
+"""
+from pathlib import Path
+
+import pytest
+
+PROMPT_FILES = [
+    "rails_agent/prompts.py",
+    "rails_plan_mode_agent/prompts.py",
+    "rails_ticket_mode_agent/prompts.py",
+    "rails_beginner_agent/prompts.py",
+]
+
+AGENTS = Path(__file__).resolve().parents[1] / "agents" / "leonardo"
+
+
+@pytest.mark.parametrize("relative", PROMPT_FILES)
+def test_prompt_mentions_the_personal_cookbook_namespace(relative):
+    source = (AGENTS / relative).read_text()
+
+    assert "/cookbook/u/" in source, (
+        f"{relative} never mentions the personal cookbook namespace, so Leo cannot follow "
+        "an @cookbook: mention pointing at one of the user's own recipes."
+    )
+
+
+@pytest.mark.parametrize("relative", PROMPT_FILES)
+def test_prompt_points_at_the_publish_guide(relative):
+    """'Save this to my cookbook' has to lead somewhere."""
+    source = (AGENTS / relative).read_text()
+
+    assert "publish-to-your-personal-cookbook.md" in source, (
+        f"{relative} does not tell Leo where the publish flow is documented."
+    )
+
+
+@pytest.mark.parametrize("relative", PROMPT_FILES)
+def test_the_fleet_cookbook_is_still_described(relative):
+    """The personal cookbook is an addition, not a replacement."""
+    source = (AGENTS / relative).read_text()
+
+    assert "cookbook.json" in source

--- a/app/tests/test_provider_key_never_leaks_openai.py
+++ b/app/tests/test_provider_key_never_leaks_openai.py
@@ -23,6 +23,7 @@ THIRD_PARTY_ENDPOINT_MODELS = [
     ("deepseek-v4-flash-gmi", "GMI_DEEPSEEK_API_KEY"),
     ("deepseek-v4-flash-fireworks", "FIREWORKS_DEEPSEEK_API_KEY"),
     ("qwen3.7-plus", "ALIBABA_API_KEY"),
+    ("qwen3.8-27b-hetzner", "HETZNER_API_KEY"),
     ("muse-spark-1.2-contributor", "META_API_KEY"),
     # Self-hosted vLLM on our own RunPod GPU. Unauthenticated today, which is
     # exactly why it belongs here: "no key needed" is the case where api_key=None
@@ -34,6 +35,10 @@ THIRD_PARTY_ENDPOINT_MODELS = [
     # which the fixture below already clears for the DeepSeek row — so the
     # no-key leak case really is keyless here.
     ("nemotron-lightning-30b-fireworks", "FIREWORKS_API_KEY"),
+    # The compiled-in OpenRouter registry entry. Config-driven models route
+    # through one shared get_llm branch, so this row covers every endpoint an
+    # operator adds later, not just this one.
+    ("deepseek-flash-0731-relace", "OPENROUTER_API_KEY"),
 ]
 
 SENTINEL = "sk-openai-must-never-leave-this-process"

--- a/app/tests/test_resilience_transient_retry.py
+++ b/app/tests/test_resilience_transient_retry.py
@@ -261,10 +261,17 @@ def test_wrap_model_call_does_NOT_retry_deterministic(monkeypatch):
 
 
 def test_wrap_model_call_stops_after_max_attempts(monkeypatch):
-    """A persistently transient endpoint gives up (and re-raises) after the cap."""
+    """A persistently transient endpoint gives up (and re-raises) after the cap.
+
+    Rung 2 is pinned off here on purpose (0.7.5): with a fallback available the
+    loop correctly moves to a second model instead of re-raising, which is a
+    different behaviour with its own tests in test_model_stall_resilience.py.
+    What this one still guards is that rung 1 does not retry forever.
+    """
     from app.agents.leonardo.rails_agent import middleware as mw
     monkeypatch.setattr(mw, "get_llm", lambda name: _ToolBindableModel())
     monkeypatch.setattr(mw.time, "sleep", lambda *_: None)
+    monkeypatch.setattr(mw, "fallback_model", lambda *a, **k: None)
 
     calls = {"n": 0}
 
@@ -275,3 +282,50 @@ def test_wrap_model_call_stops_after_max_attempts(monkeypatch):
     with pytest.raises(ConnectionError):
         mw.DynamicModelMiddleware().wrap_model_call(_Req(), handler)
     assert calls["n"] == mw._MODEL_RETRY_MAX_ATTEMPTS
+
+
+# ---------------------------------------------------------------------------
+# OpenRouter-shaped errors (0.7.5)
+# ---------------------------------------------------------------------------
+#
+# OpenRouter reports an upstream provider failure as a plain ValueError whose
+# single arg is a dict — there is no `.status_code` and no `.response`, so the
+# two attribute lookups above both miss and a 502 that literally says
+# "Retry after 2s" was classed non-transient. Measured on the real endpoint:
+# pinned Relace requests 502 under queue pressure several times in a dozen calls,
+# so this is the dominant failure mode of the routed path, not a corner case.
+
+def _openrouter_error(code, message="Upstream error from Relace: Queued past the 5s queue-time bound."):
+    return ValueError({"message": message, "code": code})
+
+
+def test_openrouter_502_is_transient():
+    from app.agents.leonardo.resilience import is_transient_error
+
+    assert is_transient_error(_openrouter_error(502)) is True
+
+
+@pytest.mark.parametrize("code", [408, 429, 500, 502, 503, 504])
+def test_openrouter_transient_codes_are_retried(code):
+    from app.agents.leonardo.resilience import is_transient_error
+
+    assert is_transient_error(_openrouter_error(code)) is True
+
+
+@pytest.mark.parametrize("code", [400, 401, 403, 404, 422])
+def test_openrouter_deterministic_codes_are_not_retried(code):
+    """A malformed or unauthorized request fails identically on retry; retrying
+    only delays the fallback rung."""
+    from app.agents.leonardo.resilience import is_transient_error
+
+    assert is_transient_error(_openrouter_error(code)) is False
+
+
+def test_a_plain_valueerror_is_still_not_transient():
+    """The dict-arg path must stay narrow. A bare ValueError carries no status
+    signal and must not become retryable just because it is a ValueError."""
+    from app.agents.leonardo.resilience import is_transient_error
+
+    assert is_transient_error(ValueError("something went wrong")) is False
+    assert is_transient_error(ValueError({"message": "no code here"})) is False
+    assert is_transient_error(ValueError({"code": "not-an-int"})) is False

--- a/app/tests/test_vision_model_resolution.py
+++ b/app/tests/test_vision_model_resolution.py
@@ -1,0 +1,166 @@
+"""The box's vision model is resolved, not hardcoded (0.7.5).
+
+Before this, image understanding anywhere in the fleet required a META key:
+``VISION_MODEL`` was the constant ``muse-spark-1.2-contributor`` in both
+``model_policy`` and ``chat/index.js``, so a DeepSeek-only box refused image
+attachments outright with "no image-capable model is configured".
+
+``vision_model()`` now picks whichever vision model the box holds a key for, and
+``/api/available-models`` reports it so the frontend auto-switch targets the same
+one. These tests pin the three properties that make that safe:
+
+  * it never names a model this box cannot build (the whole point — a wrong name
+    here means every image send 401s),
+  * a box with no vision key at all still resolves to "" rather than guessing,
+  * and the policy actually lets the resolved model through, which is what a
+    default allow-list would otherwise block.
+"""
+import pytest
+
+from app.agents.leonardo import model_policy
+from app.agents.leonardo.model_capabilities import get_model_capabilities
+
+
+def _model_dispatch_source(llm_factory) -> str:
+    """The source text where get_llm decides which client to build.
+
+    Both halves, because 0.7.5 split construction into ``_build_client`` so the
+    stall guard (``_apply_stream_chunk_timeout``) could be applied in ONE place
+    instead of at eleven ``ChatOpenAI(`` call sites. The policy gate stayed in
+    ``get_llm``; the per-model branches moved. These structural guards care about
+    the dispatch, not about which of the two functions currently holds it.
+    """
+    import inspect
+
+    return inspect.getsource(llm_factory.get_llm) + inspect.getsource(
+        llm_factory._build_client
+    )
+
+
+
+MUSE = "muse-spark-1.2-contributor"
+DS_VISION = "deepseek-v4-flash-vision-exp"
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    """No keys, no policy config — each test opts into exactly what it needs."""
+    monkeypatch.setattr(model_policy, "_read_instance_config", lambda: None)
+    for var in (
+        "META_API_KEY", "MODEL_API_KEY", "DEEPSEEK_API_KEY",
+        "ENABLED_MODELS", "DISABLED_MODELS",
+        "MODEL_SWITCHING_ALLOWED", "VISION_MODEL_ALLOWED",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("MODEL_SWITCHING_ALLOWED", "true")
+
+
+# --- resolution ------------------------------------------------------------
+
+def test_meta_keyed_box_still_resolves_to_muse(monkeypatch):
+    """The pre-0.7.5 answer must not move. Muse is multimodal AND the fleet
+    default, so a META-keyed box has nothing to gain from switching providers."""
+    monkeypatch.setenv("META_API_KEY", "meta-test-key")
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "ds-test-key")
+    assert model_policy.vision_model() == MUSE
+
+
+def test_deepseek_only_box_resolves_to_the_deepseek_vision_model(monkeypatch):
+    """The case this feature exists for: vision on the key the box already has."""
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "ds-test-key")
+    assert model_policy.vision_model() == DS_VISION
+
+
+def test_box_with_no_vision_key_resolves_to_empty(monkeypatch):
+    """"" is a real answer, not a bug: it is what makes the frontend say "no
+    image-capable model is configured" instead of sending an image to a model it
+    cannot authenticate against."""
+    assert model_policy.vision_model() == ""
+
+
+def test_resolved_vision_model_can_always_see_images():
+    """A resolver that returned a text-only model would produce exactly the 400
+    (`unknown variant image_url`) the capability table exists to prevent."""
+    for name in model_policy._VISION_MODELS:
+        assert get_model_capabilities(name)["images"] is True
+
+
+def test_resolved_vision_model_is_buildable(monkeypatch):
+    """Every candidate must have a get_llm branch — a resolver naming a model
+    that falls through to the DeepSeek text default would silently drop images."""
+    import inspect
+
+    from app.agents.leonardo import llm_factory
+
+    src = _model_dispatch_source(llm_factory)
+    for name in model_policy._VISION_MODELS:
+        assert f'model_name == "{name}"' in src
+
+
+# --- policy: the resolved model has to actually be selectable ---------------
+
+def test_deepseek_vision_is_enabled_on_a_stock_box_when_vision_is_on(monkeypatch):
+    """The compiled default allow-list names only the blessed text models, so
+    without step 2a an operator would have to hand-edit ENABLED_MODELS on every
+    box before a single image upload worked."""
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "ds-test-key")
+    monkeypatch.setenv("VISION_MODEL_ALLOWED", "true")
+    assert model_policy.is_model_enabled(DS_VISION) is True
+
+
+def test_deepseek_vision_is_disabled_when_vision_is_off(monkeypatch):
+    """VISION_MODEL_ALLOWED stays the operator's opt-in. Turning vision off must
+    close the model too, not just hide the upload button."""
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "ds-test-key")
+    monkeypatch.setenv("VISION_MODEL_ALLOWED", "false")
+    assert model_policy.is_model_enabled(DS_VISION) is False
+
+
+def test_vision_defaults_off_so_the_new_model_stays_closed(monkeypatch):
+    """Vision is still an explicit opt-in. Adding a model must not switch image
+    understanding on across the fleet by itself."""
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "ds-test-key")
+    assert model_policy.vision_allowed() is False
+    assert model_policy.is_model_enabled(DS_VISION) is False
+
+
+def test_explicit_disable_beats_the_vision_fail_open(monkeypatch):
+    """Step 1 still wins over step 2a — an operator can close it even with vision on."""
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "ds-test-key")
+    monkeypatch.setenv("VISION_MODEL_ALLOWED", "true")
+    monkeypatch.setenv("DISABLED_MODELS", DS_VISION)
+    assert model_policy.is_model_enabled(DS_VISION) is False
+
+
+def test_vision_fail_open_does_not_open_other_models(monkeypatch):
+    """Only the ONE resolved vision model gets the exemption."""
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "ds-test-key")
+    monkeypatch.setenv("VISION_MODEL_ALLOWED", "true")
+    assert model_policy.is_model_enabled("gpt-5-codex") is False
+    assert model_policy.is_model_enabled("gemini-3-flash") is False
+    # ...including the vision model this box has no key for.
+    assert model_policy.is_model_enabled(MUSE) is True  # fail-open default, not vision
+    assert model_policy.is_model_enabled("deepseek-v4-pro") is False
+
+
+def test_vision_model_is_never_the_box_default_text_model(monkeypatch):
+    """It is a switch target, not a general-purpose model. If it could win the
+    enabled_default_model walk, every text turn on the box would run on it."""
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "ds-test-key")
+    monkeypatch.setenv("VISION_MODEL_ALLOWED", "true")
+    # Force the walk: disable both models the default would normally resolve to.
+    monkeypatch.setenv("DISABLED_MODELS", f"{MUSE},deepseek-v4-flash")
+    assert model_policy.enabled_default_model() != DS_VISION
+
+
+# --- the endpoint contract the frontend depends on -------------------------
+
+def test_available_models_reports_the_resolved_vision_model():
+    """index.js reads `vision_model` off this payload to pick its auto-switch
+    target. A missing field silently reverts the frontend to hardcoded Muse."""
+    import inspect
+
+    from app.routers import api
+
+    src = inspect.getsource(api.available_models)
+    assert '"vision_model": vision_model()' in src

--- a/app/websocket/request_handler.py
+++ b/app/websocket/request_handler.py
@@ -8,6 +8,7 @@ from app.websocket.web_socket_request_context import WebSocketRequestContext
 from app.lib.token_usage import extract_token_usage
 from app.lib.turn_metrics import start_turn
 from app.lib.rails_error_watch import resume_error_watch, start_error_watch
+from app.lib.turn_notices import start_turn_notices
 from typing import Dict, Optional
 
 from langchain_core.messages import HumanMessage
@@ -193,6 +194,10 @@ class RequestHandler:
                 "type": "model_substituted",
                 "requested": requested,
                 "effective": actual,
+                # Same frame now also carries a mid-turn failure fallback (see
+                # DynamicModelMiddleware). The banner words the two differently,
+                # so it has to be told which one it is rather than guessing.
+                "reason": "policy",
             })
         except Exception as e:
             logger.warning("Could not report a model substitution to the user: %s", e)
@@ -964,6 +969,16 @@ class RequestHandler:
                 agent_name=incoming_message.get("agent_name"),
                 api_token=incoming_message.get("api_token"),
             )
+
+            # Give the resilience ladder a way to speak. It runs inside
+            # DynamicModelMiddleware, several layers below this socket, and was
+            # completely silent: when a provider accepted requests and streamed
+            # nothing (2026-08-26), the browser showed a spinning shimmer for ten
+            # minutes and the customer's report was "no changes". Installed in
+            # the same async context and for the same reason as the two above.
+            # `websocket` here is the run's sink, so notices inherit thread_id
+            # stamping and replay-on-reattach. See app/lib/turn_notices.py.
+            start_turn_notices(websocket.send_json)
             turn_started_at = _time.monotonic()
             try:
                 app, state, agent_config = self.get_langgraph_app_and_state(incoming_message)
@@ -1249,6 +1264,13 @@ class RequestHandler:
                                                     # reply, so the mothership gets a per-message
                                                     # tokens/sec series next to the token counts.
                                                     timings=turn.last_model_call(),
+                                                    # Stable identity for this reply. Feedback used to be
+                                                    # matched by comparing message TEXT, so a stream cut
+                                                    # short by a dropped socket matched nothing and the
+                                                    # mothership fabricated a placeholder row from the
+                                                    # fragment (annotation #688). The browser echoes this
+                                                    # same id back when the user rates the message.
+                                                    message_key=str(getattr(message, "id", "") or "") or None,
                                                 ))
 
                                         # Report ToolMessage observations (tool outputs/observations).

--- a/docs/dev/adding_a_model.md
+++ b/docs/dev/adding_a_model.md
@@ -106,3 +106,24 @@ print(type(m).__name__, m.model_name, m.openai_api_base)"'
   error, and Fireworks imposes no small default of its own. Key: `FIREWORKS_API_KEY`,
   falling back to the `FIREWORKS_DEEPSEEK_API_KEY` name already deployed on boxes (one
   Fireworks account issues one key, so a per-model key name would be fiction).
+
+- **`qwen3.8-27b-hetzner`** — Qwen3.8-27B (dense) on **Hetzner's Inference API**
+  (`https://inference.hetzner.com/api/v1`), an EU-hosted OpenAI-compatible gateway, so
+  the client is a plain `ChatOpenAI` with an overridden `base_url` — not `ChatQwen`,
+  which exists for Alibaba DashScope's reasoning shape. Key: `HETZNER_API_KEY`.
+  262k context, text + image in. Hetzner serves a small, changing set of models and
+  `/v1/models` is the definitive list; `HETZNER_QWEN_MODEL` re-points this entry to
+  their other one (`Qwen/Qwen3.6-35B-A3B-FP8`, MoE, 35B total / 3B active, same context
+  and modalities) with no code change, and `HETZNER_BASE_URL` overrides the endpoint.
+
+  **The rate limit is on requests, not tokens: 10 per 60s per key** (against 4M in /
+  100k out tokens per 60s). One agentic Leo turn is many sequential requests, so a
+  single busy user can exhaust it. 429s are classified transient and retried by the
+  resilience middleware, so they surface as slow turns rather than failed ones — but
+  it is why this must not become a fleet default while the API is free/experimental.
+
+  Not yet verified against the live endpoint (no `HETZNER_API_KEY` on the dev box as
+  of 2026-08-30). Two things to check on first use: whether tool calling works at all
+  through their vLLM serve flags, and whether thinking arrives inline as
+  `<think>…</think>` inside `content` — if it does, `chat_template_kwargs=
+  {"enable_thinking": False}` (as on the RunPod Qwen3-8B entry) is the first knob.

--- a/docs/dev/error_telemetry.md
+++ b/docs/dev/error_telemetry.md
@@ -104,8 +104,8 @@ Different error classes need different rungs. **Blindly chaining "retry 3× → 
 | Rung | Trigger | Action | Status |
 |---|---|---|---|
 | **0. Tool-call repair** | malformed/orphaned tool call | re-feed error to model | ✅ exists |
-| **1. Retry same model** | *transient only* (429, timeout, 5xx, connection) | `with_retry` + backoff, silent | ⚠️ broaden from Google-only |
-| **2. Fallback model** | anything rung 1 didn't fix | `with_fallbacks([...])` → another enabled model | ➕ add (one-liner) |
+| **1. Retry same model** | *transient only* (429, timeout, 5xx, connection, zero-chunk stall) | re-call the handler + backoff, bounded by BOTH an attempt cap and a **wall-clock budget**; announced in the shimmer once it costs >10s | ✅ live (budget + notice: 0.7.5) |
+| **2. Fallback model** | rung 1 spent its budget on a *transient* failure | `model_policy.fallback_model()` → another enabled, buildable model; capability-aware; one rung only | ✅ live (0.7.5) |
 | **3. Graceful floor** | the *graph itself* threw | **stripped-down** DeepSeek call → friendly message + escape hatches | ➕ add (the UX win) |
 | **—. Report + escalate** | any rung fired | `report_error` to mothership + [Contact support] | ➕ §4 |
 
@@ -114,49 +114,79 @@ Different error classes need different rungs. **Blindly chaining "retry 3× → 
 1. **Retry the model call, never the whole turn.** Tools have side effects (Rails writes). Re-running a whole failed turn can double-write. The existing middleware already retries at the safe level (the model call) — keep it there.
 2. **Escalation is *within a single turn*, and mode-switching is an *offer*, not automatic.** No cross-session "3 errors → switch mode" counter (stateful bug farm). Silently moving a user into beginner mode mid-conversation is surprising UX. When rung 3 fires, *offer* a simpler retry — the user stays in control.
 
-### Rungs 1–2 live in `wrap_model_call` (`rails_agent/middleware.py:389`)
+### Rungs 1–2 live in `DynamicModelMiddleware` (`rails_agent/middleware.py:522`)
 
 > **Rung 1 also lives outside the middleware.** Raw StateGraph nodes
 > (`rails_beginner_agent`, `rails_ai_builder_agent`) invoke the model directly and
 > never touch `wrap_model_call`, so before 2026-07-12 they had *no* transient retry
 > at all — a single connection blip killed the turn. They now wrap each direct
 > `.invoke(...)` in `resilience.invoke_with_transient_retry(fn)`, which shares the
-> same classifier + backoff constants as the middleware loop. **Any new raw-node
+> same classifier, backoff constants AND wall-clock budget as the middleware loop (rung 2 does not reach them — a raw node hands over a thunk, not a model name). **Any new raw-node
 > agent must do the same** (or be built via `create_agent`, which gets the
 > middleware for free). Also note `httpx.ReadError`/`WriteError` (mid-stream socket
 > failures, empty `str(e)`) are classified transient as of the same date.
 
-Today (Google rate-limits only):
+`with_fallbacks` is deliberately *not* what shipped: it wraps the model, and a
+wrapped model has no `bind_tools`, which breaks every tool-calling agent (see
+`with_retry` breaking `bind_tools`, 0.6.x). Both rungs are an inline loop over
+`handler(...)` instead — the same pattern langchain's own `ModelRetryMiddleware`
+uses — so the raw chat model reaches the handler untouched:
 
 ```python
-model = get_llm(llm_model)
-model = model.with_retry(
-    retry_if_exception_type=(ResourceExhausted,),
-    stop_after_attempt=5,
-    wait_exponential_jitter=True,
-)
+llm_model = request.state.get('llm_model') or enabled_default_model()
+req, tried, started_at = self._override(request, llm_model), {llm_model}, time.monotonic()
+while True:
+    try:
+        return await handler(req)
+    except Exception as e:
+        if not is_transient_error(e):
+            raise                        # a 400 fails identically everywhere
+        if attempt >= _MODEL_RETRY_MAX_ATTEMPTS or elapsed >= _MODEL_RETRY_MAX_TOTAL_SECONDS:
+            fallback = fallback_model(llm_model, needs_vision=..., exclude=tried)
+            if fallback is None:
+                raise                    # rung 2 has nowhere to go
+            await _announce_fallback(llm_model, fallback, sync=False)
+            llm_model = fallback; ...; continue
+        if elapsed >= _RETRY_NOTICE_AFTER_SECONDS:
+            await _notify_retry(attempt, sync=False)
+        await asyncio.sleep(_model_retry_delay(attempt))
 ```
 
-Target — broaden retry to the *transient* class, then add a capability-aware fallback:
+### Why rung 1 needed a *clock*, not more attempts (0.7.5)
 
-```python
-model = get_llm(llm_model)
-# Rung 1: retry only genuinely transient failures (never deterministic 4xx)
-model = model.with_retry(
-    retry_if_exception_type=(ResourceExhausted, APITimeoutError, APIConnectionError, InternalServerError),
-    stop_after_attempt=3,
-    wait_exponential_jitter=True,
-)
-# Rung 2: fall back to a second enabled model if the primary keeps failing.
-#   Capability-aware: if the request carries an image, the fallback must be a
-#   vision-capable model; otherwise fall back to the text floor (DeepSeek).
-fallbacks = choose_fallbacks(llm_model, request)   # returns [] when none apply
-if fallbacks:
-    model = model.with_fallbacks([get_llm(m) for m in fallbacks])
-return handler(request.override(model=model))
-```
+2026-08-26, rsb-dev: the Muse Spark endpoint returned HTTP 200 and then streamed
+**zero chunks**. `langchain_openai`'s inherited 120s `stream_chunk_timeout` fired,
+the classifier called it transient — correctly — and rung 1 retried the same dead
+endpoint five times. **5 × 120s ≈ 10 minutes of a spinning shimmer.** The customer's
+report was "it runs for like 10 minutes with no changes."
 
-`with_fallbacks` alone would have **silently absorbed the `cache_control` crash** (fall to a model whose client accepts it, or to the stripped floor).
+The retry *count* was never wrong. The backoff (0.5–8s) was sized against a 503,
+whose failing attempt costs about a second; nobody sized the budget against an
+attempt that costs two minutes. **A 503 and a zero-chunk stall hit the same rung
+with a 100× difference in user impact — that asymmetry was the bug.** Three
+changes, all in this ladder:
+
+1. `llm_factory.stream_chunk_timeout_s()` — **25s, chosen not inherited**, applied
+   centrally in `get_llm` (11 `ChatOpenAI(` call sites; a per-site fix misses one).
+   Never disabled: a disabled chunk timeout is how a turn hangs forever.
+2. `resilience._MODEL_RETRY_MAX_TOTAL_SECONDS` — **60s**, checked before each
+   retry in all three loops. 60 and not 90 because what the user sits through is
+   the budget *plus* the attempt still in flight when it ran out: 60 + 25 = 85s.
+3. `_RETRY_NOTICE_AFTER_SECONDS` — a retry past 10s pushes
+   *"Model is not responding. Retrying (N of M)…"* into the thinking shimmer via
+   `app/lib/turn_notices.py`. Below the threshold it stays silent: a notice on
+   every 1-second 503 trains users to ignore the notice that matters.
+
+Rung 2's fallback rides the **existing** `model_substituted` frame (raised in
+`request_handler`, branched in `MessageHandler.js`, rendered as the banner above
+the composer) with a new `reason` field — `"policy"` for the pre-run substitution,
+`"fallback"` for a mid-turn stall. They are worded differently on purpose: reading
+a provider outage as "isn't enabled on this instance" is the wrong explanation.
+
+Escalation is capped at **one** fallback rung. `fallback_model` takes the models
+already tried, because on a Muse box the policy default *is* the model that
+stalled — without that, the resolver hands Muse back as DeepSeek's fallback and
+the pair bounces forever.
 
 ### Rung 3 lives at the outer net (`request_handler.py:824`)
 
@@ -340,7 +370,7 @@ The net makes failures graceful; these make the *common, known* cases actually s
 3. Rung-3 graceful floor at `request_handler.py` catch sites — bare DeepSeek call with **content stripped**.
 4. ✅ **DONE (method + wiring)** — `MothershipClient.report_error` + wired into all 3 handler catch sites via `RequestHandler._report_error_to_mothership`. Tests: `test_report_error.py`. *Remaining: the [Contact support] button → mothership emails support@llamapress.ai (frontend + mothership endpoint).*
 
-**Implementation status (this branch):** rungs 0 (tool-repair, pre-existing) and 1 (transient retry) are live; error telemetry to the mothership is live for all three chat error paths (`recovered=False` until the graceful floor lands). Not yet built: rung 2 fallback, rung 3 graceful floor, the [Contact support] button, and the §5 cures.
+**Implementation status (0.7.5):** rungs 0 (tool-repair), 1 (transient retry — now bounded by a wall clock and visible in the shimmer) and 2 (policy-resolved fallback model) are live; error telemetry to the mothership is live for all three chat error paths (`recovered=False` until the graceful floor lands). Not yet built: rung 3 graceful floor, the [Contact support] button, the §5 cures, and — the gap the 2026-08-26 incident exposed — **a `report_error`/`report_degradation` for a turn the ladder *recovered***. A retried transient error is still caught and swallowed, so `check_spike!` never runs: across that whole 20-minute customer-facing outage the box sent 0 `report_error` POSTs. The only detector we had was the customer.
 
 **Phase 2 — cures & mothership (driven by Phase-1 telemetry):**
 5. Model-aware image format (§5.1) + conservative capability default (§5.3).
@@ -360,7 +390,10 @@ Don't build Phase 3 until Phase 1's telemetry shows where the pain actually is.
 - Frontend render (lost): `app/frontend/chat/websocket/MessageHandler.js:1300-1301`
 - Phone-home channel: `app/services/mothership_client.py` (esp. `report_disconnect:281`)
 - Instance identity: `.leonardo/instance.json` via `MothershipClient._load_config` (`:27-49`)
-- Model retry chokepoint: `app/agents/leonardo/rails_agent/middleware.py:389-400` (`wrap_model_call`)
+- Model retry + fallback chokepoint: `app/agents/leonardo/rails_agent/middleware.py:568` (`wrap_model_call`) / `:629` (`awrap_model_call`)
+- Retry policy constants + classifier: `app/agents/leonardo/resilience.py`
+- Fallback resolution: `app/agents/leonardo/model_policy.py` (`fallback_model`)
+- Mid-run status frames: `app/lib/turn_notices.py`
 - Tool-call repair (exists): `app/agents/leonardo/agent_factory.py:112-126` (`build_leonardo_agent`)
 - Capability table + preflight: `app/agents/leonardo/model_capabilities.py`; consulted at `request_handler.py:1392`, `middleware.py:279`
 - Model wiring (Responses API): `app/agents/leonardo/llm_factory.py:171-184` (`gpt-5-nano`, `use_responses_api=True`)

--- a/docs/dev/openrouter_models.md
+++ b/docs/dev/openrouter_models.md
@@ -1,0 +1,154 @@
+# Adding an OpenRouter model (no code change)
+
+Every first-party model in LlamaBot costs six code edits to add — the dropdown,
+`get_llm`, `MODEL_CAPABILITIES`, `_KNOWN_MODELS`, the api-key map and the label
+map. `test_model_registry_consistency` exists to make missing one a red build.
+
+OpenRouter does not fit that shape. It is one OpenAI-compatible endpoint in front
+of hundreds of models, and each model is served by many *provider endpoints* that
+differ only in price, quantization and throughput — `deepseek/deepseek-v4-flash-0731`
+alone has 28. Trying one is a pricing experiment, not a code change, so they are
+config: **`.leonardo/openrouter_models.json`**.
+
+## The file
+
+```json
+{
+  "models": {
+    "deepseek-flash-0731-openinference": {
+      "label": "DeepSeek V4 Flash 0731 (OpenInference fp4)",
+      "short_label": "DS 0731 OI",
+      "model": "deepseek/deepseek-v4-flash-0731",
+      "provider": { "order": ["open-inference/fp4"], "allow_fallbacks": false },
+      "capabilities": { "images": false, "video": false, "pdf": false }
+    }
+  }
+}
+```
+
+The key (`deepseek-flash-0731-openinference`) is the name the frontend sends and
+the policy gates on. That block is the entire registration: it feeds `get_llm`,
+the capability table, the policy's known-models list, the api-key map and the
+dropdown. Restart is not required — the file is re-read on each call, so you can
+edit it and reload the chat page.
+
+| Field | Required | Meaning |
+|---|---|---|
+| `model` | **yes** | The OpenRouter model id. An entry without one is dropped with a warning — it could not build a client. |
+| `label` / `short_label` | no | Dropdown text. Defaults to the entry key. `short_label` is what inline notices use. |
+| `provider` | no | OpenRouter provider routing, verbatim. **Pin it** — see below. |
+| `capabilities` | no | `images` / `video` / `pdf`. Defaults to **text-only**. |
+| `enabled` | no | `false` parks the entry (keep the notes, hide the model). |
+| `reasoning` | no | `false` builds a plain `ChatOpenAI` instead of the reasoning-aware client. |
+| `extra_body` | no | Escape hatch for any other top-level OpenRouter request field. |
+
+## Always pin the provider
+
+Without a `provider` block, OpenRouter load-balances across every endpoint for
+that model. Two things break:
+
+- **Price.** `relace/fp4` is $0.040/$0.080 per M tokens; the same model routed to
+  DeepSeek direct is $0.44/$1.32. A silent reroute erases the reason you picked it.
+- **Prompt caching.** Cache hit rate is per-replica. A request that lands on a
+  different provider each turn caches nothing.
+
+`allow_fallbacks: false` means a provider outage is a **failed turn**, not a
+silent switch to a pricier endpoint. That is the intended default here. Flip it
+to `true` for a box that would rather pay than fail.
+
+Find the endpoint slugs for a model with:
+
+```bash
+curl -s https://openrouter.ai/api/v1/models/<author>/<slug>/endpoints \
+  | python3 -c "import json,sys; [print(e['tag'], e['quantization'], e['pricing']['prompt']) for e in json.load(sys.stdin)['data']['endpoints']]"
+```
+
+## What ships compiled in
+
+Three entries, all smoke-tested (tool calling, reasoning, streaming, through the
+pin). They are siblings, not alternatives — who serves and bills for a turn stays
+an explicit user choice:
+
+| Entry | Model | Endpoint | In/M | Out/M | Cache read/M | Uptime |
+|---|---|---|---|---|---|---|
+| `deepseek-flash-0731-relace` | DS V4 Flash 0731 | `relace/fp4` | $0.040 | $0.080 | $0.0080 | 97.94% |
+| `deepseek-flash-0731-digitalocean` | DS V4 Flash 0731 | `digitalocean` | $0.080 | $0.252 | $0.0252 | 99.06% |
+| `glm-5.3-flash-zai` | GLM 5.3 Flash | `z-ai/fp8` | $0.075 | $0.250 | $0.0150 | 99.44% |
+
+For reference, the same model at DeepSeek direct is $0.44/$1.32. Relace is the
+cheap one; DigitalOcean costs ~2-3x more and buys better uptime and a named US
+host. With `allow_fallbacks: false`, a provider's downtime is a failed turn, so
+uptime is not a footnote.
+
+> **Measured caveat (2026-08-26): DigitalOcean's tool calling is unreliable.**
+> Against the real 22.8k-token agent prompt it invented tool names that were
+> never bound (`Read`, `exec_command`, `list_files`, `exec`) in 4 of 9 turns, and
+> once emitted its raw tool-call template as plain text instead of a structured
+> call — a serving-side tool-parser defect. Relace scored 12/12 correct tool
+> choice with zero invented names and was ~5x faster. Relace's own weakness is
+> availability: it 502s under queue pressure (`Queued past the 5s queue-time
+> bound`), which `allow_fallbacks: false` turns into a failed turn. Those 502s
+> are now classified transient and retried (see `resilience._status_code_of`).
+>
+> **Single probes do not surface either problem.** Measure a new endpoint at
+> volume, against a real prompt with real tools bound, before trusting it.
+
+`glm-5.3-flash-zai` (added 2026-08-27) is a different model on the same routing.
+Probed the same way — 12 turns, real prompt, real tools — it scored **12/12
+correct tool choice, zero invented names, zero template leaks**, matching Relace
+and unlike DigitalOcean. Two things distinguish it:
+
+- **Prompt caching lands hard.** 22,208 of 22,250 input tokens returned as cache
+  reads, billed at $0.015/M instead of $0.075/M. On a steady-state Leo turn that
+  is most of the input cost gone.
+- **It is slower.** ~7s/turn vs 1.6s on Relace, with ttft ~5s. It is a reasoning
+  model and that is thinking time (well inside the 25s stall detector), but pick
+  Relace for a latency-sensitive box.
+
+It is also **1M+ context** and the only compiled-in entry that can see images —
+verified through the pin, not assumed. Jurisdiction is the open question: `z-ai/fp8`
+is a first-party Chinese host, and the same weights are served from the US by
+`baseten/fp8` and `cloudflare` at $0.15/$0.50. Changing `order` in the overlay
+moves it without a rebuild.
+
+**Quantization tells you less than it looks.** Relace is explicitly `fp4`;
+DigitalOcean reports `unknown`, which is unreported metadata rather than a claim
+of higher precision — 10 of this model's 29 endpoints report `unknown`, including
+DeepSeek's own and Fireworks. Assume nothing from the field; if fp4 output
+quality matters for a task, test it.
+
+Neither appears on a box without an `OPENROUTER_API_KEY`.
+
+## Credentials and policy
+
+One key for everything: `OPENROUTER_API_KEY`. `OPENROUTER_BASE_URL` overrides the
+endpoint (a proxy, or a mock in tests).
+
+**Registering a model enables it.** The file is operator-owned and host-mounted,
+the same trust tier as `instance.json` and `ENABLED_MODELS`, so the act of adding
+a block is the operator saying "offer this" — requiring `ENABLED_MODELS` as well
+would be configuring one intent twice. Still true:
+
+- `DISABLED_MODELS` wins over a registration.
+- `MODEL_SWITCHING_ALLOWED=false` still pins the box to its default model.
+- A registered model is never chosen as a box's *default*; it is a thing a user
+  picks.
+
+## Gotchas
+
+- **Capabilities default to text-only**, the opposite of the unknown-model default
+  elsewhere. Declaring `images: true` for a model that cannot see them offers an
+  upload that 400s at the provider, so it is opt-in.
+- **Probe vision with a realistic image.** An 8x8 test PNG is rejected by Z.AI
+  with `400 code 1210 图片输入格式/解析错误` — indistinguishable from "this
+  endpoint has no vision path". The same model describes a 256x256 PNG correctly.
+  A tiny probe image will talk you out of a capability the model actually has.
+- **A malformed file is ignored, not fatal** — you get the compiled-in base and a
+  warning in the container logs. Check the logs if a model you added never shows up.
+- **Reasoning survives the routing** — verified on both compiled-in entries:
+  `reasoning_content` arrives populated and streams as deltas, so thinking renders
+  the same as on DeepSeek direct. Do not assume that for a *new* endpoint though;
+  it is the first thing to check, and `"reasoning": false` is the escape hatch.
+- **Third data processor.** A routed request goes to OpenRouter *and* the chosen
+  provider. The move to Fireworks for DeepSeek was made on jurisdiction grounds;
+  routing re-opens that question with a different set of names.

--- a/docs/dev_logs/0.7.5
+++ b/docs/dev_logs/0.7.5
@@ -1,0 +1,20 @@
+0.7.5:
+[x] - Leo can look at images on a box with no META key — DeepSeek's vision model is now an option, so image understanding runs on the DeepSeek key every box already has.
+[x] - The model Leo switches to when you attach an image is now chosen per box instead of always being Muse Spark.
+[x] - Models can be added from a config file now, no code change — drop a block in .leonardo/openrouter_models.json and it shows up in the dropdown.
+[x] - Added DeepSeek V4 Flash 0731 via OpenRouter pinned to Relace fp4 — same model, roughly a fifth of the price per token.
+[x] - Added the same model on DigitalOcean as a second choice — costs more than Relace, but better uptime and a US host.
+[x] - When Leo asks several questions at once you now answer them one at a time — "Question 2 of 3" with Back/Next — instead of scrolling a stacked list.
+[x] - A stalled model is dropped in 90 seconds, not 10 minutes.
+[x] - Leo finishes on a second model when the first stops responding.
+[x] - Leo now says it's retrying instead of silently spinning.
+[x] - Added GLM 5.3 Flash (Z.AI) as a model option — over a million tokens of context, it can look at images, and it is the cheapest per-token option in the dropdown.
+[x] - Leo's answer survives a dropped connection instead of cutting off mid-sentence.
+[x] - A rejected model request now logs what we sent, so the 400s are diagnosable.
+[x] - Rails restarts itself after a crash instead of sitting there dead.
+[x] - Agent and CLI credentials can no longer be committed by accident.
+[x] - Uploads written to the wrong folder survive an update instead of vanishing.
+[x] - Login stops failing when the browser sends a preflight request first.
+[x] - /cookbook now searches your own recipes too, not just the public ones.
+[x] - Feedback bubble keeps your text and retries after a session times out.
+[x] - Added Qwen3.8 27B on Hetzner's EU inference API as a model option — 262k context, reads images, and free while Hetzner's API is experimental.

--- a/docs/test_plans/0.7.5.md
+++ b/docs/test_plans/0.7.5.md
@@ -1,0 +1,197 @@
+# Test plan — 0.7.5
+
+Manual QA checklist for user-visible changes in 0.7.5. See `README.md` for conventions.
+The full change list for this release lives in `docs/dev_logs/0.7.5`.
+
+**Status:** in progress
+**Tester:**
+**Date:**
+
+---
+
+## A stalled model no longer reads as a frozen agent
+
+Before this, a provider that accepted the request and then sent **nothing** cost the user
+about ten minutes of a spinning shimmer. Leo retried the same dead endpoint five times at
+two minutes each, said nothing while it did, and had no second model to try. That is the
+2026-08-26 RSB incident: *"engineering mode is not working… it runs for like 10 minutes
+with no changes."*
+
+Three things changed. A stalled stream is now abandoned after 25 seconds instead of 120.
+The retry rung is capped by a **wall clock** (60s) as well as an attempt count, so the
+worst case is ~85 seconds, not ~600. And when that budget is spent, Leo **moves to another
+model** and tells you so, instead of failing.
+
+**Setup**
+
+- Change is in **LlamaBot** — needs a released image or a `--force-recreate` (uvicorn runs
+  without `--reload`), plus a hard refresh for the banner JS.
+- Code: `app/agents/leonardo/llm_factory.py` (`stream_chunk_timeout_s`,
+  `_apply_stream_chunk_timeout`), `app/agents/leonardo/resilience.py`,
+  `app/agents/leonardo/model_policy.py` (`fallback_model`),
+  `app/agents/leonardo/rails_agent/middleware.py` (`DynamicModelMiddleware`),
+  `app/lib/turn_notices.py`, `app/websocket/request_handler.py`,
+  `app/frontend/chat/index.js`, `app/frontend/chat/websocket/MessageHandler.js`.
+  Automated coverage: `app/tests/test_model_stall_resilience.py`,
+  `app/tests/test_resilience_transient_retry.py`,
+  `app/tests/js/model_substitution_notice.test.mjs`.
+- Most of this only shows up when a provider is genuinely broken, so **the stall has to be
+  faked**. See "How to fake a stall" below — you do not need a real outage.
+
+### How to fake a stall
+
+Point the box at a stub that returns HTTP 200 and then holds the connection open sending
+nothing — exactly what the provider did. Anything that serves an SSE response and never
+writes a chunk works; the smallest version is a few lines of Python:
+
+```python
+# stall.py — run on the box, then set DEEPSEEK_API_BASE (or the relevant provider base)
+# to http://<box>:9000/v1 in ~/dev/Leonardo/.env and force-recreate llamabot.
+from http.server import BaseHTTPRequestHandler, HTTPServer
+import time
+
+class Stall(BaseHTTPRequestHandler):
+    def do_POST(self):
+        self.send_response(200)
+        self.send_header("Content-Type", "text/event-stream")
+        self.end_headers()
+        time.sleep(600)          # accepted, then silence
+
+HTTPServer(("0.0.0.0", 9000), Stall).serve_forever()
+```
+
+Remember to put the real base URL back afterwards and force-recreate again.
+
+### The turn does not hang
+
+- [ ] Send a normal chat message against the stalling endpoint. Something visibly happens
+      (a status line, an error, or an answer) **within about 90 seconds** — not ten minutes.
+- [ ] Time it roughly with a phone. Two minutes of silence with no status line at all is a
+      failure of this change, not a slow model.
+- [ ] The container log shows `Giving up on <model> after …s` or `<model> stalled for …s;
+      finishing this step on <other model>` — not five repeats of the same retry line.
+
+### Leo says something while it is retrying
+
+- [ ] Past roughly ten seconds of retrying, the thinking shimmer reads
+      **"Model is not responding. Retrying (N of M)…"**.
+- [ ] That text appears **in the shimmer**, not as a chat message from Leo in the
+      transcript. If it lands in the transcript, the frame is being mis-rendered.
+- [ ] Now send a normal message against a **healthy** model. No retry notice appears at
+      all. (This is the important negative: a notice on every turn trains people to ignore
+      it.)
+
+### It finishes on another model
+
+- [ ] On a box with two enabled models (e.g. Muse + DeepSeek), stall the selected one. The
+      turn **completes** with a real answer.
+- [ ] A banner appears above the composer reading **"<Model> stopped responding — finished
+      this step on <Other model>."**
+- [ ] The banner auto-hides after ~12 seconds.
+- [ ] The model **dropdown still shows your original pick** — the fallback is for this step,
+      not a permanent change to your selection.
+- [ ] Reload and send another message: it goes back to the model you picked. Nothing was
+      silently remembered.
+
+### The other banner still works and reads differently
+
+- [ ] Pick a model that is **not** in this box's `enabled_models` (see
+      `.leonardo/instance.json`), then send a message. The banner reads **"<Model> isn't
+      enabled on this instance — answering with <Other> instead."**
+- [ ] Confirm those two banners are worded differently. The outage one must not say "isn't
+      enabled on this instance" — that explains a provider outage as a permissions problem.
+
+### Degrades safely
+
+- [ ] On a box pinned to a single model (`MODEL_SWITCHING_ALLOWED=false`), a stall ends in a
+      normal error message. There is no banner naming a model the box cannot run.
+- [ ] Attach an image and stall the vision model. Leo either finishes on another
+      **image-capable** model or fails honestly — it must never answer a question about the
+      screenshot on a model that cannot see it.
+- [ ] Send a message that fails deterministically (an unsupported attachment type on a
+      text-only model). It fails **immediately**, with no retry notice and no fallback
+      banner — a bad request fails the same way everywhere, so retrying it just wastes the
+      user's time.
+- [ ] Normal, healthy turns are unchanged: no new banner, no new shimmer text, same speed.
+
+### Not yet covered by a manual plan
+
+Everything else in `docs/dev_logs/0.7.5` (the DeepSeek vision model, the OpenRouter model
+registry, the one-at-a-time question cards) shipped earlier in this release without a
+section here.
+
+**Known gap, deliberately not built in 0.7.5:** a turn the ladder *recovers* still reports
+nothing to the mothership, so a fleet-wide provider stall is invisible until a customer
+complains. That is part 5 of the incident ticket and needs the mothership's matching
+receiver — see `docs/dev/error_telemetry.md` §3.
+
+---
+
+## Dropped connection mid-answer (inbox 2026-08-28, 45 of 57 reporting boxes)
+
+**Why this matters:** the socket dies mid-run, ActionCable reconnects the pipe but nothing
+replays the run, so the final answer renders starting mid-sentence. On `rsb-dev` the
+customer saw the last 435 characters of a complete 906-character reply and had no way to
+know anything was missing. Only 1 of 122 such events ever produced a complaint.
+
+- [ ] Ask Leo for something that takes ~60s (e.g. "add a sortable column to a page").
+- [ ] While it is answering, kill the socket: DevTools → Network → Offline for ~10s, then
+      back Online. (Or `docker compose restart llamabot` mid-run.)
+- [ ] The reply that ends up on screen is COMPLETE — it starts at the beginning of a
+      sentence, not mid-word. Compare against the box's own log or the mothership's
+      `InstanceMessage` for that thread.
+- [ ] The thinking indicator stops spinning after the reconnect. It must not keep going.
+- [ ] There is exactly ONE assistant bubble for that turn — no duplicate, no truncated
+      bubble left above the corrected one.
+- [ ] The composer is usable again afterwards without a page reload. (Before this, the send
+      button stayed disabled forever on ActionCable boxes.)
+- [ ] Do the same on an idle chat (drop the socket while Leo is NOT answering): nothing
+      repaints, no refetch, the thread is left exactly as it was.
+
+## Login preflight (inbox 2026-08-07, SI leo-nefe)
+
+- [ ] `curl -s -o /dev/null -w "%{http_code}\n" -X OPTIONS -H "Origin: https://llamapress.ai"
+      -H "Access-Control-Request-Method: GET" http://127.0.0.1:8000/auth/consume`
+      → **204** (was 400).
+- [ ] Same for `/login` → **204**.
+- [ ] Normal sign-in through "Open Leo" on llamapress.ai still works end to end.
+- [ ] The box's llamabot log shows no `OPTIONS … 400` lines at all.
+
+## Phones can reach Leo-built apps (SI#344)
+
+- [ ] From a real older phone, or DevTools device emulation with an iOS Safari 16.6 UA,
+      open a Leo-built app's sign-in page. It loads — **not** a "browser not supported" page.
+- [ ] Chrome/Safari on desktop are unaffected.
+
+## Feedback bubble survives a session timeout (SI#342)
+
+- [ ] Open a Leo-built app, open the feedback bubble, type a long message but do NOT send.
+- [ ] In another tab, sign out (or wait for the app's Devise timeout).
+- [ ] Press Send. Expect a plain-English "session expired" message with a **Sign in again**
+      button — NOT "Status: 422" and not a Rails debug page.
+- [ ] Sign in again; the bubble reopens with your text still in it.
+- [ ] Send it. It submits, and the draft is cleared (reopening shows an empty box).
+
+## Personal cookbook in /cookbook
+
+- [ ] Type `/cookbook` in chat. Recipes the box owner published show a **"yours"** badge.
+- [ ] Type `/cookbook <word from one of your own recipes>` — yours appears; picking it
+      inserts an `@cookbook:` mention whose URL is `/cookbook/u/<handle>/<slug>`.
+- [ ] Ask Leo to follow that mention — it curls the `.json` and applies the recipe.
+- [ ] On a box with no mothership token, `/cookbook` still lists the fleet guides normally.
+
+## Rails self-heals after a crash (SI#207)
+
+- [ ] `docker compose exec -T llamapress pkill -9 -f puma`
+- [ ] Within ~1 minute `curl -s -o /dev/null -w "%{http_code}\n" localhost:3000/` returns 200
+      again, and `docker compose ps` had shown `(unhealthy)` in between.
+- [ ] Kill Puma 4+ times in a row: it stops retrying and the container stays alive so
+      `tail_rails_logs` still works (the debug husk must not be lost).
+
+## Uploads survive an image bump (SI#327)
+
+- [ ] Upload a file to a Leo-built app, then `docker compose up -d --force-recreate llamapress`.
+- [ ] The file is still there and still renders.
+- [ ] Inside the container as uid 1000: `touch /rails/storage/probe` succeeds (was EACCES).
+- [ ] `docker compose exec llamapress bundle exec rails runner
+      'puts ActiveStorage::Blob.service.root'` prints `/rails/storage`, not a tmp path.


### PR DESCRIPTION
[x] - Leo can look at images on a box with no META key — DeepSeek's vision model is now an option, so image understanding runs on the DeepSeek key every box already has. [x] - The model Leo switches to when you attach an image is now chosen per box instead of always being Muse Spark. [x] - Models can be added from a config file now, no code change — drop a block in .leonardo/openrouter_models.json and it shows up in the dropdown. [x] - Added DeepSeek V4 Flash 0731 via OpenRouter pinned to Relace fp4 — same model, roughly a fifth of the price per token. [x] - Added the same model on DigitalOcean as a second choice — costs more than Relace, but better uptime and a US host. [x] - When Leo asks several questions at once you now answer them one at a time — "Question 2 of 3" with Back/Next — instead of scrolling a stacked list. [x] - A stalled model is dropped in 90 seconds, not 10 minutes. [x] - Leo finishes on a second model when the first stops responding. [x] - Leo now says it's retrying instead of silently spinning. [x] - Added GLM 5.3 Flash (Z.AI) as a model option — over a million tokens of context, it can look at images, and it is the cheapest per-token option in the dropdown. [x] - Leo's answer survives a dropped connection instead of cutting off mid-sentence. [x] - A rejected model request now logs what we sent, so the 400s are diagnosable. [x] - Rails restarts itself after a crash instead of sitting there dead. [x] - Agent and CLI credentials can no longer be committed by accident. [x] - Uploads written to the wrong folder survive an update instead of vanishing. [x] - Login stops failing when the browser sends a preflight request first. [x] - /cookbook now searches your own recipes too, not just the public ones. [x] - Feedback bubble keeps your text and retries after a session times out. [x] - Added Qwen3.8 27B on Hetzner's EU inference API as a model option — 262k context, reads images, and free while Hetzner's API is experimental.