### PR TITLE
0.7.6:

### DIFF
--- a/app/agents/leonardo/llm_factory.py
+++ b/app/agents/leonardo/llm_factory.py
@@ -28,9 +28,16 @@ from langchain_openai import ChatOpenAI
 from langchain_qwq import ChatQwen
 
 from app.agents.leonardo.openrouter_models import (
+    API_KEY_ENV as _OPENROUTER_API_KEY_ENV,
     api_base as openrouter_api_base,
     get_openrouter_model,
+    is_openrouter_model,
 )
+
+
+def openrouter_api_key_env() -> str:
+    """The single env var every OpenRouter-routed model authenticates with."""
+    return _OPENROUTER_API_KEY_ENV
 
 
 logger = logging.getLogger(__name__)
@@ -45,6 +52,29 @@ DEFAULT_LLM_MODEL = "muse-spark-1.2-contributor"
 # always build this one, so it is what keeps chat working on a box the Muse
 # rollout has not reached (or that deliberately opts out).
 FALLBACK_TEXT_MODEL = "deepseek-v4-flash"
+
+
+def default_llm_model() -> str:
+    """The default model this box is TOLD to run, before any buildability check.
+
+    Read at call time so a .env sweep plus a restart moves the fleet. Until 0.7.6
+    this was a bare constant, so when Meta retired the compiled default on
+    2026-08-31 — 89% of fleet turns — nothing in the box could be told to run
+    anything else, and a config outage needed a release to fix.
+
+    Env only; the mothership override is layered on in
+    :func:`model_policy.configured_default_model`, which owns the full precedence.
+    """
+    return (os.getenv("DEFAULT_LLM_MODEL") or "").strip() or DEFAULT_LLM_MODEL
+
+
+def fallback_text_model() -> str:
+    """What a locked-out box runs, overridable with ``FALLBACK_TEXT_MODEL``.
+
+    A fleet forbidden from running DeepSeek has to be able to move this too, or
+    the last line of defence is still a banned model.
+    """
+    return (os.getenv("FALLBACK_TEXT_MODEL") or "").strip() or FALLBACK_TEXT_MODEL
 
 # --- Stall detection -------------------------------------------------------
 #
@@ -257,7 +287,17 @@ def has_provider_key(model_name: str) -> bool:
     A model absent from `DEFAULT_MODEL_KEY_ENVS` reports True: this is not a
     general reachability check and must not start disabling models it has no
     opinion about.
+
+    The one exception is an OpenRouter-registered model. Those are absent from the
+    map by construction (they are added from config, not code), so they all
+    reported True — including on a box with no OPENROUTER_API_KEY. That was
+    harmless while such a model could never BE the default; once an operator can
+    name one, it means the box "defaults" to something that 401s on every turn.
+    They route through one shared credential, so the check is exact.
     """
+    if is_openrouter_model(model_name):
+        return provider_key(openrouter_api_key_env()) != _MISSING_KEY_PLACEHOLDER
+
     env_vars = DEFAULT_MODEL_KEY_ENVS.get(model_name)
     if not env_vars:
         return True

--- a/app/agents/leonardo/model_health.py
+++ b/app/agents/leonardo/model_health.py
@@ -1,0 +1,78 @@
+"""Short-lived memory of models that answered "I no longer exist".
+
+Meta retired ``muse-spark-1.2-contributor`` on 2026-08-31 while it carried 89% of
+fleet turns. Every request to it returned a deterministic 404. Without this module
+each turn re-discovers that 404, waits for it, announces a fallback and only then
+answers — for as long as the retirement lasts, which is forever.
+
+Recording the death lets the policy layer route around it BEFORE spending a call.
+
+Deliberately in-process and TTL'd rather than persisted:
+
+- **In-process** because it is a cache, not a decision. A restart re-learns it from
+  one cheap 404, and nothing important is lost. Persisting it would mean a wrong
+  entry could outlive the incident that caused it.
+- **TTL'd** because a retirement can be reversed and a 404 can be the provider
+  having a bad day. A death record that never expires turns a transient blip into
+  a permanent capability loss, which is a worse failure than the one it prevents.
+
+The policy layer treats this as advisory and stays fail-open: if every known model
+is marked gone, it still returns a model rather than locking the box out of chat.
+"""
+import logging
+import threading
+import time
+
+logger = logging.getLogger(__name__)
+
+#: How long a model stays marked gone. Long enough that a real retirement is not
+#: re-probed on every turn, short enough that a reversal heals without a restart.
+TTL_SECONDS = 15 * 60
+
+_lock = threading.Lock()
+_gone: dict[str, float] = {}
+
+
+def _now() -> float:
+    """Monotonic clock, isolated so tests can move time without sleeping."""
+    return time.monotonic()
+
+
+def mark_model_gone(model_name: str) -> None:
+    """Remember that ``model_name`` reported itself retired."""
+    if not model_name:
+        return
+    with _lock:
+        first_time = model_name not in _gone
+        _gone[model_name] = _now()
+    if first_time:
+        logger.warning(
+            "Model %s reported as retired by its provider; routing around it for "
+            "the next %ds. If this is the box default, set DEFAULT_LLM_MODEL.",
+            model_name, TTL_SECONDS,
+        )
+
+
+def is_gone(model_name: str) -> bool:
+    """True if ``model_name`` was recently seen to be retired."""
+    with _lock:
+        marked_at = _gone.get(model_name)
+        if marked_at is None:
+            return False
+        if _now() - marked_at > TTL_SECONDS:
+            del _gone[model_name]
+            return False
+        return True
+
+
+def gone_models() -> set[str]:
+    """Every model currently marked gone, expired entries dropped."""
+    with _lock:
+        names = list(_gone)
+    return {name for name in names if is_gone(name)}
+
+
+def reset() -> None:
+    """Forget every death record. For tests, and for an operator-forced re-probe."""
+    with _lock:
+        _gone.clear()

--- a/app/agents/leonardo/model_policy.py
+++ b/app/agents/leonardo/model_policy.py
@@ -64,10 +64,12 @@ import logging
 import os
 from typing import Optional
 
+from app.agents.leonardo import model_health
 from app.agents.leonardo.llm_factory import (
     _CHATGPT_SUBSCRIPTION_MODELS,
     DEFAULT_LLM_MODEL,
     FALLBACK_TEXT_MODEL,
+    fallback_text_model,
     has_provider_key,
 )
 from app.agents.leonardo.openrouter_models import (
@@ -235,6 +237,100 @@ def model_switching_allowed() -> bool:
     return _env_bool("MODEL_SWITCHING_ALLOWED", _MODEL_SWITCHING_ALLOWED_DEFAULT)
 
 
+def remote_policy() -> dict:
+    """Model policy the mothership pushed to this box. ``{}`` when none.
+
+    Every key is validated independently and a malformed one is DROPPED rather
+    than poisoning the payload: this channel reaches every box in a single lease
+    interval, so one bad value must not be able to take the fleet down. Patched
+    wholesale in tests.
+    """
+    try:
+        from app.services import model_policy_store
+
+        raw = model_policy_store.load()
+    except Exception as e:  # noqa: BLE001 — never let telemetry config break chat
+        logger.warning("Ignoring unreadable remote model policy: %s", e)
+        return {}
+
+    clean: dict = {}
+    default_model = raw.get("default_model")
+    if isinstance(default_model, str) and default_model.strip():
+        clean["default_model"] = default_model.strip()
+    elif default_model is not None:
+        logger.warning("Remote model policy: ignoring non-string default_model %r", default_model)
+
+    for key in ("disabled_models", "enabled_models"):
+        value = raw.get(key)
+        if value is None:
+            continue
+        if isinstance(value, list) and all(isinstance(v, str) for v in value):
+            names = [v.strip() for v in value if v.strip()]
+            if names:
+                clean[key] = names
+        else:
+            logger.warning("Remote model policy: ignoring malformed %s %r", key, value)
+    return clean
+
+
+def configured_default_model() -> Optional[str]:
+    """The model this box was TOLD to run, or None if nobody said.
+
+    Precedence, most specific first: **mothership > instance.json > env**. The
+    compiled constant is deliberately NOT part of this — "nobody configured a
+    default" and "the default happens to equal the compiled one" are different
+    facts, and only the first should fall through to the normal policy walk.
+
+    The mothership outranks a box's own .env because it is the operator of record
+    on a fleet box: a stale hand-edit made during the last incident must not make
+    the next remote fix silently no-op on exactly the boxes someone touched.
+    """
+    remote = remote_policy().get("default_model")
+    if remote:
+        return remote
+
+    config = _read_instance_config() or {}
+    instance_default = config.get("default_model")
+    if isinstance(instance_default, str) and instance_default.strip():
+        return instance_default.strip()
+
+    env_default = (os.getenv("DEFAULT_LLM_MODEL") or "").strip()
+    return env_default or None
+
+
+def _usable_configured_default() -> Optional[str]:
+    """The configured default, but only if this box can actually run it.
+
+    The invariant that outranks the operator's intent: the box always resolves to
+    a model it can build. A default that is unknown, keyless, or currently
+    answering 404 degrades to the normal walk instead of locking chat out — a bad
+    remote value must never be more damaging than the outage it was sent to fix.
+    """
+    name = configured_default_model()
+    if not name:
+        return None
+    if name not in known_models():
+        logger.warning(
+            "Configured default model %r is not a model this build knows; "
+            "ignoring it and resolving normally.", name,
+        )
+        return None
+    if not has_provider_key(name):
+        logger.warning(
+            "Configured default model %r has no provider key on this box; "
+            "ignoring it so turns do not 401. Set the key or change the default.",
+            name,
+        )
+        return None
+    if model_health.is_gone(name):
+        logger.warning(
+            "Configured default model %r is reporting itself retired; routing "
+            "around it until the record expires.", name,
+        )
+        return None
+    return name
+
+
 def default_text_model() -> str:
     """The default model THIS box can actually build.
 
@@ -248,9 +344,13 @@ def default_text_model() -> str:
     here; this answers only "is it buildable". ``enabled_default_model`` layers
     the policy on top.
     """
+    configured = _usable_configured_default()
+    if configured:
+        return configured
+
     if has_provider_key(DEFAULT_LLM_MODEL):
         return DEFAULT_LLM_MODEL
-    return FALLBACK_TEXT_MODEL
+    return fallback_text_model()
 
 
 def vision_allowed() -> bool:
@@ -291,13 +391,20 @@ def _allowlist() -> Optional[set]:
     in the module docstring) rather than "everything is enabled".
     """
     env_allow = _csv_names(os.environ.get("ENABLED_MODELS", "")) or None
+    remote_allow = remote_policy().get("enabled_models") or None
     allow: Optional[set] = None
-    for source in (_instance_list("enabled_models"), env_allow):
+    for source in (_instance_list("enabled_models"), env_allow, remote_allow):
         if source is None:
             continue
         source_set = set(source)
         allow = source_set if allow is None else (allow & source_set)
     if allow is None:
+        # No allow-list configured anywhere. A box told to run a specific model
+        # gets that model, not the compiled two — same reasoning as the fail-open
+        # narrowing above.
+        configured = _usable_configured_default()
+        if configured:
+            return {configured, *_CHATGPT_SUBSCRIPTION_MODELS}
         return set(_DEFAULT_ENABLED_MODELS)
     return allow
 
@@ -309,7 +416,23 @@ def _disabled_set() -> set:
     instance_disabled = _instance_list("disabled_models") or []
     disabled.update(env_disabled)
     disabled.update(instance_disabled)
+    # The mothership can disable too — same union rule as every other source, so
+    # a remote ban cannot be broadened away by a stale local list.
+    disabled.update(remote_policy().get("disabled_models") or [])
     return disabled
+
+
+def _fail_open_models() -> frozenset:
+    """Models that survive any allow-list, so a box always keeps something runnable.
+
+    Normally the compiled pair. Once the operator names a default this box can
+    actually build, that model IS the guarantee and the compiled pair loses the
+    privilege — otherwise a retired compiled default stays selectable forever.
+    """
+    configured = _usable_configured_default()
+    if configured:
+        return frozenset({configured})
+    return _FAIL_OPEN_MODELS
 
 
 def is_model_enabled(model_name: str) -> bool:
@@ -317,6 +440,13 @@ def is_model_enabled(model_name: str) -> bool:
 
     See the module docstring for the full resolution order.
     """
+    # 0. The box's CONFIGURED default outranks even an explicit disable. An
+    #    operator who names a default and then disables it has contradicted
+    #    himself, and the alternative reading leaves the box with no model at all.
+    #    Scoped to an explicitly configured default: disabling the COMPILED
+    #    default keeps its old meaning.
+    if model_name and model_name == configured_default_model():
+        return True
     # 1. Explicit disable wins over everything — even the fail-open defaults.
     if model_name in _disabled_set():
         return False
@@ -334,8 +464,13 @@ def is_model_enabled(model_name: str) -> bool:
         if model_name == vision_model() and vision_allowed():
             return True
         return False
-    # 3. The fail-open defaults are globally enabled (survive any allow-list).
-    if model_name in _FAIL_OPEN_MODELS:
+    # 3. The fail-open defaults are globally enabled (survive any allow-list) —
+    #    but a box with a usable CONFIGURED default already has its guaranteed
+    #    runnable model, so the compiled pair stops being fail-open. That is what
+    #    lets the substitution reach a user whose 365-day llmModel cookie still
+    #    names the retired model: while Muse stayed fail-open it remained
+    #    "enabled" and effective_model handed it straight back.
+    if model_name in _fail_open_models():
         return True
     # 3a. So is the box's resolved vision model, whenever vision is switched on.
     #     Without this, a DeepSeek-only box could never reach the vision model:
@@ -370,10 +505,24 @@ def enabled_default_model() -> str:
     (misconfiguration), returns the fallback text model anyway so the instance is
     never locked out of chat.
     """
+    # A configured default wins outright, fail-open: the policy lists must not be
+    # able to disable the box's own default out from under it and drop it back on
+    # the compiled fallback. That is exactly the shape of the 2026-08-31 outage —
+    # banning DeepSeek fleet-wide would have put every box ON DeepSeek, because
+    # the lockout path returned the compiled constant and ignored the disable list.
+    configured = _usable_configured_default()
+    if configured:
+        return configured
+
     preferred = default_text_model()
-    if is_model_enabled(preferred):
+    if is_model_enabled(preferred) and not model_health.is_gone(preferred):
         return preferred
     for name in known_models():
+        # A model that just told us it no longer exists is not a fallback. Without
+        # this, every turn re-discovers the same 404 and pays for it before
+        # answering, for as long as the retirement lasts.
+        if model_health.is_gone(name):
+            continue
         # Never resolve the box default onto a model paid for by an individual
         # user's ChatGPT plan: a user who has connected nothing could not chat at
         # all. _KNOWN_MODELS lists them last, which used to be enough — it stopped
@@ -394,13 +543,15 @@ def enabled_default_model() -> str:
             continue
         if is_model_enabled(name):
             return name
+    lockout_fallback = fallback_text_model()
     logger.warning(
         "Model policy disables all known models; falling back to %s. "
         "Check enabled_models/disabled_models in instance.json and "
-        "ENABLED_MODELS/DISABLED_MODELS.",
-        FALLBACK_TEXT_MODEL,
+        "ENABLED_MODELS/DISABLED_MODELS. Set DEFAULT_LLM_MODEL (or "
+        "FALLBACK_TEXT_MODEL) to choose what a locked-out box runs.",
+        lockout_fallback,
     )
-    return FALLBACK_TEXT_MODEL
+    return lockout_fallback
 
 
 def fallback_model(
@@ -452,7 +603,8 @@ def fallback_model(
     # the Muse box in the incident it is also the model that stalled — hence the
     # tried check rather than returning it outright.
     preferred = enabled_default_model()
-    if preferred not in tried and has_provider_key(preferred):
+    if (preferred not in tried and has_provider_key(preferred)
+            and not model_health.is_gone(preferred)):
         return preferred
 
     for name in known_models():
@@ -468,6 +620,10 @@ def fallback_model(
             continue
         if is_openrouter_model(name):
             continue
+        # Rung 2 exists to finish the turn somewhere else; a model that just told
+        # us it is retired is the one place guaranteed not to work.
+        if model_health.is_gone(name):
+            continue
         if is_model_enabled(name) and has_provider_key(name):
             return name
     return None
@@ -482,6 +638,13 @@ def effective_model(model_name: str) -> str:
     silent: the dropdown kept showing the model the user chose while every turn
     ran on the default, and the only trace was a WARNING in the container log.
     """
+    # A model that reported itself retired is never "effective", whatever the policy
+    # says. An allow-list is the operator stating a model MAY be used; it is not a
+    # claim that the model still exists. Without this a box whose instance.json names
+    # the retired model kept handing it back — and because the llmModel cookie lives
+    # 365 days, this function is the only thing that reaches an already-pinned user.
+    if model_health.is_gone(model_name):
+        return enabled_default_model()
     if is_model_enabled(model_name):
         return model_name
     return enabled_default_model()

--- a/app/agents/leonardo/rails_agent/middleware.py
+++ b/app/agents/leonardo/rails_agent/middleware.py
@@ -23,8 +23,10 @@ from app.agents.leonardo.llm_factory import (
 # The box's resolved default (Muse where the box has a META key, DeepSeek
 # where it does not) — never a hardcoded id, or a turn that arrives without
 # an explicit llm_model silently ignores the fleet default.
+from app.agents.leonardo import model_health
 from app.agents.leonardo.model_policy import enabled_default_model, fallback_model
 from app.agents.leonardo.resilience import (
+    is_model_gone,
     is_transient_error,
     retry_notice_text,
     _MODEL_RETRY_MAX_ATTEMPTS,
@@ -623,6 +625,39 @@ class DynamicModelMiddleware(AgentMiddleware):
                 elapsed = time.monotonic() - started_at
                 # A deterministic error (bad kwarg, 400) fails identically on
                 # every provider, so it must not spend rung 2's budget either.
+                # A RETIRED model is the one failure that is both pointless to
+                # retry and perfectly recoverable by moving. It is not transient,
+                # so before 0.7.6 it fell into the branch below and the raw
+                # provider 404 went straight to the customer while every other
+                # model sat there working — which is what turned Meta's
+                # 2026-08-31 retirement of our default into a fleet outage.
+                # Skip rung 1 entirely (a 404 is known-permanent on the first
+                # response) and remember it so later turns do not pay for it.
+                if is_model_gone(e):
+                    model_health.mark_model_gone(llm_model)
+                    fallback = (
+                        None if fallbacks_used >= _MODEL_FALLBACK_MAX_RUNGS
+                        else self._next_rung(request, llm_model, tried)
+                    )
+                    if fallback is None:
+                        logger.error(
+                            f"{llm_model} reports itself retired and there is no "
+                            f"other model available on this box"
+                        )
+                        _record_bad_request_shape(e, req, llm_model)
+                        raise
+                    logger.warning(
+                        f"{llm_model} reports itself retired; finishing this step "
+                        f"on {fallback}"
+                    )
+                    _announce_fallback(llm_model, fallback, sync=True)
+                    llm_model = fallback
+                    tried.add(fallback)
+                    fallbacks_used += 1
+                    req = self._override(request, llm_model)
+                    attempt = 0
+                    started_at = time.monotonic()
+                    continue
                 if not is_transient_error(e):
                     _record_bad_request_shape(e, req, llm_model)
                     raise
@@ -681,6 +716,39 @@ class DynamicModelMiddleware(AgentMiddleware):
             except Exception as e:
                 attempt += 1
                 elapsed = time.monotonic() - started_at
+                # A RETIRED model is the one failure that is both pointless to
+                # retry and perfectly recoverable by moving. It is not transient,
+                # so before 0.7.6 it fell into the branch below and the raw
+                # provider 404 went straight to the customer while every other
+                # model sat there working — which is what turned Meta's
+                # 2026-08-31 retirement of our default into a fleet outage.
+                # Skip rung 1 entirely (a 404 is known-permanent on the first
+                # response) and remember it so later turns do not pay for it.
+                if is_model_gone(e):
+                    model_health.mark_model_gone(llm_model)
+                    fallback = (
+                        None if fallbacks_used >= _MODEL_FALLBACK_MAX_RUNGS
+                        else self._next_rung(request, llm_model, tried)
+                    )
+                    if fallback is None:
+                        logger.error(
+                            f"{llm_model} reports itself retired and there is no "
+                            f"other model available on this box"
+                        )
+                        _record_bad_request_shape(e, req, llm_model)
+                        raise
+                    logger.warning(
+                        f"{llm_model} reports itself retired; finishing this step "
+                        f"on {fallback}"
+                    )
+                    await _announce_fallback(llm_model, fallback, sync=False)
+                    llm_model = fallback
+                    tried.add(fallback)
+                    fallbacks_used += 1
+                    req = self._override(request, llm_model)
+                    attempt = 0
+                    started_at = time.monotonic()
+                    continue
                 if not is_transient_error(e):
                     # A provider that rejects the REQUEST tells us nothing
                     # actionable ("'param': None" — 32 occurrences on 7 boxes in

--- a/app/agents/leonardo/resilience.py
+++ b/app/agents/leonardo/resilience.py
@@ -126,6 +126,45 @@ def _status_code_of(exc: BaseException):
     return None
 
 
+#: What a provider says when a model id no longer exists. Matched case-insensitively
+#: against the message, because the shape differs per provider and only the 404 is
+#: reliable across all of them.
+_MODEL_GONE_MARKERS = (
+    "model_not_found",
+    "does not exist",
+    "no longer available",
+    "has been deprecated",
+    "unknown model",
+)
+
+
+def is_model_gone(exc: BaseException) -> bool:
+    """True if this error means the MODEL is retired, not that the call failed.
+
+    Meta retired ``muse-spark-1.2-contributor`` on 2026-08-31 and every request to
+    it returned a deterministic 404. The ladder classified that as "not transient"
+    — correct — and therefore also as "not worth falling back from", which was not:
+    the raw provider 404 went straight to the customer while seven other models sat
+    there working.
+
+    A dead model is the one failure that is BOTH pointless to retry and perfectly
+    recoverable by switching, so it gets its own classification.
+
+    Note ``GET /v1/models`` still listed the retired id, so no health check that
+    reads the model list could have caught this. Only a real completion tells the
+    truth, which is why this is decided from a live error rather than a probe.
+    """
+    if _status_code_of(exc) == 404:
+        return True
+    # OpenRouter surfaces upstream failures as a bare ValueError carrying a dict,
+    # with no status code anywhere — the same blind spot that hid its 502s.
+    haystack = str(exc).lower()
+    for arg in getattr(exc, "args", ()):
+        if isinstance(arg, dict):
+            haystack += " " + " ".join(str(v).lower() for v in arg.values())
+    return any(marker in haystack for marker in _MODEL_GONE_MARKERS)
+
+
 def is_transient_error(exc: BaseException) -> bool:
     """Model-agnostic predicate: is this exception worth retrying?
 

--- a/app/services/lease_manager.py
+++ b/app/services/lease_manager.py
@@ -8,8 +8,11 @@ Background task that:
 
 import asyncio
 import logging
+import time
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING
+
+import httpx
 
 if TYPE_CHECKING:
     from fastapi import FastAPI
@@ -24,11 +27,31 @@ class LeaseManager:
     CHECK_INTERVAL = 300  # 5 minutes
     ACTIVITY_THRESHOLD = 600  # 10 minutes - user must have activity within this window
 
+    #: The customer's Rails app, by docker service name. Resolves from inside the
+    #: llamabot container with no new env var and no new configuration.
+    RAILS_HEALTH_URL = "http://llamapress:3000/up"
+
+    #: Deliberately generous. Leo boxes run RAILS_ENV=development, so the first
+    #: request after any file save pays the whole class reload — and the agent
+    #: saves files all day. A HEALTHY box measured 10.045s on /up while / answered
+    #: in 1.37s moments later (crm-4, 2026-08-31). A short timeout here would
+    #: report healthy boxes as down several times an hour and make the signal
+    #: worthless. Report the real status and duration; let the mothership judge.
+    RAILS_PROBE_TIMEOUT = 25.0
+
+    #: How often the box spends a real completion checking its own default model.
+    #: Hourly, not every tick: a retirement is permanent, so finding it within the
+    #: hour is fast enough, and 148 boxes probing every 5 minutes is pointless
+    #: spend. `GET /v1/models` is NOT a substitute — it still listed the retired
+    #: model right through the 2026-08-31 outage.
+    MODEL_PROBE_INTERVAL = 3600
+
     def __init__(self, app: "FastAPI", mothership_client: "MothershipClient"):
         self.app = app
         self.mothership = mothership_client
         self._task = None
         self._running = False
+        self._last_model_probe = None
 
     async def start(self):
         """Start the background lease renewal task."""
@@ -61,11 +84,67 @@ class LeaseManager:
 
         while self._running:
             try:
-                await self._check_and_renew()
+                await self._tick()
             except Exception as e:
                 logger.error(f"LeaseManager error: {e}", exc_info=True)
 
             await asyncio.sleep(self.CHECK_INTERVAL)
+
+    async def _tick(self):
+        """One pass of the loop: report Rails health, then renew the lease.
+
+        Health is reported on EVERY tick, deliberately outside _check_and_renew.
+        Lease renewal is gated on ACTIVITY_THRESHOLD, so folding the health report
+        into it would silence idle boxes — and an idle box that stops answering is
+        precisely the blind spot this closes (SI#417).
+
+        Health reporting is telemetry. Lease renewal keeps a customer's box alive.
+        The first must never be able to stop the second, so it is fully contained.
+        """
+        try:
+            rails_status, rails_ms = await self._probe_rails()
+            health_result = await self.mothership.report_rails_health(
+                rails_status=rails_status, rails_ms=rails_ms
+            )
+            # Policy rides this response as well as the lease one. Lease renewal is
+            # gated on ACTIVITY_THRESHOLD, so an idle box would otherwise never receive
+            # a model change — and most of the fleet was idle when the default model was
+            # retired at 22:46 UTC on 2026-08-31. This call has no such gate.
+            if health_result:
+                self._sync_model_policy(health_result)
+        except Exception as e:
+            logger.warning(f"LeaseManager: Rails health report failed: {e}")
+
+        # Rate-limited, and contained for the same reason as the health report:
+        # a model probe is diagnostics, lease renewal keeps the box alive.
+        try:
+            now = time.monotonic()
+            if (self._last_model_probe is None
+                    or now - self._last_model_probe >= self.MODEL_PROBE_INTERVAL):
+                self._last_model_probe = now
+                await self._probe_default_model()
+        except Exception as e:
+            logger.warning(f"LeaseManager: model probe failed: {e}")
+
+        await self._check_and_renew()
+
+    async def _probe_rails(self):
+        """Ask the customer's Rails app whether it is answering.
+
+        Returns (status_code, milliseconds). A wedged Rails answers nothing at all,
+        including its own health endpoint, so "no answer" is reported as status 0
+        rather than swallowed — that is the case worth alerting on.
+        """
+        started = time.monotonic()
+        try:
+            async with httpx.AsyncClient(timeout=self.RAILS_PROBE_TIMEOUT) as client:
+                response = await client.get(self.RAILS_HEALTH_URL)
+                status = response.status_code
+        except Exception:
+            status = 0
+
+        elapsed_ms = int((time.monotonic() - started) * 1000)
+        return status, elapsed_ms
 
     async def _check_and_renew(self):
         """If user was active in last 10 minutes, renew lease."""
@@ -87,12 +166,81 @@ class LeaseManager:
                 logger.info(
                     f"LeaseManager: Lease renewed until {result.get('lease_expires_at')}"
                 )
+                self._sync_model_policy(result)
                 self._sync_instance_lock(result)
         else:
             logger.info(
                 f"LeaseManager: User inactive ({seconds_since_activity:.0f}s ago), "
                 f"not renewing lease"
             )
+
+    async def _probe_default_model(self):
+        """Spend one real completion checking the model this box would actually run.
+
+        A completion, not ``GET /v1/models``: when Meta retired
+        ``muse-spark-1.2-contributor`` on 2026-08-31 the model list STILL LISTED it,
+        so every list-reading health check reported green through the whole outage.
+        Only a real call tells the truth.
+
+        A 404 feeds the same dead-model memory the live ladder uses, so the box
+        reroutes itself before a customer types anything. Any OTHER failure is
+        ignored on purpose — a timeout or a 500 is the provider having a bad
+        minute, and condemning a model on that would let one blip move the fleet.
+        """
+        from app.agents.leonardo import model_health
+        from app.agents.leonardo.llm_factory import get_llm
+        from app.agents.leonardo.model_policy import enabled_default_model
+        from app.agents.leonardo.resilience import is_model_gone
+
+        model = enabled_default_model()
+        try:
+            llm = get_llm(model)
+            await llm.ainvoke([{"role": "user", "content": "ping"}])
+            logger.debug(f"LeaseManager: default model {model} answered the probe")
+        except Exception as e:
+            if is_model_gone(e):
+                logger.error(
+                    f"LeaseManager: default model {model} reports itself RETIRED "
+                    f"({e!r}). Routing around it; set DEFAULT_LLM_MODEL to choose "
+                    f"the replacement."
+                )
+                model_health.mark_model_gone(model)
+            else:
+                logger.info(
+                    f"LeaseManager: model probe for {model} failed without saying "
+                    f"the model is gone ({e!r}); not condemning it"
+                )
+
+    def _sync_model_policy(self, result: dict) -> None:
+        """Apply a model policy the mothership sent down with the lease renewal.
+
+        Meta retired the compiled default model on 2026-08-31 while it carried 89%
+        of fleet turns, and the only way to move a box off it was to SSH in and
+        edit .env. This is the channel that makes it one fleet-wide action.
+
+        Deliberately a PULL riding the lease response rather than a new inbound
+        endpoint: no new listening surface, no second credential, and it reuses
+        the authenticated call the box already makes. Same shape as the instance
+        lock below, for the same reason.
+
+        No-op unless the mothership actually sends the key, so an older mothership
+        never clears a policy — and absent is not the same as empty. Fully
+        contained: telemetry must never be able to break lease renewal.
+        """
+        if "model_policy" not in result:
+            return
+        try:
+            from app.services import model_policy_store
+
+            policy = result["model_policy"]
+            if policy:
+                model_policy_store.save(policy)
+            else:
+                # An explicit empty policy IS a clear — the mothership handing the
+                # box back to its own configuration.
+                model_policy_store.clear()
+        except Exception as e:
+            logger.warning(f"LeaseManager: could not apply remote model policy: {e}")
 
     def _sync_instance_lock(self, result: dict) -> None:
         """Backstop for the sleep lock when the mothership can't reach us inbound.

--- a/app/services/model_policy_store.py
+++ b/app/services/model_policy_store.py
@@ -1,0 +1,108 @@
+"""Model policy pushed down from the mothership.
+
+The 2026-08-31 retirement of ``muse-spark-1.2-contributor`` took 89% of fleet turns
+down at once, and the only way to move a box off it was to SSH in and edit ``.env``.
+This is the channel that makes it one authenticated call to the fleet instead.
+
+Carries three keys, all optional:
+
+    {"default_model": "...", "disabled_models": [...], "enabled_models": [...]}
+
+Stored on disk rather than in memory so it survives the container restart that a
+model change usually needs, and written atomically so a half-written file can never
+be read.
+
+**Blast radius is the whole point of the care here.** One bad value reaches every
+box in a single lease interval, so every consumer of this treats it as untrusted:
+:func:`load` never raises and never returns a partial dict, and
+``model_policy.remote_policy`` drops individual malformed keys rather than the
+whole payload. The invariant that outranks the remote operator's intent is that the
+box still resolves to a model it can actually build.
+"""
+import json
+import logging
+import os
+import tempfile
+import threading
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+#: Beside instance.json, which is the box's other mothership-written config.
+DEFAULT_PATH = ".leonardo/model_policy.json"
+PATH_ENV = "MODEL_POLICY_PATH"
+
+_lock = threading.Lock()
+
+#: Only these are honoured; anything else in the payload is ignored, so the
+#: mothership adding a key cannot change behaviour on a box that predates it.
+_ALLOWED_KEYS = ("default_model", "disabled_models", "enabled_models")
+
+
+def path() -> Path:
+    return Path(os.getenv(PATH_ENV) or DEFAULT_PATH)
+
+
+def load() -> dict:
+    """The stored policy, or ``{}``. Never raises.
+
+    A missing file is the normal case (most boxes are not steered remotely), so it
+    is not worth a log line. A CORRUPT file is worth one, but is still ``{}`` — a
+    box must not lose chat because a push was interrupted.
+    """
+    try:
+        with path().open() as f:
+            payload = json.load(f)
+    except FileNotFoundError:
+        return {}
+    except (OSError, json.JSONDecodeError) as e:
+        logger.warning("Ignoring unreadable model policy at %s: %s", path(), e)
+        return {}
+
+    if not isinstance(payload, dict):
+        logger.warning("Ignoring model policy at %s: expected an object", path())
+        return {}
+    return {k: v for k, v in payload.items() if k in _ALLOWED_KEYS}
+
+
+def save(policy: dict) -> None:
+    """Replace the stored policy atomically.
+
+    Written to a temp file in the same directory and renamed, so a reader either
+    sees the old policy or the new one — never a truncated file. A partially
+    written policy on every box at once is exactly the failure this channel exists
+    to prevent.
+    """
+    if not isinstance(policy, dict):
+        raise ValueError("model policy must be an object")
+
+    filtered = {k: v for k, v in policy.items() if k in _ALLOWED_KEYS}
+    target = path()
+
+    with _lock:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp = tempfile.mkstemp(dir=str(target.parent), prefix=".model_policy-")
+        try:
+            with os.fdopen(fd, "w") as f:
+                json.dump(filtered, f, indent=2)
+                f.flush()
+                os.fsync(f.fileno())
+            os.replace(tmp, target)
+        except BaseException:
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+            raise
+
+    logger.info("Model policy updated from the mothership: %s", filtered)
+
+
+def clear() -> None:
+    """Remove the stored policy, returning the box to its own configuration."""
+    with _lock:
+        try:
+            path().unlink()
+        except FileNotFoundError:
+            pass

--- a/app/services/mothership_client.py
+++ b/app/services/mothership_client.py
@@ -10,6 +10,7 @@ import httpx
 import json
 import logging
 import os
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 
@@ -152,6 +153,55 @@ class MothershipClient:
         except httpx.RequestError as e:
             logger.error(f"Lease renewal request failed: {e}")
             return None
+
+    async def report_rails_health(self, *, rails_status: int, rails_ms: int) -> Optional[dict]:
+        """
+        POST /api/leonardo/report_health
+
+        Tell the mothership whether the customer's Rails app is answering.
+
+        Until this existed the fleet heartbeat came from LlamaBot alone, so a box
+        whose Rails app was completely down still looked healthy: crm-4 called the
+        mothership 12 times during a 10 minute outage (SI#417). LlamaBot's liveness
+        is not the box's liveness.
+
+        Fail-open on purpose. A 404 means the mothership is older than this build
+        and does not serve the endpoint yet; the two halves may ship in either
+        order, so 404 is a no-op rather than an error. Nothing here may raise —
+        the caller's next job is lease renewal, which keeps the box alive.
+        """
+        if not self.reporting_enabled:
+            return
+
+        try:
+            async with httpx.AsyncClient(timeout=self.TIMEOUT) as client:
+                response = await client.post(
+                    f"{self.config['mothership_url']}/api/leonardo/report_health",
+                    json={
+                        "instance_name": self.config["instance_name"],
+                        "rails_status": rails_status,
+                        "rails_ms": rails_ms,
+                        "checked_at": datetime.now(timezone.utc).isoformat(),
+                    },
+                    headers={"Authorization": f"Bearer {self.config['mothership_api_token']}"},
+                )
+                response.raise_for_status()
+                # The response is also the delivery path for model policy: it is the
+                # only mothership call every box makes on every tick, gated on nothing.
+                try:
+                    return response.json()
+                except ValueError:
+                    return None
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 404:
+                logger.debug("Mothership has no report_health endpoint yet; skipping")
+                return None
+            logger.error(
+                f"Rails health report failed (HTTP {e.response.status_code}): {e.response.text}"
+            )
+        except httpx.RequestError as e:
+            logger.error(f"Rails health report request failed: {e}")
+        return None
 
     async def report_message(
         self,

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -243,3 +243,22 @@ def mock_build_workflow():
         workflow.get_state = MagicMock(return_value={"messages": []})
         mock.return_value = workflow
         yield mock 
+
+@pytest.fixture(autouse=True)
+def _reset_model_health():
+    """Clear the dead-model cache between tests.
+
+    ``model_health`` is process-global by design (it is a cache, not a decision), so a
+    test that marks a model retired leaks that record into every later test in the
+    session. Under random ordering that surfaces as an unrelated file failing —
+    `test_enabled_default_model_prefers_project_default` did exactly that, and passed
+    in isolation, which is the worst shape of flake to chase.
+
+    Reset on both sides so it does not matter whether the leak came from before or
+    after.
+    """
+    from app.agents.leonardo import model_health
+
+    model_health.reset()
+    yield
+    model_health.reset()

--- a/app/tests/test_model_health_probe.py
+++ b/app/tests/test_model_health_probe.py
@@ -1,0 +1,169 @@
+"""The box checks its own model with a REAL call (0.7.6).
+
+Meta retired ``muse-spark-1.2-contributor`` on 2026-08-31 at 4:46 PM MDT. Nothing
+detected it, and the reason is specific and worth keeping: **``GET /v1/models``
+still listed the retired id.** Every health check that reads the model list
+reported green throughout the outage. Verified against the provider with two keys —
+only the ``-contributor`` tier 404s, and only on a completion.
+
+So the probe has to be a real completion. It is cheap, it runs rarely, and when it
+fails it feeds the same dead-model memory the live ladder uses, which means a box
+reroutes itself BEFORE a customer types anything.
+
+What it must not do is cry wolf: a probe that marks a model dead on any error would
+turn a network blip into a fleet-wide model change.
+"""
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from datetime import datetime, timezone, timedelta
+
+from app.agents.leonardo import model_health
+from app.services.lease_manager import LeaseManager
+
+
+@pytest.fixture(autouse=True)
+def _no_death_records():
+    model_health.reset()
+    yield
+    model_health.reset()
+
+
+def _make_manager():
+    app = MagicMock()
+    app.state.timestamp = datetime.now(timezone.utc) - timedelta(seconds=5)
+    mothership = MagicMock()
+    mothership.enabled = True
+    mothership.report_rails_health = AsyncMock(return_value=None)
+    mothership.renew_lease = AsyncMock(return_value=None)
+    return LeaseManager(app, mothership)
+
+
+class _Retired(Exception):
+    def __init__(self):
+        super().__init__("model_not_found")
+        self.status_code = 404
+
+
+@pytest.mark.asyncio
+async def test_a_retired_model_is_recorded_by_the_probe():
+    """THE DETECTION GAP. This is what nothing caught on 2026-08-31."""
+    manager = _make_manager()
+    llm = MagicMock()
+    llm.ainvoke = AsyncMock(side_effect=_Retired())
+
+    with patch("app.agents.leonardo.model_policy.enabled_default_model", return_value="dead-model"):
+        with patch("app.agents.leonardo.llm_factory.get_llm", return_value=llm):
+            await manager._probe_default_model()
+
+    assert model_health.is_gone("dead-model") is True
+
+
+@pytest.mark.asyncio
+async def test_a_healthy_model_is_not_marked_dead():
+    manager = _make_manager()
+    llm = MagicMock()
+    llm.ainvoke = AsyncMock(return_value=MagicMock())
+
+    with patch("app.agents.leonardo.model_policy.enabled_default_model", return_value="live-model"):
+        with patch("app.agents.leonardo.llm_factory.get_llm", return_value=llm):
+            await manager._probe_default_model()
+
+    assert model_health.is_gone("live-model") is False
+
+
+@pytest.mark.asyncio
+async def test_an_ordinary_failure_does_not_condemn_the_model():
+    """A timeout or a 500 is the provider having a bad minute, not a retirement.
+
+    Marking a model dead on any error would let one blip move every box.
+    """
+    manager = _make_manager()
+    llm = MagicMock()
+    llm.ainvoke = AsyncMock(side_effect=TimeoutError("slow"))
+
+    with patch("app.agents.leonardo.model_policy.enabled_default_model", return_value="slow-model"):
+        with patch("app.agents.leonardo.llm_factory.get_llm", return_value=llm):
+            await manager._probe_default_model()
+
+    assert model_health.is_gone("slow-model") is False
+
+
+@pytest.mark.asyncio
+async def test_the_probe_is_rate_limited():
+    """A real completion on every 5-minute tick is 148 boxes of pointless spend.
+
+    A retirement is permanent, so hourly finds it fast enough.
+    """
+    manager = _make_manager()
+    assert manager.MODEL_PROBE_INTERVAL >= 3600
+
+    calls = []
+
+    async def fake_probe():
+        calls.append(1)
+
+    with patch.object(manager, "_probe_rails", AsyncMock(return_value=(200, 10))):
+        with patch.object(manager, "_probe_default_model", fake_probe):
+            await manager._tick()
+            await manager._tick()
+            await manager._tick()
+
+    assert len(calls) == 1, "the model probe must not run on every tick"
+
+
+@pytest.mark.asyncio
+async def test_a_failing_probe_never_breaks_the_tick():
+    """Same rule as every other piece of telemetry in this loop."""
+    manager = _make_manager()
+
+    with patch.object(manager, "_probe_rails", AsyncMock(return_value=(200, 10))):
+        with patch.object(manager, "_probe_default_model", AsyncMock(side_effect=RuntimeError("boom"))):
+            await manager._tick()
+
+    manager.mothership.report_rails_health.assert_awaited()
+
+
+# ---------------------------------------------------------------------------
+# A retired model is never "effective", even when explicitly allow-listed
+# ---------------------------------------------------------------------------
+#
+# Caught on the live dev box, not by a unit test: the box's instance.json names
+# muse-spark-1.2-contributor in enabled_models, so it stayed enabled and
+# effective_model handed it straight back — even with a different default configured
+# and the model retired. The earlier tests all patch _read_instance_config away, so
+# none of them saw it.
+#
+# The 365-day llmModel cookie means effective_model is the ONLY thing that reaches an
+# already-pinned user. An allow-list is the operator saying "this model may be used";
+# it is not a claim that the model still exists.
+
+def test_a_retired_model_is_not_effective_even_when_allowlisted(monkeypatch):
+    from app.agents.leonardo import model_policy
+
+    monkeypatch.setenv("META_API_KEY", "meta-test-key")
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "ds-test-key")
+    monkeypatch.setattr(
+        model_policy, "_read_instance_config",
+        lambda: {"enabled_models": ["muse-spark-1.2-contributor", "deepseek-v4-flash"]},
+    )
+
+    muse = "muse-spark-1.2-contributor"
+    # While it is alive the allow-list governs and nothing changes.
+    assert model_policy.effective_model(muse) == muse
+
+    model_health.mark_model_gone(muse)
+    assert model_policy.effective_model(muse) != muse, (
+        "a cookie-pinned user must be moved off a model that reports itself retired"
+    )
+
+
+def test_a_live_allowlisted_model_is_untouched(monkeypatch):
+    """The rule is scoped to DEAD models — it must not evict a healthy one."""
+    from app.agents.leonardo import model_policy
+
+    monkeypatch.setenv("META_API_KEY", "meta-test-key")
+    monkeypatch.setattr(
+        model_policy, "_read_instance_config",
+        lambda: {"enabled_models": ["muse-spark-1.2-contributor"]},
+    )
+    assert model_policy.effective_model("muse-spark-1.2-contributor") == "muse-spark-1.2-contributor"

--- a/app/tests/test_operator_default_model.py
+++ b/app/tests/test_operator_default_model.py
@@ -1,0 +1,328 @@
+"""0.7.6: the fleet default model becomes operator- and mothership-settable.
+
+Meta retired ``muse-spark-1.2-contributor`` on 2026-08-31 at 4:46 PM MDT. It was
+the compiled ``DEFAULT_LLM_MODEL`` and carried 89% of fleet turns, so every box
+on it went down at once — and nothing in the box could be told to run something
+else, because the default was a bare Python constant. Four layers close that:
+
+  1. **Config-settable default.** ``DEFAULT_LLM_MODEL`` / ``FALLBACK_TEXT_MODEL``
+     read the environment, and the mothership can override both remotely through
+     :mod:`app.services.model_policy_store`. Precedence, most specific first:
+     mothership > instance.json > env > compiled constant.
+  2. **Automatic reroute.** A retired model raises a deterministic 404, which the
+     resilience ladder classified as "do not retry, do not fall back" and
+     surfaced raw to the customer. It now routes straight to rung 2 and the dead
+     model is remembered, so later turns skip it without failing first.
+  3. **Real health probe.** ``GET /v1/models`` still listed the retired model, so
+     every health check reported green. Only a real completion tells the truth.
+  4. **Remote control.** The mothership sets all of the above over an
+     authenticated endpoint instead of SSHing in and editing .env.
+
+The invariant that outranks all of it: **the box always resolves to a model it
+can actually build.** A bad remote default must degrade, never lock chat out.
+"""
+
+import pytest
+
+from app.agents.leonardo import model_policy
+from app.agents.leonardo import model_health
+from app.agents.leonardo import llm_factory
+from app.agents.leonardo.resilience import is_model_gone, is_transient_error
+
+MUSE = "muse-spark-1.2-contributor"
+DEEPSEEK = "deepseek-v4-flash"
+GLM = "glm-5.3-flash-zai"
+
+
+@pytest.fixture(autouse=True)
+def _unconfigured_box(monkeypatch):
+    """A box that configures nothing, with no remote policy and no dead models."""
+    monkeypatch.setattr(model_policy, "_read_instance_config", lambda: None)
+    monkeypatch.setattr(model_policy, "remote_policy", lambda: {})
+    model_health.reset()
+    for var in (
+        "ENABLED_MODELS",
+        "DISABLED_MODELS",
+        "DEFAULT_LLM_MODEL",
+        "FALLBACK_TEXT_MODEL",
+        "MODEL_SWITCHING_ALLOWED",
+        "VISION_MODEL_ALLOWED",
+        "META_API_KEY",
+        "MODEL_API_KEY",
+        "DEEPSEEK_API_KEY",
+        "OPENROUTER_API_KEY",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    yield
+    model_health.reset()
+
+
+def _glm_box(monkeypatch):
+    """A box keyed for GLM and told to run it, with DeepSeek banned outright."""
+    monkeypatch.setenv("OPENROUTER_API_KEY", "or-test-key")
+    monkeypatch.setenv("DEFAULT_LLM_MODEL", GLM)
+
+
+# --- 1. Nothing changes on a box that sets nothing --------------------------
+#
+# Every other test here configures something. This one is the control: the
+# compiled constants are still Muse and DeepSeek, and an unconfigured box still
+# resolves exactly as it did in 0.7.5.
+
+
+def test_the_compiled_default_is_still_muse():
+    assert llm_factory.DEFAULT_LLM_MODEL == MUSE
+    assert llm_factory.FALLBACK_TEXT_MODEL == DEEPSEEK
+
+
+def test_an_unset_override_changes_nothing(monkeypatch):
+    monkeypatch.setenv("META_API_KEY", "meta-test-key")
+    assert llm_factory.default_llm_model() == MUSE
+    assert llm_factory.fallback_text_model() == DEEPSEEK
+    assert model_policy.enabled_default_model() == MUSE
+
+
+# --- 2. The operator sets the default in .env -------------------------------
+
+
+def test_env_sets_the_default_model(monkeypatch):
+    _glm_box(monkeypatch)
+    assert llm_factory.default_llm_model() == GLM
+    assert model_policy.enabled_default_model() == GLM
+
+
+def test_env_sets_the_fallback_model(monkeypatch):
+    monkeypatch.setenv("FALLBACK_TEXT_MODEL", GLM)
+    assert llm_factory.fallback_text_model() == GLM
+
+
+def test_a_configured_openrouter_default_survives_the_walk(monkeypatch):
+    """The skip that made this impossible is scoped to the INCIDENTAL walk.
+
+    ``enabled_default_model`` refuses to wander onto a registered OpenRouter
+    endpoint someone added to try. That rule is right, and it is why the fleet
+    could not be moved to GLM from config. The operator naming one as THE default
+    is the opposite of wandering onto it, so only that name is exempt.
+    """
+    _glm_box(monkeypatch)
+    monkeypatch.setenv("DISABLED_MODELS", f"{MUSE},{DEEPSEEK}")
+    assert model_policy.enabled_default_model() == GLM
+
+
+def test_a_cookie_pinned_user_moves_off_the_retired_model(monkeypatch):
+    """The 365-day llmModel cookie is the ONLY thing that reaches these users.
+
+    Muse stops being fail-open once the operator names a different default, which
+    is what makes the substitution fire for a user whose browser still asks for
+    the retired model by name.
+    """
+    _glm_box(monkeypatch)
+    assert model_policy.effective_model(MUSE) == GLM
+
+
+def test_the_configured_default_never_resolves_to_a_banned_model(monkeypatch):
+    """The bug measured on leo-mize: disabling DeepSeek SERVED DeepSeek.
+
+    With every model disabled, the lockout path returned the compiled
+    ``FALLBACK_TEXT_MODEL`` and ignored the disable list entirely, so banning
+    DeepSeek fleet-wide would have put every box on it.
+    """
+    _glm_box(monkeypatch)
+    monkeypatch.setenv("DISABLED_MODELS", f"{MUSE},{DEEPSEEK},deepseek-v4-pro")
+    assert model_policy.enabled_default_model() == GLM
+    assert model_policy.effective_model(DEEPSEEK) == GLM
+    assert model_policy.effective_model(MUSE) == GLM
+
+
+def test_the_configured_default_cannot_be_disabled_out_from_under_itself(monkeypatch):
+    """An operator who names a default AND disables it has contradicted himself.
+
+    The default wins, because the alternative is a box with no model at all. Note
+    this applies only to an EXPLICITLY configured default — disabling the
+    compiled default keeps its old meaning, covered below.
+    """
+    _glm_box(monkeypatch)
+    monkeypatch.setenv("DISABLED_MODELS", GLM)
+    assert model_policy.is_model_enabled(GLM) is True
+    assert model_policy.enabled_default_model() == GLM
+
+
+def test_disabling_the_compiled_default_still_works(monkeypatch):
+    """0.7.5 behavior, unchanged: no configured default, so disable still wins."""
+    monkeypatch.setenv("META_API_KEY", "meta-test-key")
+    monkeypatch.setenv("DISABLED_MODELS", MUSE)
+    assert model_policy.is_model_enabled(MUSE) is False
+
+
+# --- 3. A default the box cannot build must degrade, not lock chat out ------
+
+
+def test_a_keyless_openrouter_default_degrades(monkeypatch):
+    """``has_provider_key`` reported True for every OpenRouter model.
+
+    It answers from a hand-maintained map and returns True for anything absent,
+    so GLM passed the buildable check on a box with no OpenRouter key. The box
+    would have "defaulted" to a model that 401s on every turn.
+    """
+    monkeypatch.setenv("DEFAULT_LLM_MODEL", GLM)
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "ds-test-key")
+    assert llm_factory.has_provider_key(GLM) is False
+    assert model_policy.default_text_model() == DEEPSEEK
+    assert model_policy.enabled_default_model() == DEEPSEEK
+
+
+def test_an_openrouter_default_is_buildable_with_the_key(monkeypatch):
+    _glm_box(monkeypatch)
+    assert llm_factory.has_provider_key(GLM) is True
+    assert model_policy.default_text_model() == GLM
+
+
+def test_a_nonsense_default_degrades_to_something_runnable(monkeypatch):
+    monkeypatch.setenv("DEFAULT_LLM_MODEL", "not-a-real-model")
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "ds-test-key")
+    assert model_policy.enabled_default_model() == DEEPSEEK
+
+
+def test_the_box_is_never_left_without_a_model(monkeypatch):
+    """Belt and braces: every knob hostile at once still yields a model name."""
+    monkeypatch.setenv("DEFAULT_LLM_MODEL", "not-a-real-model")
+    monkeypatch.setenv("DISABLED_MODELS", ",".join(model_policy.known_models()))
+    assert model_policy.enabled_default_model()
+
+
+# --- 4. The mothership sets the default remotely ----------------------------
+
+
+def test_remote_policy_sets_the_default(monkeypatch):
+    monkeypatch.setenv("OPENROUTER_API_KEY", "or-test-key")
+    monkeypatch.setattr(model_policy, "remote_policy", lambda: {"default_model": GLM})
+    assert model_policy.enabled_default_model() == GLM
+
+
+def test_remote_policy_outranks_the_env_override(monkeypatch):
+    """The mothership is the operator of record on a fleet box.
+
+    A stale .env on a box the mothership is actively steering must not win, or a
+    remote fix silently no-ops on exactly the boxes that were hand-edited during
+    the last incident.
+    """
+    monkeypatch.setenv("OPENROUTER_API_KEY", "or-test-key")
+    monkeypatch.setenv("DEFAULT_LLM_MODEL", MUSE)
+    monkeypatch.setattr(model_policy, "remote_policy", lambda: {"default_model": GLM})
+    assert model_policy.enabled_default_model() == GLM
+
+
+def test_remote_policy_can_disable_a_model(monkeypatch):
+    monkeypatch.setenv("META_API_KEY", "meta-test-key")
+    monkeypatch.setattr(
+        model_policy, "remote_policy", lambda: {"disabled_models": [DEEPSEEK]}
+    )
+    assert model_policy.is_model_enabled(DEEPSEEK) is False
+    assert model_policy.is_model_enabled(MUSE) is True
+
+
+def test_remote_disables_union_with_local_ones(monkeypatch):
+    """Any source can disable — the 0.7.5 rule, extended to the remote source."""
+    monkeypatch.setenv("META_API_KEY", "meta-test-key")
+    monkeypatch.setenv("DISABLED_MODELS", MUSE)
+    monkeypatch.setattr(
+        model_policy, "remote_policy", lambda: {"disabled_models": [DEEPSEEK]}
+    )
+    assert model_policy.is_model_enabled(MUSE) is False
+    assert model_policy.is_model_enabled(DEEPSEEK) is False
+
+
+def test_remote_allowlist_intersects_with_the_local_one(monkeypatch):
+    """Neither source can broaden what the other restricts — also the 0.7.5 rule."""
+    monkeypatch.setenv("ENABLED_MODELS", f"{MUSE},gpt-5-mini")
+    monkeypatch.setattr(
+        model_policy, "remote_policy", lambda: {"enabled_models": [MUSE, "gpt-5-nano"]}
+    )
+    assert model_policy.is_model_enabled("gpt-5-mini") is False
+    assert model_policy.is_model_enabled("gpt-5-nano") is False
+
+
+def test_a_malformed_remote_policy_is_ignored(monkeypatch):
+    """A bad remote payload must never take chat down on every box at once.
+
+    This is the blast radius that makes the remote channel worth being careful
+    about: one bad value reaches the whole fleet in a single lease interval.
+    """
+    monkeypatch.setenv("META_API_KEY", "meta-test-key")
+    monkeypatch.setattr(
+        model_policy,
+        "remote_policy",
+        lambda: {"default_model": 42, "disabled_models": "not-a-list"},
+    )
+    assert model_policy.enabled_default_model() == MUSE
+
+
+# --- 5. A retired model is recognised and rerouted --------------------------
+
+
+class _NotFound(Exception):
+    def __init__(self, message="model_not_found"):
+        super().__init__(message)
+        self.status_code = 404
+
+
+def test_a_404_is_classified_as_a_dead_model():
+    assert is_model_gone(_NotFound()) is True
+
+
+def test_a_dead_model_is_still_not_worth_retrying():
+    """Rung 1 must not touch it — retrying a retired model is pure latency.
+
+    Five attempts at 25s each is the ~10 minutes of silence the 2026-08-26 stall
+    incident was about; a 404 is known-permanent on the first response.
+    """
+    assert is_transient_error(_NotFound()) is False
+
+
+def test_a_model_not_found_message_without_a_status_counts():
+    """OpenRouter reports upstream failures as a bare ValueError with a dict arg."""
+    assert is_model_gone(ValueError({"message": "model_not_found"})) is True
+
+
+def test_an_ordinary_failure_is_not_a_dead_model():
+    assert is_model_gone(TimeoutError("stalled")) is False
+    assert is_model_gone(ValueError({"code": 502})) is False
+
+
+def test_a_dead_model_is_skipped_by_later_turns(monkeypatch):
+    """Remembering the death is what stops every later turn paying for it again.
+
+    Without this, each turn re-discovers the 404, waits for it, announces a
+    fallback and only then answers — for as long as the retirement lasts.
+    """
+    monkeypatch.setenv("META_API_KEY", "meta-test-key")
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "ds-test-key")
+    assert model_policy.enabled_default_model() == MUSE
+    model_health.mark_model_gone(MUSE)
+    assert model_policy.enabled_default_model() == DEEPSEEK
+
+
+def test_a_dead_model_is_never_chosen_as_a_fallback(monkeypatch):
+    monkeypatch.setenv("META_API_KEY", "meta-test-key")
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "ds-test-key")
+    model_health.mark_model_gone(DEEPSEEK)
+    assert model_policy.fallback_model(MUSE) != DEEPSEEK
+
+
+def test_every_model_dead_still_yields_a_model(monkeypatch):
+    """Fail open. A wrong death record must not be more damaging than the outage."""
+    monkeypatch.setenv("META_API_KEY", "meta-test-key")
+    for name in model_policy.known_models():
+        model_health.mark_model_gone(name)
+    assert model_policy.enabled_default_model()
+
+
+def test_a_death_record_expires(monkeypatch):
+    """A retirement can be reversed, and a 404 can be the provider having a bad day."""
+    monkeypatch.setenv("META_API_KEY", "meta-test-key")
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "ds-test-key")
+    model_health.mark_model_gone(MUSE)
+    assert model_health.is_gone(MUSE) is True
+    later = model_health._now() + model_health.TTL_SECONDS + 1
+    monkeypatch.setattr(model_health, "_now", lambda: later)
+    assert model_health.is_gone(MUSE) is False

--- a/app/tests/test_rails_health_report.py
+++ b/app/tests/test_rails_health_report.py
@@ -1,0 +1,399 @@
+"""
+Rails health reporting in the lease loop (SI#417).
+
+The fleet heartbeat was sent by LlamaBot, so the mothership could not tell a
+healthy box from one whose Rails app was completely down. crm-4 called the
+mothership 12 times during a 10 minute outage on 2026-08-31.
+
+These tests pin the three things that make the signal trustworthy:
+  1. the probe is generous enough not to cry wolf (25s — a HEALTHY box measured
+     10.045s because dev-mode class reloading pays the whole reload cost),
+  2. health is reported on EVERY tick, including on an idle box that is not
+     renewing its lease (that idle box is the blind spot being closed),
+  3. the report is fail-open: it never breaks lease renewal, and a mothership
+     that does not have the endpoint yet (404) is a no-op, not an error.
+"""
+import asyncio
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from datetime import datetime, timezone, timedelta
+
+import httpx
+
+from app.services.mothership_client import MothershipClient, TELEMETRY_DISABLED_ENV
+from app.services.lease_manager import LeaseManager
+
+
+FAKE_CONFIG = {
+    "instance_name": "crm-4",
+    "mothership_url": "https://mothership.example.com",
+    "mothership_api_token": "tok-test",
+    "lease_duration_seconds": 300,
+}
+
+
+@pytest.fixture(autouse=True)
+def _reporting_not_suppressed(monkeypatch):
+    """These tests assert the reported payloads, so the suite-wide telemetry kill
+    switch (conftest.py) has to be off. httpx is patched in every test, so
+    nothing leaves the process either way."""
+    monkeypatch.delenv(TELEMETRY_DISABLED_ENV, raising=False)
+
+
+def _make_client() -> MothershipClient:
+    client = MothershipClient.__new__(MothershipClient)
+    client.config = FAKE_CONFIG
+    return client
+
+
+def _mock_response(status=200, body=None):
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = status
+    resp.json.return_value = body or {}
+    resp.raise_for_status = MagicMock()
+    return resp
+
+
+def _make_manager(mothership, *, last_activity_seconds_ago=99999):
+    """A LeaseManager whose app.state.timestamp is that many seconds old."""
+    app = MagicMock()
+    app.state.timestamp = datetime.now(timezone.utc) - timedelta(
+        seconds=last_activity_seconds_ago
+    )
+    return LeaseManager(app, mothership)
+
+
+# --------------------------------------------------------------------------
+# MothershipClient.report_rails_health
+# --------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_report_rails_health_posts_the_agreed_contract():
+    """The mothership half is built against a fixed contract; do not drift."""
+    client = _make_client()
+    captured = {}
+
+    async def fake_post(url, *, json, headers):
+        captured["url"] = url
+        captured["payload"] = json
+        captured["headers"] = headers
+        return _mock_response(body={"ok": True})
+
+    mock_ctx = AsyncMock()
+    mock_ctx.__aenter__.return_value.post = fake_post
+    with patch("httpx.AsyncClient", return_value=mock_ctx):
+        await client.report_rails_health(rails_status=200, rails_ms=1370)
+
+    assert captured["url"] == (
+        "https://mothership.example.com/api/leonardo/report_health"
+    )
+    assert captured["headers"]["Authorization"] == "Bearer tok-test"
+
+    payload = captured["payload"]
+    assert payload["instance_name"] == "crm-4"
+    assert payload["rails_status"] == 200
+    assert payload["rails_ms"] == 1370
+    # ISO 8601 UTC, and actually parseable.
+    assert datetime.fromisoformat(payload["checked_at"].replace("Z", "+00:00"))
+
+
+@pytest.mark.asyncio
+async def test_report_rails_health_treats_404_as_a_noop():
+    """A LlamaBot that ships before the mothership endpoint must not log errors."""
+    client = _make_client()
+
+    request = httpx.Request("POST", "https://mothership.example.com/x")
+    response = httpx.Response(404, request=request)
+
+    async def fake_post(url, *, json, headers):
+        raise httpx.HTTPStatusError("not found", request=request, response=response)
+
+    mock_ctx = AsyncMock()
+    mock_ctx.__aenter__.return_value.post = fake_post
+    with patch("httpx.AsyncClient", return_value=mock_ctx):
+        with patch("app.services.mothership_client.logger") as log:
+            await client.report_rails_health(rails_status=200, rails_ms=10)
+
+    assert not log.error.called, "404 is an expected older mothership, not an error"
+
+
+@pytest.mark.asyncio
+async def test_report_rails_health_silent_when_reporting_disabled(monkeypatch):
+    """The telemetry kill switch must silence health reports."""
+    monkeypatch.setenv(TELEMETRY_DISABLED_ENV, "1")
+    client = _make_client()
+
+    called = False
+
+    async def fake_post(url, *, json, headers):
+        nonlocal called
+        called = True
+        return _mock_response()
+
+    mock_ctx = AsyncMock()
+    mock_ctx.__aenter__.return_value.post = fake_post
+    with patch("httpx.AsyncClient", return_value=mock_ctx):
+        await client.report_rails_health(rails_status=200, rails_ms=10)
+
+    assert called is False
+
+
+# --------------------------------------------------------------------------
+# LeaseManager._probe_rails
+# --------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_probe_uses_a_25_second_timeout():
+    """MANDATORY GUARD. A healthy box measured 10.045s on /up because dev-mode
+    class reloading pays the whole reload. A short timeout would report healthy
+    boxes as down several times an hour."""
+    manager = _make_manager(MagicMock())
+    captured = {}
+
+    def fake_client(*args, **kwargs):
+        captured["timeout"] = kwargs.get("timeout")
+        ctx = AsyncMock()
+        ctx.__aenter__.return_value.get = AsyncMock(
+            return_value=_mock_response(status=200)
+        )
+        return ctx
+
+    with patch("httpx.AsyncClient", side_effect=fake_client):
+        await manager._probe_rails()
+
+    assert captured["timeout"] == 25.0
+
+
+@pytest.mark.asyncio
+async def test_probe_returns_status_and_duration():
+    manager = _make_manager(MagicMock())
+
+    ctx = AsyncMock()
+    ctx.__aenter__.return_value.get = AsyncMock(return_value=_mock_response(status=200))
+    with patch("httpx.AsyncClient", return_value=ctx):
+        status, ms = await manager._probe_rails()
+
+    assert status == 200
+    assert isinstance(ms, int)
+    assert ms >= 0
+
+
+@pytest.mark.asyncio
+async def test_probe_reports_zero_when_rails_does_not_answer():
+    """A wedged Rails answers nothing at all, including /up. That is status 0,
+    which is the whole point of the signal."""
+    manager = _make_manager(MagicMock())
+
+    ctx = AsyncMock()
+    ctx.__aenter__.return_value.get = AsyncMock(
+        side_effect=httpx.ConnectTimeout("wedged")
+    )
+    with patch("httpx.AsyncClient", return_value=ctx):
+        status, ms = await manager._probe_rails()
+
+    assert status == 0
+    assert isinstance(ms, int)
+
+
+# --------------------------------------------------------------------------
+# The loop wiring — the actual blind spot
+# --------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_idle_box_still_reports_health():
+    """THE BUG. Lease renewal is gated on ACTIVITY_THRESHOLD (600s). If the health
+    report lived inside _check_and_renew, an idle box would stop reporting, which
+    is exactly the blind spot being closed. Idle here = 99999s since activity."""
+    mothership = MagicMock()
+    mothership.enabled = True
+    mothership.renew_lease = AsyncMock(return_value=None)
+    mothership.report_rails_health = AsyncMock(return_value=None)
+
+    manager = _make_manager(mothership, last_activity_seconds_ago=99999)
+    with patch.object(manager, "_probe_rails", AsyncMock(return_value=(200, 1370))):
+        await manager._tick()
+
+    assert mothership.report_rails_health.await_count == 1, (
+        "an idle box must still report Rails health"
+    )
+    assert mothership.renew_lease.await_count == 0, (
+        "an idle box must NOT renew its lease (unchanged behaviour)"
+    )
+
+
+@pytest.mark.asyncio
+async def test_health_report_failure_does_not_break_lease_renewal():
+    """Lease renewal keeps customer boxes alive and outranks telemetry."""
+    mothership = MagicMock()
+    mothership.enabled = True
+    mothership.renew_lease = AsyncMock(return_value={"lease_expires_at": "later"})
+    mothership.report_rails_health = AsyncMock(side_effect=RuntimeError("boom"))
+
+    manager = _make_manager(mothership, last_activity_seconds_ago=5)
+    with patch.object(manager, "_probe_rails", AsyncMock(return_value=(0, 25000))):
+        with patch.object(manager, "_sync_instance_lock", MagicMock()):
+            await manager._tick()
+
+    assert mothership.renew_lease.await_count == 1, (
+        "a failed health report must never stop lease renewal"
+    )
+
+
+@pytest.mark.asyncio
+async def test_probe_failure_does_not_break_lease_renewal():
+    """Same guarantee, one layer lower: the probe itself blowing up."""
+    mothership = MagicMock()
+    mothership.enabled = True
+    mothership.renew_lease = AsyncMock(return_value={"lease_expires_at": "later"})
+    mothership.report_rails_health = AsyncMock(return_value=None)
+
+    manager = _make_manager(mothership, last_activity_seconds_ago=5)
+    with patch.object(manager, "_probe_rails", AsyncMock(side_effect=RuntimeError("x"))):
+        with patch.object(manager, "_sync_instance_lock", MagicMock()):
+            await manager._tick()
+
+    assert mothership.renew_lease.await_count == 1
+
+
+# --------------------------------------------------------------------------
+# Model policy arrives on the SAME authenticated channel (0.7.6)
+# --------------------------------------------------------------------------
+#
+# The mothership needs to move a box's model without SSHing in to edit .env —
+# that is what made Meta's 2026-08-31 retirement a fleet outage. It rides the
+# lease-renew RESPONSE rather than a new inbound endpoint: pull, not push, so
+# there is no new listening surface and no second credential. Same shape as the
+# instance-lock backstop already in this loop.
+
+@pytest.mark.asyncio
+async def test_a_model_policy_on_the_lease_response_is_stored():
+    from app.services import model_policy_store
+
+    mothership = MagicMock()
+    mothership.enabled = True
+    mothership.report_rails_health = AsyncMock(return_value=None)
+    mothership.renew_lease = AsyncMock(
+        return_value={"lease_expires_at": "later",
+                      "model_policy": {"default_model": "glm-5.3-flash-zai"}}
+    )
+
+    manager = _make_manager(mothership, last_activity_seconds_ago=5)
+    with patch.object(manager, "_probe_rails", AsyncMock(return_value=(200, 10))):
+        with patch.object(manager, "_sync_instance_lock", MagicMock()):
+            with patch.object(model_policy_store, "save") as save:
+                await manager._tick()
+
+    save.assert_called_once()
+    assert save.call_args[0][0]["default_model"] == "glm-5.3-flash-zai"
+
+
+@pytest.mark.asyncio
+async def test_a_lease_response_without_a_policy_changes_nothing():
+    """An older mothership sends no such key; that must not wipe the box's policy."""
+    from app.services import model_policy_store
+
+    mothership = MagicMock()
+    mothership.enabled = True
+    mothership.report_rails_health = AsyncMock(return_value=None)
+    mothership.renew_lease = AsyncMock(return_value={"lease_expires_at": "later"})
+
+    manager = _make_manager(mothership, last_activity_seconds_ago=5)
+    with patch.object(manager, "_probe_rails", AsyncMock(return_value=(200, 10))):
+        with patch.object(manager, "_sync_instance_lock", MagicMock()):
+            with patch.object(model_policy_store, "save") as save:
+                with patch.object(model_policy_store, "clear") as clear:
+                    await manager._tick()
+
+    save.assert_not_called()
+    clear.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_a_broken_policy_store_never_breaks_lease_renewal():
+    from app.services import model_policy_store
+
+    mothership = MagicMock()
+    mothership.enabled = True
+    mothership.report_rails_health = AsyncMock(return_value=None)
+    mothership.renew_lease = AsyncMock(
+        return_value={"lease_expires_at": "later", "model_policy": {"default_model": "x"}}
+    )
+
+    manager = _make_manager(mothership, last_activity_seconds_ago=5)
+    with patch.object(manager, "_probe_rails", AsyncMock(return_value=(200, 10))):
+        with patch.object(manager, "_sync_instance_lock", MagicMock()) as lock:
+            with patch.object(model_policy_store, "save", side_effect=OSError("disk")):
+                await manager._tick()
+
+    lock.assert_called_once(), "a failed policy write must not stop the rest of the tick"
+
+
+# --------------------------------------------------------------------------
+# Policy must reach an IDLE box too
+# --------------------------------------------------------------------------
+#
+# The lease-renew response only exists when the box renewed its lease, and renewal is
+# gated on ACTIVITY_THRESHOLD. So carrying the model policy there alone means an idle
+# box never receives it — and during the 2026-08-31 retirement most of the fleet was
+# idle at 22:46 UTC. A model change has to reach a box BEFORE its next user arrives,
+# not five minutes after.
+#
+# The health report has no such gate: it runs on every tick. So the policy may ride
+# either response, and the health one is what makes it universal.
+
+@pytest.mark.asyncio
+async def test_an_idle_box_still_receives_a_model_policy():
+    """THE GAP. Idle box: no lease renewal, so the lease response never arrives."""
+    from app.services import model_policy_store
+
+    mothership = MagicMock()
+    mothership.enabled = True
+    mothership.renew_lease = AsyncMock(return_value=None)
+    mothership.report_rails_health = AsyncMock(
+        return_value={"model_policy": {"default_model": "glm-5.3-flash-zai"}}
+    )
+
+    manager = _make_manager(mothership, last_activity_seconds_ago=99999)
+    with patch.object(manager, "_probe_rails", AsyncMock(return_value=(200, 10))):
+        with patch.object(model_policy_store, "save") as save:
+            await manager._tick()
+
+    assert mothership.renew_lease.await_count == 0, "precondition: the box is idle"
+    save.assert_called_once()
+    assert save.call_args[0][0]["default_model"] == "glm-5.3-flash-zai"
+
+
+@pytest.mark.asyncio
+async def test_a_health_response_without_a_policy_changes_nothing():
+    """An older mothership returns 200 with no body, or no such key."""
+    from app.services import model_policy_store
+
+    mothership = MagicMock()
+    mothership.enabled = True
+    mothership.renew_lease = AsyncMock(return_value=None)
+    mothership.report_rails_health = AsyncMock(return_value=None)
+
+    manager = _make_manager(mothership, last_activity_seconds_ago=99999)
+    with patch.object(manager, "_probe_rails", AsyncMock(return_value=(200, 10))):
+        with patch.object(model_policy_store, "save") as save:
+            with patch.object(model_policy_store, "clear") as clear:
+                await manager._tick()
+
+    save.assert_not_called()
+    clear.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_report_rails_health_returns_the_mothership_body():
+    """The client has to hand the response back for any of the above to work."""
+    client = _make_client()
+
+    async def fake_post(url, *, json, headers):
+        return _mock_response(body={"model_policy": {"default_model": "x"}})
+
+    mock_ctx = AsyncMock()
+    mock_ctx.__aenter__.return_value.post = fake_post
+    with patch("httpx.AsyncClient", return_value=mock_ctx):
+        result = await client.report_rails_health(rails_status=200, rails_ms=10)
+
+    assert result == {"model_policy": {"default_model": "x"}}

--- a/docs/dev_logs/0.7.6
+++ b/docs/dev_logs/0.7.6
@@ -1,0 +1,9 @@
+0.7.6:
+[x] - Report Rails health so a dead app is visible.
+[x] - Backups no longer skip both databases over one unreadable file.
+[x] - A stuck Rails server now restarts itself instead of serving nothing.
+[x] - The fleet default model can be changed from config now, no release needed.
+[x] - A retired model reroutes to a working one instead of failing the turn.
+[x] - Leo now checks its model with a real call, so a dead model stops reporting healthy.
+[x] - The mothership can set a box's models over the API instead of SSHing in.
+[x] - Leo can run JS in your page again, instead of silently failing.

--- a/docs/test_plans/0.7.6.md
+++ b/docs/test_plans/0.7.6.md
@@ -1,0 +1,219 @@
+# 0.7.6 manual test plan
+
+Pairs with the automated tests. Automated coverage is listed per item so you only
+hand-check what a test cannot reach.
+
+| Change | Repo | Automated |
+|---|---|---|
+| Rails health in the lease loop | LlamaBot | 9 tests, `app/tests/test_rails_health_report.py` |
+| Wedged Rails self-heal | Leonardo | 12 checks, `test/rails_watchdog.sh` |
+| Backup exit-2 | Leonardo | 16 checks, `test/backup_exit_codes.sh` |
+| Chromium HOME | LlamaPress-Simple | 4 specs, `spec/docker/chromium_home_spec.rb` |
+| Anonymous feedback | gem + skeleton | 20 specs + 6 JS tests |
+| Operator/mothership default model | LlamaBot | 27 tests, `test_operator_default_model.py` |
+| Real model health probe | LlamaBot | 5 tests, `test_model_health_probe.py` |
+
+---
+
+## 1. Rails health reaches the mothership
+
+The mothership endpoint `/api/leonardo/report_health` is **Mother Leo's half and is not
+built yet**. Our side is fail-open, so a 404 is a no-op. Both halves can ship in either
+order. Until hers exists, only steps 1.1 and 1.2 are checkable.
+
+1.1 On a box, watch the llamabot logs for five minutes. Confirm no error appears from the
+health report even though the endpoint 404s.
+
+1.2 Leave the box completely idle for 11 minutes (past `ACTIVITY_THRESHOLD`). Confirm the
+health probe still runs. This is the whole point: lease renewal stops when idle, health
+reporting must not.
+
+1.3 (After her half lands) Confirm a report arrives every 5 minutes, and that stopping the
+llamapress container makes `rails_status` change to 0 within one interval.
+
+1.4 Confirm lease renewal still works with the mothership unreachable.
+
+---
+
+## 2. A wedged Rails restarts itself
+
+**Do this on a scratch box, not a customer's.**
+
+2.1 Reproduce a wedge. In the llamapress container, make Rails stop answering (for
+example, `kill -STOP` the Puma master):
+```
+docker compose exec llamapress bash -c 'pkill -STOP -f puma'
+```
+
+2.2 Watch `docker compose logs -f llamapress`. Within about 2 minutes you should see the
+watchdog count failures, then:
+```
+!! WATCHDOG: Rails is wedged — /up failed 3 times in a row. Killing Puma to force a restart.
+```
+
+2.3 Confirm the site answers again afterwards, without anyone touching the box.
+
+2.4 **Check the false-positive guard.** Save a file in the app to force a dev-mode class
+reload, then load a page. It can take ~10 seconds. Confirm this does NOT trigger a kill.
+This is why the timeout is 25s, not 5s.
+
+2.5 Confirm a box that has restarted several times over days still self-heals, rather than
+parking in the debug husk. `HEALTHY_RUN_SECONDS` (600) resets the budget after a sustained
+healthy run.
+
+---
+
+## 3. Backups survive an unreadable file
+
+3.1 On a scratch box, plant the fault:
+```
+sudo mkdir -p /home/ubuntu/Leonardo/.leonardo/reprodir
+sudo sh -c 'echo secret > /home/ubuntu/Leonardo/.leonardo/reprodir/unreadable.txt'
+sudo chmod 600 /home/ubuntu/Leonardo/.leonardo/reprodir/unreadable.txt
+sudo chown root:root /home/ubuntu/Leonardo/.leonardo/reprodir/unreadable.txt
+```
+
+3.2 Run `quick_backup.sh`. Confirm:
+- the source step reports a **warning**, not a failure;
+- **both** database dumps still run;
+- the summary says "complete with warnings", not "FAILED";
+- `last-quick-backup.txt` IS written.
+
+3.3 Clean up: `sudo rm -rf /home/ubuntu/Leonardo/.leonardo/reprodir`
+
+3.4 Now break a database dump instead (stop the `db` container). Confirm the run reports
+FAILED and does **not** write `last-quick-backup.txt`.
+
+> **Shipping note:** the S3 copy of these scripts re-syncs over the git copy on every
+> backup. A merge alone reaches no box. After merge, run `upload_backup_scripts_to_s3.sh`,
+> then do a fleet push.
+
+---
+
+## 4. Chromium runs in the image
+
+Needs a rebuilt `llamapress-simple` image.
+
+4.1 `docker compose exec -T llamapress sh -c 'echo HOME=$HOME; test -w "$HOME" && echo W || echo NOTW'`
+Expect `HOME=/rails/tmp/home` and `W`.
+
+4.2 In the container, run a system spec explicitly (they are excluded by default) and
+confirm Ferrum no longer times out.
+
+4.3 Confirm the running app is unaffected. Sign in and load a page.
+
+---
+
+## 5. Anonymous feedback
+
+Default is **off**. Nothing should change for any existing app until someone opts in.
+
+5.1 **Before opting in.**
+
+**FIRST restart the llamapress container.** Gem and engine code does not hot-reload, so a
+container booted before these changes still runs the old code — which has no anonymous path
+at all — and this step passes without testing anything. (It did exactly that on the
+mothership's first run, 2026-09-01.)
+
+Then sign out and load a page. Confirm no feedback bubble appears, **and** confirm the
+page's `window.llamapressConfig` contains `"anonymousFeedbackEnabled": false` and
+`"feedbackSubmissionToken": null`. If either key is MISSING rather than false/null, you are
+testing a stale process — restart and try again.
+
+The config assertion is the important half: "correctly off" and "code not loaded" look
+identical if you only check that the bubble is absent. This is the upgrade-safety check.
+
+5.2 Opt in, in `config/initializers/llama_bot_rails.rb`:
+```ruby
+Rails.application.config.llama_bot_rails.anonymous_feedback_enabled = true
+```
+Restart the container. The value is read at boot, so a file save alone does nothing.
+
+5.3 Signed out, confirm the bubble appears and a submission succeeds.
+
+5.4 Confirm the new row shows as **Anonymous** in the feedback index and on its show page,
+and that the index and kanban views do not raise on a row with no user.
+
+5.5 Confirm the screenshot, video and paperclip buttons are **not** offered while signed
+out.
+
+5.6 Confirm the Messages and Notifications tabs are still refused while signed out.
+
+5.7 **Bot defences.** POST the endpoint directly with curl, in three steps. The parameter
+is nested — `user_feedback[submission_token]`, NOT a top-level `feedback_submission_token`.
+Getting that wrong looks identical to a genuine rejection.
+
+  a. No CSRF token at all → expect **422**. Rails' CSRF check rejects it before the
+     submission-token guard runs, so this proves the outer layer, not the token. Testing
+     only this would never exercise the defence it is meant to test.
+  b. Valid CSRF token (read the `csrf-token` meta tag from a page load) and NO
+     `user_feedback[submission_token]` → expect **403 `invalid_submission_token`**. This
+     is the real check.
+  c. Valid CSRF token and a tampered token → expect **403**.
+
+5.8 Sign in and confirm nothing changed: the bubble works, attachments work, element
+selection still rides along.
+
+5.9 **A submit with no title must not 500.** POST with a valid CSRF and submission token but
+no `user_feedback[title]`. Expect **422 with a JSON body**, never a Rails developer error
+page. Leo boxes run `RAILS_ENV=development` in production, so an unrescued exception here
+renders our source and the failing SQL row — including the submitter's IP — to whoever sent
+the request. The bubble always sends a title, so only a direct POST reaches this.
+
+> **Rollout note:** the migration is installed in Leonardo at
+> `rails/db/migrate/20260901004500_...`. `rails/db/migrate` is on the `bin/update`
+> allowlist, so it reaches the fleet on a normal update push.
+
+---
+
+## 6. The fleet default model is settable (P0, from the 2026-08-31 outage)
+
+The provider retired our default model while it carried 89% of fleet turns, and no
+box could be told to run anything else. **The point of this section is that a
+retirement is now a config change, not a release.**
+
+6.1 **Baseline.** On a box that sets nothing, confirm chat still runs on the compiled
+default exactly as in 0.7.5. Nothing below should change an unconfigured box.
+
+6.2 Set `DEFAULT_LLM_MODEL=glm-5.3-flash-zai` in the box `.env` and restart the
+container (the value is read per call, but the container must pick up the new env).
+Confirm:
+- `/api/available-models` reports `default_model: glm-5.3-flash-zai`
+- a real turn completes on GLM through the `z-ai/fp8` pin
+- a user whose browser still has the 365-day `llmModel` cookie set to the retired
+  model is moved to GLM. This is the only thing that reaches those users.
+
+6.3 **The ban that did not ban.** Add every `deepseek*` variant to `DISABLED_MODELS`.
+Confirm no turn resolves to DeepSeek and the container log does NOT say "disables all
+known models". Before this change, banning DeepSeek put every box ON DeepSeek.
+
+6.4 **Degrade, do not lock out.** Set `DEFAULT_LLM_MODEL` to a model this box has no
+key for, then to a nonsense string. Confirm chat still works both times and the log
+explains which default was ignored and why. A bad remote default must never be worse
+than the outage it was sent to fix.
+
+6.5 **Remote control.** Have the mothership include a `model_policy` block in the
+lease-renew response. Confirm it lands in `.leonardo/model_policy.json` within one
+check interval and takes effect, and that it OUTRANKS a stale `DEFAULT_LLM_MODEL` in
+that box's `.env`.
+
+6.6 **Retirement reroute.** Point a box at a model id that does not exist and send a
+turn. Confirm the customer gets an answer from another model rather than a raw
+provider 404, that the log names the retired model, and that the NEXT turn does not
+pay for the 404 again.
+
+> **Note on health checks:** do not verify any of this with `GET /v1/models`. That
+> endpoint listed the retired model throughout the outage. Only a real completion
+> tells the truth, which is what the hourly probe now does.
+
+---
+
+## Known pre-existing failures (not introduced by 0.7.6)
+
+Do not chase these; they are the same before and after this work.
+
+- LlamaBot pytest: 9 failures, all the `instance.json` `enabled_models` intersection on
+  this dev box plus the known custom-modes test. CI has no `instance.json`.
+- Gem rspec: 53 failures, identical on the base commit. Measured by reverting the 0.7.6
+  gem changes and re-running.
+- Gem rspec: `agent_streaming_spec` SSE formatting.


### PR DESCRIPTION
[x] - Report Rails health so a dead app is visible. [x] - Backups no longer skip both databases over one unreadable file. [x] - A stuck Rails server now restarts itself instead of serving nothing. [x] - The fleet default model can be changed from config now, no release needed. [x] - A retired model reroutes to a working one instead of failing the turn. [x] - Leo now checks its model with a real call, so a dead model stops reporting healthy. [x] - The mothership can set a box's models over the API instead of SSHing in. [x] - Leo can run JS in your page again, instead of silently failing.